### PR TITLE
[feat]: {대회/시험/연습문제/공지사항} 게시글 목록 리스트 아이템 hover/focus 시 밑줄 스타일 추가 (#103)

### DIFF
--- a/app/contests/components/ContestListItem.tsx
+++ b/app/contests/components/ContestListItem.tsx
@@ -19,7 +19,7 @@ export default function ContestListItem() {
       >
         1
       </th>
-      <td className="">
+      <td className="hover:underline focus:underline">
         2023년 제2회 충청북도 대학생 프로그래밍 경진대회 본선
       </td>
       <td className="font-medium">~ 2023.06.26. 03:00</td>

--- a/app/exams/components/ExamListItem.tsx
+++ b/app/exams/components/ExamListItem.tsx
@@ -19,7 +19,9 @@ export default function ExamListItem() {
       >
         1
       </th>
-      <td className="">2023-01-자료구조(소프트웨어학부 01반)</td>
+      <td className="hover:underline focus:underline">
+        2023-01-자료구조(소프트웨어학부 01반)
+      </td>
       <td className="font-medium">코딩테스트 3차</td>
       <td className="font-medium">노서영</td>
       <td className="font-medium">

--- a/app/notices/components/NoticeListItem.tsx
+++ b/app/notices/components/NoticeListItem.tsx
@@ -19,7 +19,9 @@ export default function NoticeListItem() {
       >
         1
       </th>
-      <td className="">시스템 이용 간 유의사항</td>
+      <td className="hover:underline focus:underline">
+        시스템 이용 간 유의사항
+      </td>
       <td className="font-medium">신재혁</td>
       <td className="font-medium">2023.06.26</td>
       <td className="font-medium">5</td>

--- a/app/practices/components/PracticeListItem.tsx
+++ b/app/practices/components/PracticeListItem.tsx
@@ -19,7 +19,7 @@ export default function PracticeListItem() {
       >
         1
       </th>
-      <td className="">기능개발</td>
+      <td className="hover:underline focus:underline">A+B</td>
       <td className="font-medium">신재혁</td>
       <td className="">3</td>
     </tr>


### PR DESCRIPTION
## 👀 이슈

resolve #103 

## 📌 개요

게시글 목록 리스트의 개별 아이템 제목란에 마우스 `hover` 또는 `focus`가
나타났을 때 어느 리스트 아이템이 지목되고 있는지를 분명히 나타낼 수 있도록
하고자 `underline` 스타일이 표시되도록 하였습니다.

## 👩‍💻 작업 사항

- `대회/시험/연습문제/공지사항` 게시글 목록 리스트의 개별 아이템 제목란에 `hover/focus` 시 제목에 대한 `underline` 스타일 표시

## ✅ 참고 사항

- 기능 추가 전

https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/874a3c1d-343b-47e6-a508-720dbeb0fb35

- 기능 추가 후

https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/4bde1cee-08a4-4f36-9432-a405456ac1ed