### PR TITLE
[fix]: 게시글 등록 컴포넌트 내 비밀번호 설정 입력란 상단 helper UI 스타일 일부 조정 (#58)

### DIFF
--- a/app/contests/register/page.tsx
+++ b/app/contests/register/page.tsx
@@ -268,7 +268,7 @@ export default function RegisterContest() {
                     />
                     <label
                       htmlFor="floating_first_name"
-                      className="peer-focus:font-light absolute text-base left-[0.1rem] font-light text-gray-500 dark:text-gray-400 duration-300 transform -translate-y-6 scale-75 top-3 -z-10 origin-[0] peer-focus:left-0 peer-focus:text-[#5762b3] peer-focus:dark:text-[#5762b3] peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0 peer-focus:scale-75 peer-focus:-translate-y-[1.5rem]"
+                      className="peer-focus:font-light absolute text-base left-[0.1rem] font-light text-gray-500 dark:text-gray-400 duration-300 transform -translate-y-5 scale-75 top-3 -z-10 origin-[0] peer-focus:left-[0.1rem] peer-focus:text-[#5762b3] peer-focus:dark:text-[#5762b3] peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0 peer-focus:scale-75 peer-focus:-translate-y-[1.25rem]"
                     >
                       비밀번호
                     </label>

--- a/app/exams/register/page.tsx
+++ b/app/exams/register/page.tsx
@@ -194,7 +194,7 @@ export default function RegisterExam() {
                 />
                 <label
                   htmlFor="floating_first_name"
-                  className="peer-focus:font-light absolute text-base left-[0.1rem] font-light text-gray-500 dark:text-gray-400 duration-300 transform -translate-y-6 scale-75 top-3 -z-10 origin-[0] peer-focus:left-0 peer-focus:text-[#5762b3] peer-focus:dark:text-[#5762b3] peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0 peer-focus:scale-75 peer-focus:-translate-y-[1.5rem]"
+                  className="peer-focus:font-light absolute text-base left-[0.1rem] font-light text-gray-500 dark:text-gray-400 duration-300 transform -translate-y-5 scale-75 top-3 -z-10 origin-[0] peer-focus:left-[0.1rem] peer-focus:text-[#5762b3] peer-focus:dark:text-[#5762b3] peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0 peer-focus:scale-75 peer-focus:-translate-y-[1.25rem]"
                 >
                   비밀번호
                 </label>

--- a/app/notices/register/page.tsx
+++ b/app/notices/register/page.tsx
@@ -147,7 +147,7 @@ export default function RegisterNotice() {
                 />
                 <label
                   htmlFor="floating_first_name"
-                  className="peer-focus:font-light absolute text-base left-[0.1rem] font-light text-gray-500 dark:text-gray-400 duration-300 transform -translate-y-6 scale-75 top-3 -z-10 origin-[0] peer-focus:left-0 peer-focus:text-[#5762b3] peer-focus:dark:text-[#5762b3] peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0 peer-focus:scale-75 peer-focus:-translate-y-[1.5rem]"
+                  className="peer-focus:font-light absolute text-base left-[0.1rem] font-light text-gray-500 dark:text-gray-400 duration-300 transform -translate-y-5 scale-75 top-3 -z-10 origin-[0] peer-focus:left-[0.1rem] peer-focus:text-[#5762b3] peer-focus:dark:text-[#5762b3] peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0 peer-focus:scale-75 peer-focus:-translate-y-[1.25rem]"
                 >
                   비밀번호
                 </label>

--- a/app/practices/register/page.tsx
+++ b/app/practices/register/page.tsx
@@ -325,7 +325,7 @@ export default function Registerpractice() {
                 />
                 <label
                   htmlFor="floating_first_name"
-                  className="peer-focus:font-light absolute text-base left-[0.1rem] font-light text-gray-500 dark:text-gray-400 duration-300 transform -translate-y-6 scale-75 top-3 -z-10 origin-[0] peer-focus:left-0 peer-focus:text-[#5762b3] peer-focus:dark:text-[#5762b3] peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0 peer-focus:scale-75 peer-focus:-translate-y-[1.5rem]"
+                  className="peer-focus:font-light absolute text-base left-[0.1rem] font-light text-gray-500 dark:text-gray-400 duration-300 transform -translate-y-5 scale-75 top-3 -z-10 origin-[0] peer-focus:left-[0.1rem] peer-focus:text-[#5762b3] peer-focus:dark:text-[#5762b3] peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0 peer-focus:scale-75 peer-focus:-translate-y-[1.25rem]"
                 >
                   비밀번호
                 </label>


### PR DESCRIPTION
## 👀 이슈

resolve #58 

## 📌 개요

홈페이지 내 `대회/시험/연습문제/공지사항` 등록 컴포넌트 하단에 위치한 `비밀번호 설정`
입력란 상단에 helper UI가 입력란에 해당하는 input 요소가 `focus` 및 `active` 되었을 경우
helper의 label 위치가 불안정하게 움직이는 문제가 발견되어 해당 부분을 수정하였습니다.

## 👩‍💻 작업 사항

- 모든 게시글 등록 컴포넌트 내 `비밀번호 설정` 입력란 상단의 helper의 UI 스타일 조정

## ✅ 참고 사항

- 기능 수정 전 `비밀번호 설정` 입력란 UI

![2](https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/c7fc318a-5ccf-4ab1-a09e-2f2bdcdc040e)

- 기능 수정 후 `비밀번호 설정` 입력란 UI

![ezgif com-video-to-gif (33)](https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/7f1d4baf-cce2-40ad-a8d7-0aee4227478d)