### PR TITLE
[feat]: 컴포넌트 내 테이블 헤드 높이 크기 조절 (#17)

### DIFF
--- a/app/assignments/page.tsx
+++ b/app/assignments/page.tsx
@@ -63,19 +63,19 @@ export default function Assignments() {
                 <table className="w-full text-sm text-left text-gray-500 dark:text-gray-400">
                   <thead className="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-gray-700 dark:text-gray-400 text-center">
                     <tr>
-                      <th scope="col" className="px-4 py-3">
-                        #
+                      <th scope="col" className="px-4 py-2">
+                        번호
                       </th>
-                      <th scope="col" className="px-4 py-3">
+                      <th scope="col" className="px-4 py-2">
                         수업명
                       </th>
-                      <th scope="col" className="px-4 py-3">
+                      <th scope="col" className="px-4 py-2">
                         과제명
                       </th>
-                      <th scope="col" className="px-4 py-3">
+                      <th scope="col" className="px-4 py-2">
                         교수명
                       </th>
-                      <th scope="col" className="px-4 py-3">
+                      <th scope="col" className="px-4 py-2">
                         진행 기간
                       </th>
                     </tr>

--- a/app/contests/page.tsx
+++ b/app/contests/page.tsx
@@ -61,22 +61,22 @@ export default function Contests() {
                 <table className="w-full text-sm text-left text-gray-500 dark:text-gray-400">
                   <thead className="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-gray-700 dark:text-gray-400 text-center">
                     <tr>
-                      <th scope="col" className="px-4 py-3">
-                        #
+                      <th scope="col" className="px-4 py-2">
+                        번호
                       </th>
-                      <th scope="col" className="px-4 py-3">
+                      <th scope="col" className="px-4 py-2">
                         대회명
                       </th>
-                      <th scope="col" className="px-4 py-3">
+                      <th scope="col" className="px-4 py-2">
                         신청기간
                       </th>
-                      <th scope="col" className="px-4 py-3">
+                      <th scope="col" className="px-4 py-2">
                         대회시간
                       </th>
-                      <th scope="col" className="px-4 py-3">
+                      <th scope="col" className="px-4 py-2">
                         작성자
                       </th>
-                      <th scope="col" className="px-4 py-3">
+                      <th scope="col" className="px-4 py-2">
                         작성일
                       </th>
                     </tr>

--- a/app/notices/page.tsx
+++ b/app/notices/page.tsx
@@ -61,19 +61,19 @@ export default function Notices() {
                 <table className="w-full text-sm text-left text-gray-500 dark:text-gray-400">
                   <thead className="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-gray-700 dark:text-gray-400 text-center">
                     <tr>
-                      <th scope="col" className="px-4 py-3">
-                        #
+                      <th scope="col" className="px-4 py-2">
+                        번호
                       </th>
-                      <th scope="col" className="px-4 py-3">
+                      <th scope="col" className="px-4 py-2">
                         제목
                       </th>
-                      <th scope="col" className="px-4 py-3">
+                      <th scope="col" className="px-4 py-2">
                         작성자
                       </th>
-                      <th scope="col" className="px-4 py-3">
+                      <th scope="col" className="px-4 py-2">
                         작성일
                       </th>
-                      <th scope="col" className="px-4 py-3">
+                      <th scope="col" className="px-4 py-2">
                         조회수
                       </th>
                     </tr>

--- a/app/practices/page.tsx
+++ b/app/practices/page.tsx
@@ -61,16 +61,16 @@ export default function Practices() {
                 <table className="w-full text-sm text-left text-gray-500 dark:text-gray-400">
                   <thead className="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-gray-700 dark:text-gray-400 text-center">
                     <tr>
-                      <th scope="col" className="px-4 py-3">
-                        #
+                      <th scope="col" className="px-4 py-2">
+                        번호
                       </th>
-                      <th scope="col" className="px-4 py-3">
+                      <th scope="col" className="px-4 py-2">
                         문제명
                       </th>
-                      <th scope="col" className="px-4 py-3">
+                      <th scope="col" className="px-4 py-2">
                         작성자
                       </th>
-                      <th scope="col" className="px-4 py-3">
+                      <th scope="col" className="px-4 py-2">
                         난이도
                       </th>
                     </tr>


### PR DESCRIPTION
## 👀 이슈

resolve #19 

## 📌 개요

현재 다양한 메뉴에서 사용되고 있는 `테이블`의 UI를 변경하고자 하였습니다.

## 👩‍💻 작업 사항

- `테이블`을 사용하고 있는 모든 컴포넌트

## ✅ 참고 사항

- 현재 `테이블` UI

<img width="1281" alt="Screenshot 2023-06-29 at 2 09 40 PM" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/a85361c9-df97-4a8b-bc1e-46a41fe061ae">

- 수정 후 `테이블` UI (테이블 헤드의 높이 폭 조절)

![Screenshot 2023-06-29 at 6 22 19 PM](https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/91f31a86-2cfc-4788-be7d-a255542b8365)