### PR TITLE
[refactor]: `대회/시험` 목록 리스트 컴포넌트 추가 (#45)

### DIFF
--- a/app/contests/page.tsx
+++ b/app/contests/page.tsx
@@ -1,5 +1,6 @@
-import Contest from './components/Contest';
 import Link from 'next/link';
+import ContestList from './components/ContestList';
+import { useState } from 'react';
 
 export default function Contests() {
   return (
@@ -81,18 +82,7 @@ export default function Contests() {
                       </th>
                     </tr>
                   </thead>
-                  <tbody>
-                    <Contest />
-                    <Contest />
-                    <Contest />
-                    <Contest />
-                    <Contest />
-                    <Contest />
-                    <Contest />
-                    <Contest />
-                    <Contest />
-                    <Contest />
-                  </tbody>
+                  <ContestList />
                 </table>
               </div>
             </div>

--- a/app/exams/page.tsx
+++ b/app/exams/page.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import Exam from './components/Exam';
 import Link from 'next/link';
+import ExamList from './components/ExamList';
 
 export default function exams() {
   return (
@@ -79,18 +79,7 @@ export default function exams() {
                       </th>
                     </tr>
                   </thead>
-                  <tbody>
-                    <Exam />
-                    <Exam />
-                    <Exam />
-                    <Exam />
-                    <Exam />
-                    <Exam />
-                    <Exam />
-                    <Exam />
-                    <Exam />
-                    <Exam />
-                  </tbody>
+                  <ExamList />
                 </table>
               </div>
             </div>


### PR DESCRIPTION
## 👀 이슈

resolve #45 

## 📌 개요

`refactor/45` 브랜치 내에서 작업한 내용 중 두 개의 이력을 누락한 상태로 #46
PR에 대한 `main` 브랜치의 머지가 진행되어 추가적인 이력에 대한 병합이 필요하였습니다.

## 👩‍💻 작업 사항

- `대회 목록` 페이지 컴포넌트 내 대회 목록 리스트화 컴포넌트 추가
- `시험 목록` 페이지 컴포넌트 내 시험 목록 리스트화 컴포넌트 추가

## ✅ 참고 사항

없습니다
