### PR TITLE
[refactor]: `대회/시험/연습문제/공지사항` 개별 목록 컴포넌트화 (#45)

### DIFF
--- a/app/contests/components/ContestList.tsx
+++ b/app/contests/components/ContestList.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import Contest from './Contest';
+import NoneContestParticipant from './NoneContestPostInfo';
+
+export default function ContestList() {
+  const [isContestListReady, setIsContestListReady] = useState(false);
+
+  useEffect(() => {
+    setIsContestListReady(true);
+  }, []);
+
+  return isContestListReady ? (
+    <tbody>
+      <Contest />
+      <Contest />
+      <Contest />
+      <Contest />
+      <Contest />
+      <Contest />
+      <Contest />
+      <Contest />
+      <Contest />
+      <Contest />
+    </tbody>
+  ) : null;
+  // <NoneContestParticipant />
+}

--- a/app/contests/components/NoneContestPostInfo.tsx
+++ b/app/contests/components/NoneContestPostInfo.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+export default function NoneContestPostInfo() {
+  return (
+    <tr className="border-b dark:border-gray-700 text-xs text-center">
+      <th
+        scope="row"
+        className="px-4 py-3 font-medium text-gray-900 whitespace-nowrap dark:text-white"
+      >
+        1
+      </th>
+      <td className="text-sm">등록된 대회 정보가 없습니다</td>
+      <td className="font-medium">-</td>
+      <td className="font-medium">-</td>
+      <td className="font-medium">-</td>
+      <td className="font-medium">-</td>
+    </tr>
+  );
+}

--- a/app/exams/components/ExamList.tsx
+++ b/app/exams/components/ExamList.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import Exam from './Exam';
+import NoneExamParticipant from './NoneExamPostInfo';
+
+export default function ExamList() {
+  const [isExamListReady, setIsExamListReady] = useState(false);
+
+  useEffect(() => {
+    setIsExamListReady(true);
+  }, []);
+
+  return isExamListReady ? (
+    <tbody>
+      <Exam />
+      <Exam />
+      <Exam />
+      <Exam />
+      <Exam />
+      <Exam />
+      <Exam />
+      <Exam />
+      <Exam />
+      <Exam />
+    </tbody>
+  ) : null;
+  // <NoneExamParticipant />
+}

--- a/app/exams/components/NoneExamPostInfo.tsx
+++ b/app/exams/components/NoneExamPostInfo.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export default function NoneExamPostInfo() {
+  return (
+    <tr className="border-b dark:border-gray-700 text-xs text-center">
+      <th
+        scope="row"
+        className="px-4 py-3 font-medium text-gray-900 whitespace-nowrap dark:text-white"
+      >
+        1
+      </th>
+      <td className="text-sm">등록된 시험 정보가 없습니다</td>
+      <td className="font-medium">-</td>
+      <td className="font-medium">-</td>
+      <td className="font-medium">-</td>
+    </tr>
+  );
+}

--- a/app/notices/components/NoneNoticePostInfo.tsx
+++ b/app/notices/components/NoneNoticePostInfo.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export default function NoneNoticePostInfo() {
+  return (
+    <tr className="border-b dark:border-gray-700 text-xs text-center">
+      <th
+        scope="row"
+        className="px-4 py-3 font-medium text-gray-900 whitespace-nowrap dark:text-white"
+      >
+        1
+      </th>
+      <td className="text-sm">등록된 공지사항 정보가 없습니다</td>
+      <td className="font-medium">-</td>
+      <td className="font-medium">-</td>
+      <td className="font-medium">-</td>
+    </tr>
+  );
+}

--- a/app/notices/components/NoticeList.tsx
+++ b/app/notices/components/NoticeList.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import Notice from './Notice';
+import NoneNoticeParticipant from './NoneNoticePostInfo';
+
+export default function NoticeList() {
+  const [isNoticeListReady, setIsNoticeListReady] = useState(false);
+
+  useEffect(() => {
+    setIsNoticeListReady(true);
+  }, []);
+
+  return isNoticeListReady ? (
+    <tbody>
+      <Notice />
+      <Notice />
+      <Notice />
+      <Notice />
+      <Notice />
+      <Notice />
+      <Notice />
+      <Notice />
+      <Notice />
+      <Notice />
+    </tbody>
+  ) : null;
+  //   <NoneNoticeParticipant />;
+}

--- a/app/practices/components/NonePracticePostInfo.tsx
+++ b/app/practices/components/NonePracticePostInfo.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export default function NonePracticePostInfo() {
+  return (
+    <tr className="border-b dark:border-gray-700 text-xs text-center">
+      <th
+        scope="row"
+        className="px-4 py-3 font-medium text-gray-900 whitespace-nowrap dark:text-white"
+      >
+        1
+      </th>
+      <td className="text-sm">등록된 연습문제 정보가 없습니다</td>
+      <td className="font-medium">-</td>
+      <td className="font-medium">-</td>
+    </tr>
+  );
+}

--- a/app/practices/components/PracticeList.tsx
+++ b/app/practices/components/PracticeList.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import Practice from './Practice';
+import NonePracticeParticipant from './NonePracticePostInfo';
+
+export default function PracticeList() {
+  const [isPracticeListReady, setIsPracticeListReady] = useState(false);
+
+  useEffect(() => {
+    setIsPracticeListReady(true);
+  }, []);
+
+  return isPracticeListReady ? (
+    <tbody>
+      <Practice />
+      <Practice />
+      <Practice />
+      <Practice />
+      <Practice />
+      <Practice />
+      <Practice />
+      <Practice />
+      <Practice />
+      <Practice />
+    </tbody>
+  ) : null;
+  //   <NonePracticeParticipant />;
+}


### PR DESCRIPTION
## 👀 이슈

resolve #45 

## 📌 개요

현재 홈페이지 내 `대회`, `시험`, `연습문제`, `공지사항` 목록 페이지 컴포넌트 내
개별 게시글 정보에 대한 `tr` 컴포넌트가 각각 추가되어 있는데, 해당 부분을 하나의
`tbody` 태그로 묶어 하나의 리스트 컴포넌트로 만든 후 개별 `tr` 컴포넌트들을 관리할
수 있도록 코드 구조를 재조정하였습니다.

## 👩‍💻 작업 사항

- `대회` 목록 페이지 컴포넌트 리팩토링
- `시험` 목록 페이지 컴포넌트 리팩토링
- `연습문제` 목록 페이지 컴포넌트 리팩토링
- `공지사항` 목록 페이지 컴포넌트 리팩토링

## ✅ 참고 사항

없습니다
