### PR TITLE
[feat]: 'Footer' 컴포넌트 내에 저작권 고지 년도 부분을 최신으로 유지하는 기능 추가 (#64)

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -2,6 +2,9 @@ import Link from 'next/link';
 import React from 'react';
 
 export default function Footer() {
+  // 현재 년도를 가져오기
+  const currentYear = new Date().getFullYear();
+
   return (
     <div className="w-full flex justify-start mt-auto font-light text-[10px] py-5 px-3 leading-[1.175rem] bg-[#505050]">
       <div className="flex flex-col 3xs:flex-row gap-10 justify-between mx-auto w-[60rem]">
@@ -40,7 +43,7 @@ export default function Footer() {
           </a> */}
           </div>
           <div className="mt-2 text-[#ccc]">
-            © 2020 충북대학교 SW중심대학사업단. All rights reserved.
+            © {currentYear} 충북대학교 SW중심대학사업단. All rights reserved.
           </div>
         </div>
         <div className="flex gap-5 mt-auto mr-2">


### PR DESCRIPTION
## 👀 이슈

resolve #64 

## 📌 개요

`Footer` 컴포넌트 내에 저작권 고지 년도 부분을 최신으로 유지하는 기능을
추가하였습니다.

## 👩‍💻 작업 사항

- `Footer` 컴포넌트 내에 저작권 고지 년도 부분을 최신으로 유지하는 기능 추가

## ✅ 참고 사항

- 기존 `Footer` 컴포넌트 내에 저작권 고지 년도 부분
> 과거 년도로 하드코딩 되어 있음

<img width="390" alt="Screenshot 2023-09-14 at 9 53 53 AM" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/20b00f45-aec0-4ad6-9ce9-f84d76bcda88">

- 기능 추가 후 `Footer` 컴포넌트 내에 저작권 고지 년도 부분
> 금년으로 자동으로 최신화 됨.

<img width="391" alt="2" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/00f92636-602d-4273-a805-de654216798c">