### PR TITLE
[fix]: {연습문제 상세 페이지} 컴포넌트 내 uiw react-markdown-preview 라이브러리 사용 코드 제거 (#84)

### DIFF
--- a/app/practices/[id]/page.tsx
+++ b/app/practices/[id]/page.tsx
@@ -9,11 +9,6 @@ const PDFViewer = dynamic(() => import('@/app/components/PDFViewer'), {
   ssr: false,
 });
 
-const MarkdownPreview = dynamic(
-  () => import('@uiw/react-markdown-preview').then((mod) => mod.default),
-  { ssr: false },
-);
-
 export default function PracticeDetail() {
   const [isExamPostReady, setIsExamPostReady] = useState(false);
   const [isMarkdownPreviewReady, setIsMarkdownPreviewReady] = useState(false);
@@ -59,21 +54,6 @@ export default function PracticeDetail() {
             </div>
           </div>
           <div className="gap-5 border-b mt-8 mb-4 pb-5">
-            <MarkdownPreview
-              className="markdown-preview"
-              source={`\`\`\`C
-// 두 정수의 합을 반환하는 함수
-function add(int a, int b) {
-  return a + b;
-}
-
-// 두 정수의 차이 값을 반환하는 함수
-function sub(int a, int b) {
-  return a - b;
-}
-\`\`\`
-> (예시) 상단에 주어진 두 함수를 수정하지 않고 모두 사용하시오.`}
-            />
             <PDFViewer pdfFileURL={'/pdfs/test.pdf'} />
           </div>
           <div>


### PR DESCRIPTION
## 👀 이슈

resolve #84 

## 📌 개요

**연습문제 상세 페이지**에서 uiw react-markdown-preview 라이브러리에 대한
컴포넌트를 사용하지 않도록 하여 관련 코드를 제거하였습니다.

## 👩‍💻 작업 사항

- `연습문제 상세 페이지` 컴포넌트 내 uiw react-markdown-preview 라이브러리에 대한 컴포넌트 사용 코드 제거

## ✅ 참고 사항

- 기능 수정 전 `연습문제 상세 페이지` UI
> uiw react-markdown-preview 컴포넌트를 제거하기 이전

<img width="1122" alt="Screenshot 2024-01-02 at 11 27 17 AM" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/09153bc2-6233-4386-9754-b9a4e705a588">

- 기능 수정 후 `연습문제 상세 페이지` UI
> uiw react-markdown-preview 컴포넌트를 제거한 후

<img width="1122" alt="Screenshot 2024-01-02 at 11 30 44 AM" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/4ad1ea28-ba9b-4526-b573-3c2c2c7a5abc">