### PR TITLE
[feat]: 대회 문제 비밀번호 설정 기능 추가 및 대회 참가 신청/취소 UI 요소 추가 (#82)

### DIFF
--- a/app/contests/[id]/page.tsx
+++ b/app/contests/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { ChangeEvent, useEffect, useState } from 'react';
 import Participant from './components/Participant';
 import Loading from '@/app/loading';
 
@@ -14,13 +14,36 @@ const MarkdownPreview = dynamic(
 export default function ExamDetail() {
   const [isContestPostReady, setIsContestPostReady] = useState(false);
   const [isMarkdownPreviewReady, setIsMarkdownPreviewReady] = useState(false);
+  const [isApplyContest, setIsApplyContest] = useState(false);
+
   const router = useRouter();
 
+  const handleApplyContest = () => {
+    const userResponse = confirm('대회 참가 신청을 하시겠습니까?');
+    if (!userResponse) return;
+
+    setIsApplyContest(true);
+    alert(
+      '대회 참가 신청이 완료되었습니다.\n대회 시간을 확인한 후, 해당 시간에 참가해 주세요',
+    );
+  };
+
+  const handleCancelContest = () => {
+    const userResponse = confirm(
+      '대회 참가 신청을 취소하시겠습니까?\n참가신청 기간 이후에는 다시 신청할 수 없습니다.',
+    );
+    if (!userResponse) return;
+
+    setIsApplyContest(false);
+    alert('대회 참가 신청이 취소되었습니다.');
+  };
+
   const handleDeleteExam = () => {
-    let userResponse = confirm(
+    const userResponse = confirm(
       '현재 대회 게시글을 삭제하시겠습니까?\n삭제 후 내용을 되돌릴 수 없습니다.',
     );
     if (!userResponse) return;
+
     alert('게시글을 삭제하였습니다.');
     router.push('/contests');
   };
@@ -136,6 +159,21 @@ export default function ExamDetail() {
               </button>
               <button
                 onClick={() => alert('개발 예정')}
+                className="flex gap-[0.375rem] items-center text-white bg-[#0388ca] px-2 py-[0.4rem] rounded-[0.2rem] font-light focus:bg-[#007eb9] hover:bg-[#007eb9] box-shadow"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  height="20"
+                  viewBox="0 -960 960 960"
+                  width="20"
+                  fill="white"
+                >
+                  <path d="M320-240h320v-80H320v80Zm0-160h320v-80H320v80ZM240-80q-33 0-56.5-23.5T160-160v-640q0-33 23.5-56.5T240-880h320l240 240v480q0 33-23.5 56.5T720-80H240Zm280-520h200L520-800v200Z" />
+                </svg>
+                문제 관리
+              </button>
+              <button
+                onClick={() => alert('개발 예정')}
                 className="flex gap-[0.375rem] items-center text-white bg-[#eba338] px-2 py-[0.4rem] rounded-[0.2rem] font-light focus:bg-[#dc9429] hover:bg-[#dc9429] box-shadow"
               >
                 <svg
@@ -166,10 +204,75 @@ export default function ExamDetail() {
               </button>
             </div>
           </div>
-          <div className="mt-14 py-2">
-            <p className="flex gap-2 items-center text-2xl font-semibold">
-              참가자
-            </p>
+
+          <div className="mt-2">
+            <p className="text-2xl font-semibold mt-10 ">참여 방법</p>
+            <div className="flex flex-col items-center gap-4 mt-4 mx-auto bg-[#fafafa] w-full py-[1.75rem] border border-[#e4e4e4] border-t-2 border-t-gray-400">
+              {isApplyContest ? (
+                <>
+                  <button
+                    onClick={handleCancelContest}
+                    className="flex gap-[0.6rem] items-center w-fit h-11 text-[#3870e0] text-lg font-medium border-[1.5px] border-[#3870e0] px-4 py-[0.5rem] rounded-[3rem] box-shadow transition duration-75"
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      height="25"
+                      viewBox="0 -960 960 960"
+                      width="25"
+                      fill="#3870e0"
+                    >
+                      <path d="M200-120q-33 0-56.5-23.5T120-200v-560q0-33 23.5-56.5T200-840h280v80H200v560h280v80H200Zm440-160-55-58 102-102H360v-80h327L585-622l55-58 200 200-200 200Z" />
+                    </svg>
+                    대회 참가 취소하기
+                  </button>
+
+                  <div className="flex flex-col gap-1 text-center">
+                    <div className="text-[#777] text-xs">
+                      대회 시작 전까지만{' '}
+                      <span className="text-red-500">신청 취소가 가능</span>
+                      합니다.
+                    </div>
+                    <div className="text-[#777] text-xs">
+                      비정상적인 이력이 확인될 경우, 서비스 이용이 제한됩니다.
+                    </div>
+                  </div>
+                </>
+              ) : (
+                <>
+                  <button
+                    onClick={handleApplyContest}
+                    className="flex gap-[0.6rem] items-center w-fit h-11 text-white text-lg font-medium bg-[#3870e0] px-4 py-[0.5rem] rounded-[3rem] focus:bg-[#3464c2] hover:bg-[#3464c2] box-shadow transition duration-75"
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      height="25"
+                      viewBox="0 -960 960 960"
+                      width="25"
+                      fill="white"
+                    >
+                      <path d="M480-120v-80h280v-560H480v-80h280q33 0 56.5 23.5T840-760v560q0 33-23.5 56.5T760-120H480Zm-80-160-55-58 102-102H120v-80h327L345-622l55-58 200 200-200 200Z" />
+                    </svg>
+                    대회 참가 신청하기
+                  </button>
+
+                  <div className="flex flex-col gap-1 text-center">
+                    <div className="text-[#777] text-xs">
+                      대회 시작 후에는{' '}
+                      <span className="text-red-500">신청이 불가능</span>
+                      합니다.
+                    </div>
+                    <div className="text-[#777] text-xs">
+                      참가 신청 이전에 반드시 대회 내용을 자세히 읽어주시기
+                      바랍니다.
+                    </div>
+                  </div>
+                </>
+              )}
+            </div>
+          </div>
+
+          <div className="mt-8 py-2">
+            <p className="text-2xl font-semibold">참가자</p>
             <div className="flex mt-4 justify-between items-center">
               <span>
                 신청자 수: <span className="text-red-500">8명</span>

--- a/app/contests/register/page.tsx
+++ b/app/contests/register/page.tsx
@@ -19,18 +19,27 @@ export default function RegisterContest() {
   const [contestStartDateTime, setContestStartDateTime] = useState('');
   const [contestEndDateTime, setContestEndDateTime] = useState('');
   const [isCheckedAppliedPeriod, setIsCheckedAppliedPeriod] = useState(false);
-  const [isCheckedUsingPwd, setIsCheckedUsingPwd] = useState(false);
+  const [isCheckedUsingContestPwd, setIsCheckedUsingContestPwd] =
+    useState(false);
+  const [
+    isCheckedUsingContestProblemsPwd,
+    setIsCheckedUsingContestProblemsPwd,
+  ] = useState(false);
   const [contestAppliedStartDateTime, setContestAppliedStartDateTime] =
     useState('');
   const [contestAppliedEndDateTime, setContestAppliedEndDateTime] =
     useState('');
   const [contestPwd, setContestPwd] = useState('');
+  const [contestProblemsPwd, setContestProblemsPwd] = useState('');
 
   const [isContestNameValidFail, setIsContestNameValidFail] = useState(false);
   const [isContestPwdValidFail, setIsContestPwdValidFail] = useState(false);
+  const [isContestProblemsPwdValidFail, setIsContestProblemsPwdValidFail] =
+    useState(false);
 
   const contestNameRef = useRef<HTMLInputElement>(null);
   const contestPwdRef = useRef<HTMLInputElement>(null);
+  const contestProblemsPwdRef = useRef<HTMLInputElement>(null);
 
   const router = useRouter();
 
@@ -47,8 +56,15 @@ export default function RegisterContest() {
     setIsContestPwdValidFail(false);
   };
 
+  const handleContestProblemsPwdChange = (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    setContestProblemsPwd(e.target.value);
+    setIsContestProblemsPwdValidFail(false);
+  };
+
   const handleCancelContestRegister = () => {
-    let userResponse = confirm('대회 등록을 취소하시겠습니까?');
+    const userResponse = confirm('대회 등록을 취소하시겠습니까?');
     if (!userResponse) return;
 
     router.push('/contests');
@@ -84,11 +100,19 @@ export default function RegisterContest() {
       return;
     }
 
-    if (isCheckedUsingPwd && !contestPwd) {
-      alert('비밀번호를 입력해 주세요');
+    if (isCheckedUsingContestPwd && !contestPwd) {
+      alert('대회 비밀번호를 입력해 주세요');
       window.scrollTo(0, document.body.scrollHeight);
       contestPwdRef.current?.focus();
       setIsContestPwdValidFail(true);
+      return;
+    }
+
+    if (isCheckedUsingContestProblemsPwd && !contestProblemsPwd) {
+      alert('문제 비밀번호를 입력해 주세요');
+      window.scrollTo(0, document.body.scrollHeight);
+      contestProblemsPwdRef.current?.focus();
+      setIsContestProblemsPwdValidFail(true);
       return;
     }
 
@@ -180,7 +204,7 @@ export default function RegisterContest() {
                 <div className="flex">
                   <div className="flex items-center h-5">
                     <input
-                      id="helper-checkbox"
+                      id="helper-checkbox-applied-period"
                       aria-describedby="helper-checkbox-text"
                       type="checkbox"
                       checked={isCheckedAppliedPeriod}
@@ -192,7 +216,7 @@ export default function RegisterContest() {
                   </div>
                   <div className="ml-2 text-sm">
                     <label
-                      htmlFor="helper-checkbox"
+                      htmlFor="helper-checkbox-applied-period"
                       className="font-medium text-gray-900 dark:text-gray-300"
                     >
                       신청기간 설정
@@ -219,6 +243,7 @@ export default function RegisterContest() {
                     </div>
                   </div>
                 </div>
+
                 {isCheckedAppliedPeriod ? (
                   <div className="flex gap-5 items-center mt-3">
                     <input
@@ -252,20 +277,22 @@ export default function RegisterContest() {
                 <div className="flex">
                   <div className="flex items-center h-5">
                     <input
-                      id="helper-checkbox"
+                      id="helper-checkbox-using-contest-pwd"
                       aria-describedby="helper-checkbox-text"
                       type="checkbox"
-                      checked={isCheckedUsingPwd}
-                      onChange={() => setIsCheckedUsingPwd(!isCheckedUsingPwd)}
+                      checked={isCheckedUsingContestPwd}
+                      onChange={() =>
+                        setIsCheckedUsingContestPwd(!isCheckedUsingContestPwd)
+                      }
                       className="w-4 h-4 text-blue-600 border-2 border-[#757575] rounded-[0.175rem] focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
                     />
                   </div>
                   <div className="ml-2 text-sm">
                     <label
-                      htmlFor="helper-checkbox"
+                      htmlFor="helper-checkbox-using-contest-pwd"
                       className="font-medium text-gray-900 dark:text-gray-300"
                     >
-                      비밀번호 설정
+                      대회 비밀번호 설정
                     </label>
 
                     <div className="flex mt-1">
@@ -289,7 +316,7 @@ export default function RegisterContest() {
                     </div>
                   </div>
                 </div>
-                {isCheckedUsingPwd ? (
+                {isCheckedUsingContestPwd ? (
                   <div className="flex flex-col relative z-0 w-1/2 group mt-7">
                     <input
                       type="text"
@@ -313,6 +340,84 @@ export default function RegisterContest() {
                         isContestPwdValidFail ? 'red' : 'blue'
                       }-600 peer-focus:dark:text-${
                         isContestPwdValidFail ? 'red' : 'blue'
+                      }-500 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0 peer-focus:scale-75 peer-focus:-translate-y-[1.25rem]`}
+                    >
+                      비밀번호
+                    </label>
+                  </div>
+                ) : null}
+              </div>
+
+              <div className="flex flex-col">
+                <div className="flex">
+                  <div className="flex items-center h-5">
+                    <input
+                      id="helper-checkbox-using-contest-problems-pwd"
+                      aria-describedby="helper-checkbox-text"
+                      type="checkbox"
+                      checked={isCheckedUsingContestProblemsPwd}
+                      onChange={() =>
+                        setIsCheckedUsingContestProblemsPwd(
+                          !isCheckedUsingContestProblemsPwd,
+                        )
+                      }
+                      className="w-4 h-4 text-blue-600 border-2 border-[#757575] rounded-[0.175rem] focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
+                    />
+                  </div>
+                  <div className="ml-2 text-sm">
+                    <label
+                      htmlFor="helper-checkbox-using-contest-problems-pwd"
+                      className="font-medium text-gray-900 dark:text-gray-300"
+                    >
+                      문제 비밀번호 설정
+                    </label>
+
+                    <div className="flex mt-1">
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        height="15"
+                        viewBox="0 -960 960 960"
+                        width="15"
+                        fill="#5762b3"
+                        className="relative left-[-1.375rem] top-[0.1rem]"
+                      >
+                        <path d="M440.667-269.333h83.999V-520h-83.999v250.667Zm39.204-337.333q17.796 0 29.962-11.833Q522-630.332 522-647.824q0-18.809-12.021-30.825-12.021-12.017-29.792-12.017-18.52 0-30.354 11.841Q438-666.984 438-648.508q0 17.908 12.038 29.875 12.038 11.967 29.833 11.967Zm.001 547.999q-87.157 0-163.841-33.353-76.684-33.354-133.671-90.34-56.986-56.987-90.34-133.808-33.353-76.821-33.353-164.165 0-87.359 33.412-164.193 33.413-76.834 90.624-134.057 57.211-57.224 133.757-89.987t163.578-32.763q87.394 0 164.429 32.763 77.034 32.763 134.117 90 57.082 57.237 89.916 134.292 32.833 77.056 32.833 164.49 0 87.433-32.763 163.67-32.763 76.236-89.987 133.308-57.223 57.073-134.261 90.608-77.037 33.535-164.45 33.535Zm.461-83.999q140.18 0 238.59-98.744 98.411-98.744 98.411-238.923 0-140.18-98.286-238.59Q620.763-817.334 480-817.334q-139.846 0-238.59 98.286Q142.666-620.763 142.666-480q0 139.846 98.744 238.59t238.923 98.744ZM480-480Z" />
+                      </svg>
+                      <p
+                        id="helper-checkbox-text"
+                        className="relative left-[-0.8rem] text-xs font-normal text-[#5762b3] dark:text-gray-300"
+                      >
+                        비밀번호를 설정할 경우 문제 열람 시 비밀번호 입력이
+                        필요합니다.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+
+                {isCheckedUsingContestProblemsPwd ? (
+                  <div className="flex flex-col relative z-0 w-1/2 group mt-7">
+                    <input
+                      type="text"
+                      name="floating_first_name"
+                      className={`block pt-3 pb-[0.175rem] pl-0 pr-0 w-full font-normal text-gray-900 bg-transparent border-0 border-b border-gray-400 appearance-none dark:text-white dark:border-gray-600 dark:focus:border-${
+                        isContestProblemsPwdValidFail ? 'pink' : 'blue'
+                      }-500 focus:border-${
+                        isContestProblemsPwdValidFail ? 'red' : 'blue'
+                      }-500 focus:outline-none focus:ring-0 peer`}
+                      placeholder=" "
+                      required
+                      value={contestProblemsPwd}
+                      ref={contestProblemsPwdRef}
+                      onChange={handleContestProblemsPwdChange}
+                    />
+                    <label
+                      htmlFor="floating_first_name"
+                      className={`peer-focus:font-light absolute text-base left-[0.1rem] font-light text-${
+                        isContestProblemsPwdValidFail ? 'red' : 'gray'
+                      }-500 dark:text-gray-400 duration-300 transform -translate-y-5 scale-75 top-3 -z-10 origin-[0] peer-focus:left-[0.1rem] peer-focus:text-${
+                        isContestProblemsPwdValidFail ? 'red' : 'blue'
+                      }-600 peer-focus:dark:text-${
+                        isContestProblemsPwdValidFail ? 'red' : 'blue'
                       }-500 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0 peer-focus:scale-75 peer-focus:-translate-y-[1.25rem]`}
                     >
                       비밀번호


### PR DESCRIPTION
## 👀 이슈

resolve #82 

## 📌 개요

대회 내 등록된 문제 목록을 열람 시에 필요한 **비밀번호**를 설정할 수 있는 기능과
대회 상세 페이지 내에서 **대회 참가 신청하기/취소하기** 기능의 추가를 위해 관련 UI를
추가하였습니다.

## 👩‍💻 작업 사항

- `대회 문제 열람 비밀번호 설정` 기능 추가
- `대회 참가 신청하기/취소하기` UI 추가

## ✅ 참고 사항

- 기능 추가 이전의 `대회 등록하기` 페이지 UI

<img width="1142" alt="Screenshot 2024-01-02 at 10 38 35 AM" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/68318107-e7cf-44be-9a36-e65fffa5ab78">

- 기능 추가 후 `대회 등록하기` 페이지 UI
> `대회 참가 신청하기/취소하기` UI 추가

https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/6b4fe81a-fab0-477a-bab5-76c78d663f10

---

- 기능 추가 이전의 `대회 상세` 페이지 UI

<img width="1190" alt="Screenshot 2024-01-02 at 10 38 27 AM" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/49dc05e5-f90a-4616-a9ae-465b72f00084">

- 기능 추가 후 `대회 상세` 페이지 UI
> `대회 문제 열람 비밀번호 설정` 기능 추가
 
<img width="621" alt="Screenshot 2024-01-02 at 10 51 06 AM" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/8a2d0ce0-5b35-4a71-a495-72a2837bee1f">