### PR TITLE
[feat]: 로딩(Loading) 컴포넌트 추가 (#40)

### DIFF
--- a/app/contests/[id]/page.tsx
+++ b/app/contests/[id]/page.tsx
@@ -4,6 +4,7 @@ import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import Participant from './components/Participant';
+import Loading from '@/app/loading';
 
 const MarkdownPreview = dynamic(
   () => import('@uiw/react-markdown-preview').then((mod) => mod.default),
@@ -11,6 +12,7 @@ const MarkdownPreview = dynamic(
 );
 
 export default function ExamDetail() {
+  const [isContestPostReady, setIsContestPostReady] = useState(false);
   const [isMarkdownPreviewReady, setIsMarkdownPreviewReady] = useState(false);
   const router = useRouter();
 
@@ -22,10 +24,11 @@ export default function ExamDetail() {
   };
 
   useEffect(() => {
+    setIsContestPostReady(true);
     setIsMarkdownPreviewReady(true);
   }, []);
 
-  return (
+  return isContestPostReady && isMarkdownPreviewReady ? (
     <div className="mt-6 mb-24 px-5 2lg:px-0 overflow-x-auto">
       <div className="flex flex-col w-[60rem] mx-auto">
         <div className="flex flex-col">
@@ -43,9 +46,9 @@ export default function ExamDetail() {
                 <span className="font-semibold">
                   대회시간:
                   {/* <span className="text-red-500 font-bold">
-                    {' '}
-                    49분 45초 남음
-                  </span> */}
+                  {' '}
+                  49분 45초 남음
+                </span> */}
                   <span className="font-light">
                     {' '}
                     2023:07:13 17:00 ~ 2023.07.13 18:00{' '}
@@ -226,5 +229,7 @@ export default function ExamDetail() {
         </div>
       </div>
     </div>
+  ) : (
+    <Loading />
   );
 }

--- a/app/contests/register/page.tsx
+++ b/app/contests/register/page.tsx
@@ -1,12 +1,16 @@
 'use client';
 
+import Loading from '@/app/loading';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
-const DynamicEditor = dynamic(() => import('@/app/components/CKEditor'), {
-  ssr: false,
-});
+const DynamicEditor = dynamic(
+  () => import('@/app/components/CKEditor/CKEditor'),
+  {
+    ssr: false,
+  },
+);
 
 export default function RegisterContest() {
   const [isEditorReady, setIsEditorReady] = useState(false);
@@ -106,7 +110,7 @@ export default function RegisterContest() {
             <DynamicEditor isEditorReady={isEditorReady} />
           </div>
         ) : (
-          <p>로딩중입니다...</p>
+          <Loading />
         )}
 
         <div className="mt-8">

--- a/app/exams/[id]/page.tsx
+++ b/app/exams/[id]/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Loading from '@/app/loading';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
@@ -10,6 +11,7 @@ const MarkdownPreview = dynamic(
 );
 
 export default function ExamDetail() {
+  const [isExamPostReady, setIsExamPostReady] = useState(false);
   const [isMarkdownPreviewReady, setIsMarkdownPreviewReady] = useState(false);
   const router = useRouter();
 
@@ -22,9 +24,10 @@ export default function ExamDetail() {
 
   useEffect(() => {
     setIsMarkdownPreviewReady(true);
+    setIsExamPostReady(true);
   }, []);
 
-  return (
+  return isExamPostReady && isMarkdownPreviewReady ? (
     <div className="mt-6 mb-24 px-5 2lg:px-0 overflow-x-auto">
       <div className="flex flex-col w-[60rem] mx-auto">
         <div className="flex flex-col">
@@ -57,10 +60,9 @@ export default function ExamDetail() {
             </div>
           </div>
           <div className="border-b mt-8 mb-4 pb-5">
-            {isMarkdownPreviewReady ? (
-              <MarkdownPreview
-                className="markdown-preview"
-                source={`
+            <MarkdownPreview
+              className="markdown-preview"
+              source={`
 # 자료구조 알고리즘 코딩 테스트 공지
 안녕하세요, 여러분.
 
@@ -77,9 +79,9 @@ export default function ExamDetail() {
 
 ## 테스트 범위
 - 이번 테스트는 다음의 자료구조와 관련된 알고리즘에 대한 문제를 다룹니다:
-                - 스택(Stack)과 큐(Queue)
-                - 링크드 리스트(Linked List)
-                - 트리(Tree)와 그래프(Graph)
+            - 스택(Stack)과 큐(Queue)
+            - 링크드 리스트(Linked List)
+            - 트리(Tree)와 그래프(Graph)
 
 ## 기타 유의사항
 - 본 테스트는 오픈 북 형태로 진행되나, 다른 사람과의 협업은 엄격히 금지합니다.
@@ -91,8 +93,7 @@ export default function ExamDetail() {
 
 감사합니다.
 `}
-              />
-            ) : null}
+            />
           </div>
           <div>
             <div className="flex gap-3 justify-end">
@@ -161,5 +162,7 @@ export default function ExamDetail() {
         </div>
       </div>
     </div>
+  ) : (
+    <Loading />
   );
 }

--- a/app/exams/register/page.tsx
+++ b/app/exams/register/page.tsx
@@ -1,12 +1,16 @@
 'use client';
 
+import Loading from '@/app/loading';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
-const DynamicEditor = dynamic(() => import('@/app/components/CKEditor'), {
-  ssr: false,
-});
+const DynamicEditor = dynamic(
+  () => import('@/app/components/CKEditor/CKEditor'),
+  {
+    ssr: false,
+  },
+);
 
 export default function RegisterExam() {
   const [isEditorReady, setIsEditorReady] = useState(false);
@@ -106,7 +110,7 @@ export default function RegisterExam() {
             <DynamicEditor isEditorReady={isEditorReady} />
           </div>
         ) : (
-          <p>로딩중입니다...</p>
+          <Loading />
         )}
 
         <div className="mt-8">

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,0 +1,31 @@
+export default function Loading() {
+  return (
+    <div className="w-10 h-10 mx-auto flex justify-center items-center text-3xl font-thin animate-spin">
+      <svg
+        viewBox="0 0 32 32"
+        className="w-6 h-6 flex justify-center items-center text-3xl font-thin animate-spin"
+      >
+        <circle
+          cx="16"
+          cy="16"
+          fill="none"
+          r="14"
+          strokeWidth="2"
+          style={{ stroke: 'rgb(180, 180, 180)', opacity: 0.2 }}
+        ></circle>
+        <circle
+          cx="16"
+          cy="16"
+          fill="none"
+          r="14"
+          strokeWidth="2"
+          style={{
+            stroke: 'rgb(180, 180, 180)',
+            strokeDasharray: 80,
+            strokeDashoffset: 60,
+          }}
+        ></circle>
+      </svg>
+    </div>
+  );
+}

--- a/app/notices/register/page.tsx
+++ b/app/notices/register/page.tsx
@@ -1,12 +1,16 @@
 'use client';
 
+import Loading from '@/app/loading';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
-const DynamicEditor = dynamic(() => import('@/app/components/CKEditor'), {
-  ssr: false,
-});
+const DynamicEditor = dynamic(
+  () => import('@/app/components/CKEditor/CKEditor'),
+  {
+    ssr: false,
+  },
+);
 
 export default function RegisterNotice() {
   const [isEditorReady, setIsEditorReady] = useState(false);
@@ -84,7 +88,7 @@ export default function RegisterNotice() {
             <DynamicEditor isEditorReady={isEditorReady} />
           </div>
         ) : (
-          <p>로딩중입니다...</p>
+          <Loading />
         )}
 
         <div className="mt-8">

--- a/app/practices/register/page.tsx
+++ b/app/practices/register/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Loading from '@/app/loading';
 import MyDropzone from '@/app/components/MyDropzone';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
@@ -259,7 +260,7 @@ function sub(int a, int b) {
                     />
                   </div>
                 ) : (
-                  <p>로딩중입니다...</p>
+                  <Loading />
                 )}
               </div>
             ) : null}


### PR DESCRIPTION
## 👀 이슈

resolve #40 

## 📌 개요

홈페이지 구성 페이지 컴포넌트 중에 동적으로 로드하는 컴포넌트 들에
대해서 로드되는 도중에 사용자에게 로딩 중이라는 피드백을 줄 수 있도록
하고자 `로딩` 컴포넌트를 프로젝트 내 추가하였습니다.

## 👩‍💻 작업 사항

- 로딩(Loading) 컴포넌트 추가
- 동적 import문이 사용되는 컴포넌트 코드 내 컴포넌트 로드 중 로딩 컴포넌트가 표시되도록 코드 추가

## ✅ 참고 사항

- `로딩 컴포넌트` 적용 예시

![1](https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/51a660b7-e034-4439-b2aa-42db11d61a24)