### PR TITLE
[fix]: 게시글 정보 등록 컴포넌트 내 열람 비밀번호 입력란 UI 통일 (#28)

### DIFF
--- a/app/contests/register/page.tsx
+++ b/app/contests/register/page.tsx
@@ -244,7 +244,7 @@ export default function RegisterContest() {
                         id="helper-checkbox-text"
                         className="relative left-[-0.8rem] text-xs font-normal text-[#5762b3] dark:text-gray-300"
                       >
-                        비밀번호를 설정할 경우 문제 열람 시 비밀번호 입력이
+                        비밀번호를 설정할 경우 게시글 열람 시 비밀번호 입력이
                         필요합니다.
                       </p>
                     </div>

--- a/app/contests/register/page.tsx
+++ b/app/contests/register/page.tsx
@@ -256,7 +256,7 @@ export default function RegisterContest() {
                       type="text"
                       name="floating_first_name"
                       id="floating_first_name"
-                      className="block pt-3 pb-[0.175rem] pl-0 pr-0 w-52 font-normal text-gray-900 bg-transparent border-0 border-b border-gray-400 appearance-none dark:text-white dark:border-gray-600 dark:focus:border-[#5762b3] focus:outline-none focus:ring-0 focus:border-[#5762b3] peer"
+                      className="block pt-3 pb-[0.175rem] pl-0 pr-0 w-2/3 font-normal text-gray-900 bg-transparent border-0 border-b border-gray-400 appearance-none dark:text-white dark:border-gray-600 dark:focus:border-[#5762b3] focus:outline-none focus:ring-0 focus:border-[#5762b3] peer"
                       placeholder=" "
                       required
                       value={contestPwd}

--- a/app/exams/register/page.tsx
+++ b/app/exams/register/page.tsx
@@ -10,24 +10,16 @@ const DynamicEditor = dynamic(() => import('@/app/components/Editor'), {
 
 export default function RegisterExam() {
   const [isEditorReady, setIsEditorReady] = useState(false);
-  const [isCheckedAppliedPeriod, setIsCheckedAppliedPeriod] = useState(false);
-  const [isCheckedUsingPwd, setIsCheckedUsingPwd] = useState(false);
   const [courseName, setCourseName] = useState('');
   const [examName, setExamName] = useState('');
+  const [isCheckedUsingPwd, setIsCheckedUsingPwd] = useState(false);
   const [examPwd, setExamPwd] = useState('');
   const [selectedContestDateTime, setSelectedContestDateTime] = useState({
     startDate: new Date(),
     endDate: new Date(),
   });
-  const [selectedContestAppliedDateTime, setSelectedContestAppliedDateTime] =
-    useState({
-      startDate: new Date(),
-      endDate: new Date(),
-    });
 
   const router = useRouter();
-
-  const koreaTimeZone = 'ko-KR'; // 한국 시간을 사용하는 로케일 (예: en-US, ko-KR 등)
 
   const handleContestStartDateChange = (
     e: React.ChangeEvent<HTMLInputElement>,
@@ -42,24 +34,6 @@ export default function RegisterExam() {
     e: React.ChangeEvent<HTMLInputElement>,
   ) => {
     setSelectedContestDateTime((prevState) => ({
-      ...prevState,
-      endDate: new Date(e.target.value),
-    }));
-  };
-
-  const handleContestAppliedStartDateChange = (
-    e: React.ChangeEvent<HTMLInputElement>,
-  ) => {
-    setSelectedContestAppliedDateTime((prevState) => ({
-      ...prevState,
-      startDate: new Date(e.target.value),
-    }));
-  };
-
-  const handleContestAppliedEndDateChange = (
-    e: React.ChangeEvent<HTMLInputElement>,
-  ) => {
-    setSelectedContestAppliedDateTime((prevState) => ({
       ...prevState,
       endDate: new Date(e.target.value),
     }));
@@ -81,8 +55,8 @@ export default function RegisterExam() {
       <div className="flex flex-col w-[60rem] mx-auto">
         <p className="text-2xl font-semibold">시험 등록</p>
 
-        <div className="flex flex-col gap-5 mt-5 mb-8">
-          <div className="flex flex-col relative z-0 w-1/2 group">
+        <div className="flex gap-5 mt-5 mb-8">
+          <div className="flex flex-col relative z-0 w-2/5 group">
             <input
               type="text"
               name="floating_first_name"
@@ -104,50 +78,26 @@ export default function RegisterExam() {
             </p>
           </div>
 
-          <div className="flex gap-5">
-            <div className="flex flex-col relative z-0 w-1/2 group">
-              <input
-                type="text"
-                name="floating_first_name"
-                id="floating_first_name"
-                className="block pt-3 pb-[0.175rem] pl-0 pr-0 w-full font-normal text-gray-900 bg-transparent border-0 border-b border-gray-400 appearance-none dark:text-white dark:border-gray-600 dark:focus:border-blue-500 focus:outline-none focus:ring-0 focus:border-blue-600 peer"
-                placeholder=" "
-                required
-                value={courseName}
-                onChange={(e) => setCourseName(e.target.value)}
-              />
-              <label
-                htmlFor="floating_first_name"
-                className="peer-focus:font-light absolute text-base left-[0.1rem] font-light text-gray-500 dark:text-gray-400 duration-300 transform -translate-y-5 scale-75 top-3 -z-10 origin-[0] peer-focus:left-[0.1rem] peer-focus:text-blue-600 peer-focus:dark:text-blue-500 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0 peer-focus:scale-75 peer-focus:-translate-y-[1.25rem]"
-              >
-                교과목명
-              </label>
-              <p className="text-gray-500 text-xs tracking-widest font-light mt-1">
-                교과목명을 입력해 주세요
-              </p>
-            </div>
-
-            <div className="flex flex-col relative z-0 w-1/4 group">
-              <input
-                type="text"
-                name="floating_first_name"
-                id="floating_first_name"
-                className="block pt-3 pb-[0.175rem] pl-0 pr-0 w-full font-normal text-gray-900 bg-transparent border-0 border-b border-gray-400 appearance-none dark:text-white dark:border-gray-600 dark:focus:border-blue-500 focus:outline-none focus:ring-0 focus:border-blue-600 peer"
-                placeholder=" "
-                required
-                value={examPwd}
-                onChange={(e) => setExamPwd(e.target.value)}
-              />
-              <label
-                htmlFor="floating_first_name"
-                className="peer-focus:font-light absolute text-base left-[0.1rem] font-light text-gray-500 dark:text-gray-400 duration-300 transform -translate-y-5 scale-75 top-3 -z-10 origin-[0] peer-focus:left-[0.1rem] peer-focus:text-blue-600 peer-focus:dark:text-blue-500 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0 peer-focus:scale-75 peer-focus:-translate-y-[1.25rem]"
-              >
-                비밀번호
-              </label>
-              <p className="text-gray-500 text-xs tracking-widest font-light mt-1">
-                게시글 열람 비밀번호를 입력해 주세요
-              </p>
-            </div>
+          <div className="flex flex-col relative z-0 w-2/5 group">
+            <input
+              type="text"
+              name="floating_first_name"
+              id="floating_first_name"
+              className="block pt-3 pb-[0.175rem] pl-0 pr-0 w-full font-normal text-gray-900 bg-transparent border-0 border-b border-gray-400 appearance-none dark:text-white dark:border-gray-600 dark:focus:border-blue-500 focus:outline-none focus:ring-0 focus:border-blue-600 peer"
+              placeholder=" "
+              required
+              value={courseName}
+              onChange={(e) => setCourseName(e.target.value)}
+            />
+            <label
+              htmlFor="floating_first_name"
+              className="peer-focus:font-light absolute text-base left-[0.1rem] font-light text-gray-500 dark:text-gray-400 duration-300 transform -translate-y-5 scale-75 top-3 -z-10 origin-[0] peer-focus:left-[0.1rem] peer-focus:text-blue-600 peer-focus:dark:text-blue-500 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0 peer-focus:scale-75 peer-focus:-translate-y-[1.25rem]"
+            >
+              교과목명
+            </label>
+            <p className="text-gray-500 text-xs tracking-widest font-light mt-1">
+              교과목명을 입력해 주세요
+            </p>
           </div>
         </div>
 
@@ -183,6 +133,69 @@ export default function RegisterExam() {
               className="text-sm appearance-none border rounded shadow py-[0.375rem] px-2 text-gray-500"
               onChange={handleContestEndDateChange}
             />
+          </div>
+
+          <div className="flex flex-col mt-10">
+            <div className="flex">
+              <div className="flex items-center h-5">
+                <input
+                  id="helper-checkbox"
+                  aria-describedby="helper-checkbox-text"
+                  type="checkbox"
+                  checked={isCheckedUsingPwd}
+                  onChange={() => setIsCheckedUsingPwd(!isCheckedUsingPwd)}
+                  className="w-4 h-4 text-blue-600 border-2 border-[#757575] rounded-[0.175rem] focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
+                />
+              </div>
+              <div className="ml-2 text-sm">
+                <label
+                  htmlFor="helper-checkbox"
+                  className="font-medium text-gray-900 dark:text-gray-300"
+                >
+                  비밀번호 설정
+                </label>
+
+                <div className="flex mt-1">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    height="15"
+                    viewBox="0 -960 960 960"
+                    width="15"
+                    fill="#5762b3"
+                    className="relative left-[-1.375rem] top-[0.1rem]"
+                  >
+                    <path d="M440.667-269.333h83.999V-520h-83.999v250.667Zm39.204-337.333q17.796 0 29.962-11.833Q522-630.332 522-647.824q0-18.809-12.021-30.825-12.021-12.017-29.792-12.017-18.52 0-30.354 11.841Q438-666.984 438-648.508q0 17.908 12.038 29.875 12.038 11.967 29.833 11.967Zm.001 547.999q-87.157 0-163.841-33.353-76.684-33.354-133.671-90.34-56.986-56.987-90.34-133.808-33.353-76.821-33.353-164.165 0-87.359 33.412-164.193 33.413-76.834 90.624-134.057 57.211-57.224 133.757-89.987t163.578-32.763q87.394 0 164.429 32.763 77.034 32.763 134.117 90 57.082 57.237 89.916 134.292 32.833 77.056 32.833 164.49 0 87.433-32.763 163.67-32.763 76.236-89.987 133.308-57.223 57.073-134.261 90.608-77.037 33.535-164.45 33.535Zm.461-83.999q140.18 0 238.59-98.744 98.411-98.744 98.411-238.923 0-140.18-98.286-238.59Q620.763-817.334 480-817.334q-139.846 0-238.59 98.286Q142.666-620.763 142.666-480q0 139.846 98.744 238.59t238.923 98.744ZM480-480Z" />
+                  </svg>
+                  <p
+                    id="helper-checkbox-text"
+                    className="relative left-[-0.8rem] text-xs font-normal text-[#5762b3] dark:text-gray-300"
+                  >
+                    비밀번호를 설정할 경우 문제 열람 시 비밀번호 입력이
+                    필요합니다.
+                  </p>
+                </div>
+              </div>
+            </div>
+            {isCheckedUsingPwd ? (
+              <div className="flex flex-col relative z-0 w-1/2 group mt-7">
+                <input
+                  type="text"
+                  name="floating_first_name"
+                  id="floating_first_name"
+                  className="block pt-3 pb-[0.175rem] pl-0 pr-0 w-2/3 font-normal text-gray-900 bg-transparent border-0 border-b border-gray-400 appearance-none dark:text-white dark:border-gray-600 dark:focus:border-[#5762b3] focus:outline-none focus:ring-0 focus:border-[#5762b3] peer"
+                  placeholder=" "
+                  required
+                  value={examPwd}
+                  onChange={(e) => setExamPwd(e.target.value)}
+                />
+                <label
+                  htmlFor="floating_first_name"
+                  className="peer-focus:font-light absolute text-base left-[0.1rem] font-light text-gray-500 dark:text-gray-400 duration-300 transform -translate-y-6 scale-75 top-3 -z-10 origin-[0] peer-focus:left-0 peer-focus:text-[#5762b3] peer-focus:dark:text-[#5762b3] peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0 peer-focus:scale-75 peer-focus:-translate-y-[1.5rem]"
+                >
+                  비밀번호
+                </label>
+              </div>
+            ) : null}
           </div>
 
           <div className="mt-14 pb-2 flex justify-end gap-3">

--- a/app/exams/register/page.tsx
+++ b/app/exams/register/page.tsx
@@ -170,7 +170,7 @@ export default function RegisterExam() {
                     id="helper-checkbox-text"
                     className="relative left-[-0.8rem] text-xs font-normal text-[#5762b3] dark:text-gray-300"
                   >
-                    비밀번호를 설정할 경우 문제 열람 시 비밀번호 입력이
+                    비밀번호를 설정할 경우 게시글 열람 시 비밀번호 입력이
                     필요합니다.
                   </p>
                 </div>

--- a/app/practices/register/page.tsx
+++ b/app/practices/register/page.tsx
@@ -11,6 +11,8 @@ export default function Registerpractice() {
   const [difficulty, setDifficulty] = useState<number>();
   const [inFileExtensionName, setInFileExtensionName] = useState('');
   const [outFileExtensionName, setOutFileExtensionName] = useState('');
+  const [isCheckedUsingPwd, setIsCheckedUsingPwd] = useState(false);
+  const [examPwd, setExamPwd] = useState('');
 
   const router = useRouter();
 
@@ -24,7 +26,7 @@ export default function Registerpractice() {
   return (
     <div className="mt-2 px-5 2lg:px-0 overflow-x-auto">
       <div className="flex flex-col w-[60rem] mx-auto">
-        <p className="text-2xl font-semibold">시험 등록</p>
+        <p className="text-2xl font-semibold">연습문제 등록</p>
 
         <div className="flex flex-col gap-5">
           <div className="flex flex-col gap-5 mt-5 mb-8">
@@ -192,6 +194,69 @@ export default function Registerpractice() {
               </div>
               <MyDropzone guideMsg="입/출력 파일(in, out)들을 이곳에 업로드해 주세요" />
             </div>
+          </div>
+
+          <div className="flex flex-col mt-5">
+            <div className="flex">
+              <div className="flex items-center h-5">
+                <input
+                  id="helper-checkbox"
+                  aria-describedby="helper-checkbox-text"
+                  type="checkbox"
+                  checked={isCheckedUsingPwd}
+                  onChange={() => setIsCheckedUsingPwd(!isCheckedUsingPwd)}
+                  className="w-4 h-4 text-blue-600 border-2 border-[#757575] rounded-[0.175rem] focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
+                />
+              </div>
+              <div className="ml-2 text-sm">
+                <label
+                  htmlFor="helper-checkbox"
+                  className="font-medium text-gray-900 dark:text-gray-300"
+                >
+                  비밀번호 설정
+                </label>
+
+                <div className="flex mt-1">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    height="15"
+                    viewBox="0 -960 960 960"
+                    width="15"
+                    fill="#5762b3"
+                    className="relative left-[-1.375rem] top-[0.1rem]"
+                  >
+                    <path d="M440.667-269.333h83.999V-520h-83.999v250.667Zm39.204-337.333q17.796 0 29.962-11.833Q522-630.332 522-647.824q0-18.809-12.021-30.825-12.021-12.017-29.792-12.017-18.52 0-30.354 11.841Q438-666.984 438-648.508q0 17.908 12.038 29.875 12.038 11.967 29.833 11.967Zm.001 547.999q-87.157 0-163.841-33.353-76.684-33.354-133.671-90.34-56.986-56.987-90.34-133.808-33.353-76.821-33.353-164.165 0-87.359 33.412-164.193 33.413-76.834 90.624-134.057 57.211-57.224 133.757-89.987t163.578-32.763q87.394 0 164.429 32.763 77.034 32.763 134.117 90 57.082 57.237 89.916 134.292 32.833 77.056 32.833 164.49 0 87.433-32.763 163.67-32.763 76.236-89.987 133.308-57.223 57.073-134.261 90.608-77.037 33.535-164.45 33.535Zm.461-83.999q140.18 0 238.59-98.744 98.411-98.744 98.411-238.923 0-140.18-98.286-238.59Q620.763-817.334 480-817.334q-139.846 0-238.59 98.286Q142.666-620.763 142.666-480q0 139.846 98.744 238.59t238.923 98.744ZM480-480Z" />
+                  </svg>
+                  <p
+                    id="helper-checkbox-text"
+                    className="relative left-[-0.8rem] text-xs font-normal text-[#5762b3] dark:text-gray-300"
+                  >
+                    비밀번호를 설정할 경우 문제 열람 시 비밀번호 입력이
+                    필요합니다.
+                  </p>
+                </div>
+              </div>
+            </div>
+            {isCheckedUsingPwd ? (
+              <div className="flex flex-col relative z-0 w-1/2 group mt-7">
+                <input
+                  type="text"
+                  name="floating_first_name"
+                  id="floating_first_name"
+                  className="block pt-3 pb-[0.175rem] pl-0 pr-0 w-2/3 font-normal text-gray-900 bg-transparent border-0 border-b border-gray-400 appearance-none dark:text-white dark:border-gray-600 dark:focus:border-[#5762b3] focus:outline-none focus:ring-0 focus:border-[#5762b3] peer"
+                  placeholder=" "
+                  required
+                  value={examPwd}
+                  onChange={(e) => setExamPwd(e.target.value)}
+                />
+                <label
+                  htmlFor="floating_first_name"
+                  className="peer-focus:font-light absolute text-base left-[0.1rem] font-light text-gray-500 dark:text-gray-400 duration-300 transform -translate-y-6 scale-75 top-3 -z-10 origin-[0] peer-focus:left-0 peer-focus:text-[#5762b3] peer-focus:dark:text-[#5762b3] peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0 peer-focus:scale-75 peer-focus:-translate-y-[1.5rem]"
+                >
+                  비밀번호
+                </label>
+              </div>
+            ) : null}
           </div>
 
           <div className="mt-5 pb-2 flex justify-end gap-3">

--- a/app/practices/register/page.tsx
+++ b/app/practices/register/page.tsx
@@ -231,7 +231,7 @@ export default function Registerpractice() {
                     id="helper-checkbox-text"
                     className="relative left-[-0.8rem] text-xs font-normal text-[#5762b3] dark:text-gray-300"
                   >
-                    비밀번호를 설정할 경우 문제 열람 시 비밀번호 입력이
+                    비밀번호를 설정할 경우 게시글 열람 시 비밀번호 입력이
                     필요합니다.
                   </p>
                 </div>


### PR DESCRIPTION
## 👀 이슈

resolve #28 

## 📌 개요

현재 `대회 정보 등록`, `시험 정보 등록` `연습문제 정보 등록` 컴포넌트 내에 통일성
있는 게시글 열람 비밀번호 입력란 UI를 추가하고자 하였습니다.

## 👩‍💻 작업 사항

- `대회 정보 등록` 컴포넌트 내 비밀번호 입력란 UI 수정
- `시험 정보 등록` 컴포넌트 내 비밀번호 입력란 UI 수정
- `연습문제 정보 등록` 컴포넌트 내 비밀번호 입력란 UI 추가
- `연습문제 정보 등록` 컴포넌트 상단의 페이지 헤더 오타 수정

## ✅ 참고 사항

- 비밀번호 입력란 UI 통일 후

![ezgif com-video-to-gif (25)](https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/538b8029-bba0-442f-a0f6-5b4203b52025)