### PR TITLE
[feat]: `대회 순위` 페이지 추가 (#97)

### DIFF
--- a/app/contests/[id]/page.tsx
+++ b/app/contests/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
-import { ChangeEvent, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import Participant from './components/Participant';
 import Loading from '@/app/loading';
 
@@ -26,14 +26,8 @@ export default function ExamDetail(props: DefaultProps) {
 
   const router = useRouter();
 
-  const handleApplyContest = () => {
-    const userResponse = confirm('대회 참가 신청을 하시겠습니까?');
-    if (!userResponse) return;
-
-    setIsApplyContest(true);
-    alert(
-      '대회 참가 신청이 완료되었습니다.\n대회 시간을 확인한 후, 해당 시간에 참가해 주세요',
-    );
+  const handleGoToContestRankList = () => {
+    router.push(`/contests/${cid}/ranklist`);
   };
 
   const handleCancelContest = () => {
@@ -58,6 +52,16 @@ export default function ExamDetail(props: DefaultProps) {
 
     alert('게시글을 삭제하였습니다.');
     router.push('/contests');
+  };
+
+  const handleApplyContest = () => {
+    const userResponse = confirm('대회 참가 신청을 하시겠습니까?');
+    if (!userResponse) return;
+
+    setIsApplyContest(true);
+    alert(
+      '대회 참가 신청이 완료되었습니다.\n대회 시간을 확인한 후, 해당 시간에 참가해 주세요',
+    );
   };
 
   useEffect(() => {
@@ -140,8 +144,8 @@ export default function ExamDetail(props: DefaultProps) {
           <div>
             <div className="flex gap-3 justify-end">
               <button
-                onClick={() => alert('개발 예정')}
-                className="flex gap-[0.375rem] items-center text-white bg-[#3870e0] px-2 py-[0.4rem] rounded-[0.2rem] font-light focus:bg-[#3464c2] hover:bg-[#3464c2] box-shadow"
+                onClick={handleGoToContestRankList}
+                className="flex gap-[0.375rem] items-center text-white bg-[#0388ca] px-2 py-[0.4rem] rounded-[0.2rem] font-light focus:bg-[#007eb9] hover:bg-[#007eb9] box-shadow"
               >
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
@@ -171,7 +175,7 @@ export default function ExamDetail(props: DefaultProps) {
               </button>
               <button
                 onClick={() => alert('개발 예정')}
-                className="flex gap-[0.375rem] items-center text-white bg-[#0388ca] px-2 py-[0.4rem] rounded-[0.2rem] font-light focus:bg-[#007eb9] hover:bg-[#007eb9] box-shadow"
+                className="flex gap-[0.375rem] items-center text-white bg-[#3870e0] px-2 py-[0.4rem] rounded-[0.2rem] font-light focus:bg-[#3464c2] hover:bg-[#3464c2] box-shadow"
               >
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
@@ -287,7 +291,7 @@ export default function ExamDetail(props: DefaultProps) {
             <p className="text-2xl font-semibold">참가자</p>
             <div className="flex mt-4 justify-between items-center">
               <span>
-                신청자 수: <span className="text-red-500">8명</span>
+                신청자 수: <span className="text-red-500">8</span>명
               </span>
               <div className="flex gap-3">
                 <button

--- a/app/contests/[id]/ranklist/components/NoneUserScoreInfoList.tsx
+++ b/app/contests/[id]/ranklist/components/NoneUserScoreInfoList.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function NoneUserScoreInfoList() {
+  return (
+    <div className="flex justify-center items-center h-[27.5rem] text-xl text-gray-500 fade-in">
+      제출자가 존재하지 않습니다
+    </div>
+  );
+}

--- a/app/contests/[id]/ranklist/components/UserScoreInfoList.tsx
+++ b/app/contests/[id]/ranklist/components/UserScoreInfoList.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import UserScoreInfoListItem from './UserScoreInfoListItem';
+
+interface UserScoreInfoListProps {
+  cid: string;
+}
+
+export default function UserScoreInfoList({ cid }: UserScoreInfoListProps) {
+  const numberOfItems = 5;
+
+  return (
+    <div className="flex flex-col gap-5">
+      {Array.from({ length: numberOfItems }, (_, idx) => (
+        <UserScoreInfoListItem key={idx} cid={cid} ranking={idx + 1} />
+      ))}
+    </div>
+  );
+}

--- a/app/contests/[id]/ranklist/components/UserScoreInfoListItem.tsx
+++ b/app/contests/[id]/ranklist/components/UserScoreInfoListItem.tsx
@@ -1,0 +1,238 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import React, { useEffect, useState } from 'react';
+
+interface UserScoreInfoListItemProps {
+  cid: string;
+  ranking: number;
+}
+
+export default function UserScoreInfoListItem({
+  cid,
+  ranking,
+}: UserScoreInfoListItemProps) {
+  const router = useRouter();
+
+  const handleGoToTheProblem = (problemIdx: number) => {
+    alert('개발 예정');
+    // router.push(`/contests/${cid}/problems/${problemIdx}`);
+  };
+
+  return (
+    <div className="flex justify-between min-h-[9rem] border border-gray-300 shadow-md">
+      <div className="flex flex-col p-3">
+        <div className="flex items-center h-fit">
+          <div className="flex justify-center items-center w-[1.625rem] h-[1.625rem] bg-[#3870e0] rounded-sm">
+            <span className="text-white font-semibold text-base">
+              {ranking}
+            </span>
+          </div>
+          <div className="ml-2">
+            <span className="text-base">홍길동</span>{' '}
+            <span className="text-xs text-gray-600">
+              (충북대학교 소프트웨어학과)
+            </span>
+          </div>
+        </div>
+        <div className="flex flex-wrap mt-5 gap-3">
+          <div className="relative flex flex-col justify-center items-center w-[5.5rem] h-[4.5rem] bg-[#3870e0] border border-[#3565c4] hover:brightness-90 duration-150">
+            <div className="absolute top-[0.175rem] left-[0.175rem]">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                height="5"
+                viewBox="0 -960 960 960"
+                width="5"
+                fill="white"
+              >
+                <path d="M480.238-137q-71.145 0-133.868-27.023t-109.12-73.348q-46.398-46.325-73.324-108.826Q137-408.699 137-479.762q0-71.145 27.023-133.868t73.348-109.12q46.325-46.398 108.826-73.324Q408.699-823 479.762-823q71.145 0 133.868 27.023t109.12 73.348q46.398 46.325 73.324 108.826Q823-551.301 823-480.238q0 71.145-27.023 133.868t-73.348 109.12q-46.325 46.398-108.826 73.324Q551.301-137 480.238-137Z" />
+              </svg>
+            </div>
+            <button
+              className="text-white text-[0.825rem] underline font-medium hover:text-[#eee] focus:text-[#eee]"
+              onClick={() => handleGoToTheProblem(1)}
+            >
+              문제 1번
+            </button>
+            <span className="text-white text-[0.825rem]">시도: 1회</span>
+            <span className="text-white text-[0.825rem]">시간: 3분</span>
+          </div>
+
+          <div className="relative flex flex-col justify-center items-center w-[5.5rem] h-[4.5rem] bg-[#3870e0] border border-[#3565c4] hover:brightness-90 duration-150">
+            <div className="absolute top-[0.175rem] left-[0.175rem]">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                height="5"
+                viewBox="0 -960 960 960"
+                width="5"
+                fill="white"
+              >
+                <path d="M480.238-137q-71.145 0-133.868-27.023t-109.12-73.348q-46.398-46.325-73.324-108.826Q137-408.699 137-479.762q0-71.145 27.023-133.868t73.348-109.12q46.325-46.398 108.826-73.324Q408.699-823 479.762-823q71.145 0 133.868 27.023t109.12 73.348q46.398 46.325 73.324 108.826Q823-551.301 823-480.238q0 71.145-27.023 133.868t-73.348 109.12q-46.325 46.398-108.826 73.324Q551.301-137 480.238-137Z" />
+              </svg>
+            </div>
+            <button
+              className="text-white text-[0.825rem] underline font-medium hover:text-[#eee] focus:text-[#eee]"
+              onClick={() => handleGoToTheProblem(2)}
+            >
+              문제 2번
+            </button>
+            <span className="text-white text-[0.825rem]">시도: 1회</span>
+            <span className="text-white text-[0.825rem]">시간: 3분</span>
+          </div>
+
+          <div className="relative flex flex-col justify-center items-center w-[5.5rem] h-[4.5rem] bg-[#e0e0e0] border border-[#d3d3d3] hover:brightness-90 duration-150">
+            <div className="absolute top-[0.175rem] left-[0.175rem]">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                height="5"
+                viewBox="0 -960 960 960"
+                width="5"
+                fill="white"
+              >
+                <path d="M480.238-137q-71.145 0-133.868-27.023t-109.12-73.348q-46.398-46.325-73.324-108.826Q137-408.699 137-479.762q0-71.145 27.023-133.868t73.348-109.12q46.325-46.398 108.826-73.324Q408.699-823 479.762-823q71.145 0 133.868 27.023t109.12 73.348q46.398 46.325 73.324 108.826Q823-551.301 823-480.238q0 71.145-27.023 133.868t-73.348 109.12q-46.325 46.398-108.826 73.324Q551.301-137 480.238-137Z" />
+              </svg>
+            </div>
+            <button
+              className="text-[#3f3f3f] text-[0.825rem] underline font-medium hover:text-black focus:text-black"
+              onClick={() => handleGoToTheProblem(3)}
+            >
+              문제 3번
+            </button>
+            <span className="text-[#3f3f3f] text-[0.825rem]">시도: 1회</span>
+            <span className="text-[#3f3f3f] text-[0.825rem]">시간: 3분</span>
+          </div>
+
+          <div className="relative flex flex-col justify-center items-center w-[5.5rem] h-[4.5rem] bg-[#3870e0] border border-[#3565c4] hover:brightness-90 duration-150">
+            <div className="absolute top-[0.175rem] left-[0.175rem]">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                height="5"
+                viewBox="0 -960 960 960"
+                width="5"
+                fill="white"
+              >
+                <path d="M480.238-137q-71.145 0-133.868-27.023t-109.12-73.348q-46.398-46.325-73.324-108.826Q137-408.699 137-479.762q0-71.145 27.023-133.868t73.348-109.12q46.325-46.398 108.826-73.324Q408.699-823 479.762-823q71.145 0 133.868 27.023t109.12 73.348q46.398 46.325 73.324 108.826Q823-551.301 823-480.238q0 71.145-27.023 133.868t-73.348 109.12q-46.325 46.398-108.826 73.324Q551.301-137 480.238-137Z" />
+              </svg>
+            </div>
+            <button
+              className="text-white text-[0.825rem] underline font-medium hover:text-[#eee] focus:text-[#eee]"
+              onClick={() => handleGoToTheProblem(4)}
+            >
+              문제 4번
+            </button>
+            <span className="text-white text-[0.825rem]">시도: 1회</span>
+            <span className="text-white text-[0.825rem]">시간: 3분</span>
+          </div>
+
+          <div className="relative flex flex-col justify-center items-center w-[5.5rem] h-[4.5rem] bg-[#e0e0e0] border border-[#d3d3d3] hover:brightness-90 duration-150">
+            <div className="absolute top-[0.175rem] left-[0.175rem]">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                height="5"
+                viewBox="0 -960 960 960"
+                width="5"
+                fill="white"
+              >
+                <path d="M480.238-137q-71.145 0-133.868-27.023t-109.12-73.348q-46.398-46.325-73.324-108.826Q137-408.699 137-479.762q0-71.145 27.023-133.868t73.348-109.12q46.325-46.398 108.826-73.324Q408.699-823 479.762-823q71.145 0 133.868 27.023t109.12 73.348q46.398 46.325 73.324 108.826Q823-551.301 823-480.238q0 71.145-27.023 133.868t-73.348 109.12q-46.325 46.398-108.826 73.324Q551.301-137 480.238-137Z" />
+              </svg>
+            </div>
+            <button
+              className="text-[#3f3f3f] text-[0.825rem] underline font-medium hover:text-black focus:text-black"
+              onClick={() => handleGoToTheProblem(5)}
+            >
+              문제 5번
+            </button>
+            <span className="text-[#3f3f3f] text-[0.825rem]">시도: 1회</span>
+            <span className="text-[#3f3f3f] text-[0.825rem]">시간: 3분</span>
+          </div>
+
+          <div className="relative flex flex-col justify-center items-center w-[5.5rem] h-[4.5rem] bg-[#e0e0e0] border border-[#d3d3d3] hover:brightness-90 duration-150">
+            <div className="absolute top-[0.175rem] left-[0.175rem]">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                height="5"
+                viewBox="0 -960 960 960"
+                width="5"
+                fill="white"
+              >
+                <path d="M480.238-137q-71.145 0-133.868-27.023t-109.12-73.348q-46.398-46.325-73.324-108.826Q137-408.699 137-479.762q0-71.145 27.023-133.868t73.348-109.12q46.325-46.398 108.826-73.324Q408.699-823 479.762-823q71.145 0 133.868 27.023t109.12 73.348q46.398 46.325 73.324 108.826Q823-551.301 823-480.238q0 71.145-27.023 133.868t-73.348 109.12q-46.325 46.398-108.826 73.324Q551.301-137 480.238-137Z" />
+              </svg>
+            </div>
+            <button
+              className="text-[#3f3f3f] text-[0.825rem] underline font-medium hover:text-black focus:text-black"
+              onClick={() => handleGoToTheProblem(6)}
+            >
+              문제 6번
+            </button>
+            <span className="text-[#3f3f3f] text-[0.825rem]">시도: 1회</span>
+            <span className="text-[#3f3f3f] text-[0.825rem]">시간: 3분</span>
+          </div>
+
+          <div className="relative flex flex-col justify-center items-center w-[5.5rem] h-[4.5rem] bg-[#e0e0e0] border border-[#d3d3d3] hover:brightness-90 duration-150">
+            <div className="absolute top-[0.175rem] left-[0.175rem]">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                height="5"
+                viewBox="0 -960 960 960"
+                width="5"
+                fill="white"
+              >
+                <path d="M480.238-137q-71.145 0-133.868-27.023t-109.12-73.348q-46.398-46.325-73.324-108.826Q137-408.699 137-479.762q0-71.145 27.023-133.868t73.348-109.12q46.325-46.398 108.826-73.324Q408.699-823 479.762-823q71.145 0 133.868 27.023t109.12 73.348q46.398 46.325 73.324 108.826Q823-551.301 823-480.238q0 71.145-27.023 133.868t-73.348 109.12q-46.325 46.398-108.826 73.324Q551.301-137 480.238-137Z" />
+              </svg>
+            </div>
+            <button
+              className="text-[#3f3f3f] text-[0.825rem] underline font-medium hover:text-black focus:text-black"
+              onClick={() => handleGoToTheProblem(7)}
+            >
+              문제 7번
+            </button>
+            <span className="text-[#3f3f3f] text-[0.825rem]">시도: 1회</span>
+            <span className="text-[#3f3f3f] text-[0.825rem]">시간: 3분</span>
+          </div>
+
+          <div className="relative flex flex-col justify-center items-center w-[5.5rem] h-[4.5rem] bg-[#e0e0e0] border border-[#d3d3d3] hover:brightness-90 duration-150">
+            <div className="absolute top-[0.175rem] left-[0.175rem]">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                height="5"
+                viewBox="0 -960 960 960"
+                width="5"
+                fill="white"
+              >
+                <path d="M480.238-137q-71.145 0-133.868-27.023t-109.12-73.348q-46.398-46.325-73.324-108.826Q137-408.699 137-479.762q0-71.145 27.023-133.868t73.348-109.12q46.325-46.398 108.826-73.324Q408.699-823 479.762-823q71.145 0 133.868 27.023t109.12 73.348q46.398 46.325 73.324 108.826Q823-551.301 823-480.238q0 71.145-27.023 133.868t-73.348 109.12q-46.325 46.398-108.826 73.324Q551.301-137 480.238-137Z" />
+              </svg>
+            </div>
+            <button
+              className="text-[#3f3f3f] text-[0.825rem] underline font-medium hover:text-black focus:text-black"
+              onClick={() => handleGoToTheProblem(7)}
+            >
+              문제 8번
+            </button>
+            <span className="text-[#3f3f3f] text-[0.825rem]">시도: 1회</span>
+            <span className="text-[#3f3f3f] text-[0.825rem]">시간: 3분</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex justify-around w-32 border-l border-gray-300">
+        <div className="flex flex-col w-full text-center bg-[#f7f7f7]">
+          <div className="flex justify-center items-center text-[0.825rem] font-semibold bg-[#f7f7f7] h-8 border-b border-gray-300">
+            점수
+          </div>
+          <div className="flex justify-center items-center bg-white h-full">
+            10
+          </div>
+        </div>
+        <div className="flex flex-col w-full text-center bg-[#f7f7f7]">
+          <div className="flex justify-center items-center text-[0.825rem] font-semibold bg-[#f7f7f7] h-8 border-b border-l border-gray-300">
+            패널티
+          </div>
+          <div className="flex justify-center items-center bg-white h-full border-l text-red-600">
+            194
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/contests/[id]/ranklist/page.tsx
+++ b/app/contests/[id]/ranklist/page.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import Loading from '@/app/loading';
+import UserScoreInfoList from './components/UserScoreInfoList';
+import NoneUserScoreInfoList from './components/NoneUserScoreInfoList';
+
+interface DefaultProps {
+  params: {
+    id: string;
+  };
+}
+
+const MarkdownPreview = dynamic(
+  () => import('@uiw/react-markdown-preview').then((mod) => mod.default),
+  { ssr: false },
+);
+
+export default function ExamDetail(props: DefaultProps) {
+  const [isContestPostReady, setIsContestPostReady] = useState(false);
+  const [isMarkdownPreviewReady, setIsMarkdownPreviewReady] = useState(false);
+  const [isUserScoreInfoListReady, setIsUserScoreInfoListReady] =
+    useState(true);
+
+  const cid = props.params.id;
+
+  const router = useRouter();
+
+  const handleGoToContestInfo = () => {
+    router.push(`/contests/${cid}`);
+  };
+
+  useEffect(() => {
+    setIsContestPostReady(true);
+    setIsMarkdownPreviewReady(true);
+  }, []);
+
+  return isContestPostReady && isMarkdownPreviewReady ? (
+    <div className="mt-6 mb-24 px-5 2lg:px-0 overflow-x-auto">
+      <div className="flex flex-col w-[60rem] mx-auto">
+        <div className="flex flex-col">
+          <div className="flex flex-col gap-8">
+            <p className="text-2xl font-bold tracking-tight">
+              🏆{' '}
+              <span className="text-[#1048b8]">
+                2023년 제2회 충청북도 대학생 프로그래밍 경진대회 본선
+              </span>{' '}
+              순위
+            </p>
+            <div className="flex justify-between items-center pb-3 border-b border-gray-300">
+              <div className="flex gap-3">
+                <button
+                  onClick={() => alert('개발 예정')}
+                  className="flex gap-[0.375rem] items-center text-white bg-[#3870e0] px-2 py-[0.4rem] rounded-[0.2rem] font-light focus:bg-[#3464c2] hover:bg-[#3464c2] box-shadow"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    height="20"
+                    viewBox="0 -960 960 960"
+                    width="20"
+                    fill="white"
+                  >
+                    <path d="M320-240h320v-80H320v80Zm0-160h320v-80H320v80ZM240-80q-33 0-56.5-23.5T160-160v-640q0-33 23.5-56.5T240-880h320l240 240v480q0 33-23.5 56.5T720-80H240Zm280-520h200L520-800v200Z" />
+                  </svg>
+                  문제 목록
+                </button>
+                <button
+                  onClick={handleGoToContestInfo}
+                  className="flex gap-[0.375rem] items-center text-white bg-slate-500 px-2 py-[0.4rem] rounded-[0.2rem] font-light focus:bg-[#596478] hover:bg-[#596478] box-shadow"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    height="20"
+                    viewBox="0 -960 960 960"
+                    width="20"
+                    fill="white"
+                  >
+                    <path d="M280-280h280v-80H280v80Zm0-160h400v-80H280v80Zm0-160h400v-80H280v80Zm-80 480q-33 0-56.5-23.5T120-200v-560q0-33 23.5-56.5T200-840h560q33 0 56.5 23.5T840-760v560q0 33-23.5 56.5T760-120H200Zm0-80h560v-560H200v560Zm0-560v560-560Z" />
+                  </svg>
+                  대회 정보
+                </button>
+              </div>
+              <div className="mt-3">
+                <span className="font-semibold">
+                  <span className="text-red-500 font-semibold">
+                    41분 3초 후 종료
+                  </span>
+                </span>
+              </div>
+            </div>
+          </div>
+
+          {isUserScoreInfoListReady ? (
+            <>
+              <div className="flex mt-4 justify-between items-center">
+                <span>
+                  총: <span className="text-red-500">8명</span>
+                </span>
+              </div>
+
+              <div className="mt-4 mb-4 pb-5">
+                <UserScoreInfoList cid={cid} />
+              </div>
+            </>
+          ) : (
+            <NoneUserScoreInfoList />
+          )}
+        </div>
+      </div>
+    </div>
+  ) : (
+    <Loading />
+  );
+}


### PR DESCRIPTION
## 👀 이슈

resolve #97 

## 📌 개요

**대회 순위**를 확인할 수 있는 페이지를 추가하고자 하였습니다.

## 👩‍💻 작업 사항

- **대회 순위** 페이지 추가

## ✅ 참고 사항

- `대회 순위` 페이지 UI

https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/1e416db3-736c-4065-a1af-9fee43c23392
