### PR TITLE
[fix]: confirm 함수에 대한 변수 선언 키워드 일괄 변경 (#80)

### DIFF
--- a/app/exams/[id]/page.tsx
+++ b/app/exams/[id]/page.tsx
@@ -16,7 +16,7 @@ export default function ExamDetail() {
   const router = useRouter();
 
   const handleDeleteExam = () => {
-    let userResponse = confirm(
+    const userResponse = confirm(
       '현재 시험 게시글을 삭제하시겠습니까?\n삭제 후 내용을 되돌릴 수 없습니다.',
     );
     if (!userResponse) return;

--- a/app/exams/register/page.tsx
+++ b/app/exams/register/page.tsx
@@ -52,7 +52,7 @@ export default function RegisterExam() {
   };
 
   const handleCancelContestRegister = () => {
-    let userResponse = confirm('시험 등록을 취소하시겠습니까?');
+    const userResponse = confirm('시험 등록을 취소하시겠습니까?');
     if (!userResponse) return;
 
     router.push('/exams');

--- a/app/notices/[id]/page.tsx
+++ b/app/notices/[id]/page.tsx
@@ -16,7 +16,7 @@ export default function NoticeDetail() {
   const router = useRouter();
 
   const handleDeleteExam = () => {
-    let userResponse = confirm(
+    const userResponse = confirm(
       '현재 공지사항 게시글을 삭제하시겠습니까?\n삭제 후 내용을 되돌릴 수 없습니다.',
     );
     if (!userResponse) return;

--- a/app/notices/register/page.tsx
+++ b/app/notices/register/page.tsx
@@ -38,7 +38,7 @@ export default function RegisterNotice() {
   };
 
   const handleCancelContestRegister = () => {
-    let userResponse = confirm('공지사항 등록을 취소하시겠습니까?');
+    const userResponse = confirm('공지사항 등록을 취소하시겠습니까?');
     if (!userResponse) return;
 
     router.push('/notices');

--- a/app/practices/[id]/page.tsx
+++ b/app/practices/[id]/page.tsx
@@ -20,7 +20,7 @@ export default function PracticeDetail() {
   const router = useRouter();
 
   const handleDeleteExam = () => {
-    let userResponse = confirm(
+    const userResponse = confirm(
       '현재 연습문제 게시글을 삭제하시겠습니까?\n삭제 후 내용을 되돌릴 수 없습니다.',
     );
     if (!userResponse) return;

--- a/app/practices/register/page.tsx
+++ b/app/practices/register/page.tsx
@@ -43,7 +43,7 @@ export default function Registerpractice() {
   };
 
   const handleCancelContestRegister = () => {
-    let userResponse = confirm('연습문제 등록을 취소하시겠습니까?');
+    const userResponse = confirm('연습문제 등록을 취소하시겠습니까?');
     if (!userResponse) return;
 
     router.push('/practices');


### PR DESCRIPTION
## 👀 이슈

resolve #80 

## 📌 개요

홈페이지 구성 페이지 컴포넌트 내 **`confirm`** 함수의 반환값을 저장하는
변수의 선언 키워드를 `let` ➜ `const`으로 일괄 변경하였습니다.

## 👩‍💻 작업 사항

- `confirm` 함수 반환값 저장 변수의 선언 키워드를 `const`으로 일괄 변경

## ✅ 참고 사항

없습니다
