### PR TITLE
[feat]: 시험 문제 목록 관련 페이지 일괄 추가 (#107)

### DIFF
--- a/app/exams/[eid]/problems/[problemId]/edit/page.tsx
+++ b/app/exams/[eid]/problems/[problemId]/edit/page.tsx
@@ -1,0 +1,364 @@
+'use client';
+
+import MyDropzone from '@/app/components/MyDropzone';
+import { useRouter } from 'next/navigation';
+import { useRef, useState } from 'react';
+
+interface DefaultProps {
+  params: {
+    eid: string;
+    problemId: string;
+  };
+}
+
+export default function EditExamProblem(props: DefaultProps) {
+  const problemInfo = {
+    title: '2023-01-자료구조(소프트웨어학부 01반)',
+    maxExeTime: 1000,
+    maxMemCap: 5,
+    score: 1,
+    problemPdfFileUrl: 'http://localhost:3000/pdfs/test.pdf',
+    problemInAndOutFileUrls: [
+      'http://localhost:3000/in_and_out/1.in',
+      'http://localhost:3000/in_and_out/1.out',
+      'http://localhost:3000/in_and_out/2.in',
+      'http://localhost:3000/in_and_out/2.out',
+      'http://localhost:3000/in_and_out/3.in',
+      'http://localhost:3000/in_and_out/3.out',
+    ],
+  };
+
+  const [problemName, setProblemName] = useState(problemInfo.title);
+  const [maxExeTime, setMaxExeTime] = useState<number>(problemInfo.maxExeTime);
+  const [maxMemCap, setMaxMemCap] = useState<number>(problemInfo.maxMemCap);
+  const [score, setScore] = useState<number>(1);
+  const [uploadedProblemPdfFileUrl, setUploadedPdfFileUrl] = useState(
+    problemInfo.problemPdfFileUrl,
+  );
+  const [uploadedProblemInAndOutFileUrls, setUploadedProblemInAndOutFileUrls] =
+    useState<string[]>(problemInfo.problemInAndOutFileUrls);
+
+  const [isProblemNameValidFail, setIsProblemNameValidFail] = useState(false);
+  const [isMaxExeTimeValidFail, setIsMaxExeTimeValidFail] = useState(false);
+  const [isMaxMemCapValidFail, setIsMaxMemCapValidFail] = useState(false);
+  const [isScoreValidFail, setIsScoreCapValidFail] = useState(false);
+  const [isProblemFileUploadingValidFail, setIsProblemFileUploadingValidFail] =
+    useState(false);
+  const [
+    isInAndOutFileUploadingValidFail,
+    setIsInAndOutFileUploadingValidFail,
+  ] = useState(false);
+
+  const problemNameRef = useRef<HTMLInputElement>(null);
+  const maxExeTimeRef = useRef<HTMLInputElement>(null);
+  const maxMemCapRef = useRef<HTMLInputElement>(null);
+  const scoreRef = useRef<HTMLInputElement>(null);
+
+  const eid = props.params.eid;
+  const problemId = props.params.problemId;
+
+  const router = useRouter();
+
+  const handleProblemNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setProblemName(e.target.value);
+    setIsProblemNameValidFail(false);
+  };
+
+  const handleMaxExeTimeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setMaxExeTime(parseInt(e.target.value));
+    setIsMaxExeTimeValidFail(false);
+  };
+
+  const handleMaxMemCapChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setMaxMemCap(parseInt(e.target.value));
+    setIsMaxMemCapValidFail(false);
+  };
+
+  const handleScoreChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setScore(parseInt(e.target.value));
+    setIsScoreCapValidFail(false);
+  };
+
+  const handleCancelExamEdit = () => {
+    const userResponse = confirm('문제 수정을 취소하시겠습니까?');
+    if (!userResponse) return;
+
+    router.push(`/exams/${eid}/problems/${problemId}`);
+  };
+
+  const handleEditProblem = () => {
+    if (!problemName) {
+      alert('문제명을 입력해 주세요');
+      window.scrollTo(0, 0);
+      problemNameRef.current?.focus();
+      setIsProblemNameValidFail(true);
+      return;
+    }
+
+    if (!maxExeTime) {
+      alert('최대 실행 시간을 입력해 주세요');
+      window.scrollTo(0, 0);
+      maxExeTimeRef.current?.focus();
+      setIsMaxExeTimeValidFail(true);
+      return;
+    }
+
+    if (!maxMemCap) {
+      alert('최대 메모리 사용량을 입력해 주세요');
+      window.scrollTo(0, 0);
+      maxMemCapRef.current?.focus();
+      setIsMaxMemCapValidFail(true);
+      return;
+    }
+
+    if (!score) {
+      alert('문제 점수를 입력해 주세요');
+      window.scrollTo(0, 0);
+      scoreRef.current?.focus();
+      setIsScoreCapValidFail(true);
+      return;
+    }
+
+    if (!isProblemFileUploadingValidFail) {
+      alert('oblemPDF)을 업로드해 주세요');
+      window.scrollTo(0, 0);
+      return;
+    }
+
+    if (!isInAndOutFileUploadingValidFail) {
+      alert('입/출력 파일 셋(in/out)을 업로드해 주세요');
+      window.scrollTo(0, document.body.scrollHeight);
+      return;
+    }
+
+    alert('수정 기능 개발 예정');
+
+    // console.log('PDF: ', uploadedProblemPdfFileUrl);
+    // console.log('In/Out: ', uploadedProblemInAndOutFileUrls);
+  };
+
+  return (
+    <div className="mt-2 px-5 2lg:px-0 overflow-x-auto">
+      <div className="flex flex-col w-[60rem] mx-auto">
+        <p className="text-2xl font-semibold">시험 문제 등록</p>
+
+        <div className="flex flex-col gap-5">
+          <div className="flex flex-col gap-5 mt-5 mb-8">
+            <div className="flex flex-col relative z-0 w-1/2 group">
+              <input
+                type="text"
+                name="floating_first_name"
+                className={`block pt-3 pb-[0.175rem] pl-0 pr-0 w-full font-normal text-gray-900 bg-transparent border-0 border-b border-gray-400 appearance-none dark:text-white dark:border-gray-600 dark:focus:border-${
+                  isProblemNameValidFail ? 'pink' : 'blue'
+                }-500 focus:border-${
+                  isProblemNameValidFail ? 'red' : 'blue'
+                }-500 focus:outline-none focus:ring-0 peer`}
+                placeholder=" "
+                required
+                value={problemName}
+                ref={problemNameRef}
+                onChange={handleProblemNameChange}
+              />
+              <label
+                htmlFor="floating_first_name"
+                className={`peer-focus:font-light absolute text-base left-[0.1rem] font-light text-${
+                  isProblemNameValidFail ? 'red' : 'gray'
+                }-500 dark:text-gray-400 duration-300 transform -translate-y-5 scale-75 top-3 -z-10 origin-[0] peer-focus:left-[0.1rem] peer-focus:text-${
+                  isProblemNameValidFail ? 'red' : 'blue'
+                }-600 peer-focus:dark:text-${
+                  isProblemNameValidFail ? 'red' : 'blue'
+                }-500 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0 peer-focus:scale-75 peer-focus:-translate-y-[1.25rem]`}
+              >
+                문제명
+              </label>
+              <p
+                className={`text-${
+                  isProblemNameValidFail ? 'red' : 'gray'
+                }-500 text-xs tracking-widest font-light mt-1`}
+              >
+                문제명을 입력해 주세요
+              </p>
+            </div>
+
+            <div className="flex gap-5">
+              <div className="flex flex-col relative z-0 w-1/3 group">
+                <input
+                  type="number"
+                  name="floating_first_name"
+                  className={`block pt-3 pb-[0.175rem] pl-0 pr-0 w-full font-normal text-gray-900 bg-transparent border-0 border-b border-gray-400 appearance-none dark:text-white dark:border-gray-600 dark:focus:border-${
+                    isMaxExeTimeValidFail ? 'pink' : 'blue'
+                  }-500 focus:border-${
+                    isMaxExeTimeValidFail ? 'red' : 'blue'
+                  }-500 focus:outline-none focus:ring-0 peer`}
+                  placeholder=" "
+                  required
+                  value={maxExeTime}
+                  ref={maxExeTimeRef}
+                  onChange={handleMaxExeTimeChange}
+                />
+                <label
+                  htmlFor="floating_first_name"
+                  className={`peer-focus:font-light absolute text-base left-[0.1rem] font-light text-${
+                    isMaxExeTimeValidFail ? 'red' : 'gray'
+                  }-500 dark:text-gray-400 duration-300 transform -translate-y-5 scale-75 top-3 -z-10 origin-[0] peer-focus:left-[0.1rem] peer-focus:text-${
+                    isMaxExeTimeValidFail ? 'red' : 'blue'
+                  }-600 peer-focus:dark:text-${
+                    isMaxExeTimeValidFail ? 'red' : 'blue'
+                  }-500 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0 peer-focus:scale-75 peer-focus:-translate-y-[1.25rem]`}
+                >
+                  최대 실행 시간
+                </label>
+                <p
+                  className={`text-${
+                    isMaxExeTimeValidFail ? 'red' : 'gray'
+                  }-500 text-xs tracking-widest font-light mt-1`}
+                >
+                  테스트 당 최대 수행 시간을 ms 단위로 입력해 주세요
+                </p>
+              </div>
+
+              <div className="flex flex-col relative z-0 w-1/3 group">
+                <input
+                  type="number"
+                  name="floating_first_name"
+                  className={`block pt-3 pb-[0.175rem] pl-0 pr-0 w-full font-normal text-gray-900 bg-transparent border-0 border-b border-gray-400 appearance-none dark:text-white dark:border-gray-600 dark:focus:border-${
+                    isMaxMemCapValidFail ? 'pink' : 'blue'
+                  }-500 focus:border-${
+                    isMaxMemCapValidFail ? 'red' : 'blue'
+                  }-500 focus:outline-none focus:ring-0 peer`}
+                  placeholder=" "
+                  required
+                  value={maxMemCap}
+                  ref={maxMemCapRef}
+                  onChange={handleMaxMemCapChange}
+                />
+                <label
+                  htmlFor="floating_first_name"
+                  className={`peer-focus:font-light absolute text-base left-[0.1rem] font-light text-${
+                    isMaxMemCapValidFail ? 'red' : 'gray'
+                  }-500 dark:text-gray-400 duration-300 transform -translate-y-5 scale-75 top-3 -z-10 origin-[0] peer-focus:left-[0.1rem] peer-focus:text-${
+                    isMaxMemCapValidFail ? 'red' : 'blue'
+                  }-600 peer-focus:dark:text-${
+                    isMaxMemCapValidFail ? 'red' : 'blue'
+                  }-500 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0 peer-focus:scale-75 peer-focus:-translate-y-[1.25rem]`}
+                >
+                  최대 메모리 사용량
+                </label>
+                <p
+                  className={`text-${
+                    isMaxMemCapValidFail ? 'red' : 'gray'
+                  }-500 text-xs tracking-widest font-light mt-1`}
+                >
+                  테스트 당 최대 사용 메모리를 MB 단위로 입력해 주세요
+                </p>
+              </div>
+
+              <div className="flex flex-col relative z-0 w-1/3 group">
+                <input
+                  type="number"
+                  name="floating_first_name"
+                  className={`block pt-3 pb-[0.175rem] pl-0 pr-0 w-full font-normal text-gray-900 bg-transparent border-0 border-b border-gray-400 appearance-none dark:text-white dark:border-gray-600 dark:focus:border-${
+                    isScoreValidFail ? 'pink' : 'blue'
+                  }-500 focus:border-${
+                    isScoreValidFail ? 'red' : 'blue'
+                  }-500 focus:outline-none focus:ring-0 peer`}
+                  placeholder=" "
+                  required
+                  value={score}
+                  ref={scoreRef}
+                  onChange={handleScoreChange}
+                />
+                <label
+                  htmlFor="floating_first_name"
+                  className={`peer-focus:font-light absolute text-base left-[0.1rem] font-light text-${
+                    isScoreValidFail ? 'red' : 'gray'
+                  }-500 dark:text-gray-400 duration-300 transform -translate-y-5 scale-75 top-3 -z-10 origin-[0] peer-focus:left-[0.1rem] peer-focus:text-${
+                    isScoreValidFail ? 'red' : 'blue'
+                  }-600 peer-focus:dark:text-${
+                    isScoreValidFail ? 'red' : 'blue'
+                  }-500 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0 peer-focus:scale-75 peer-focus:-translate-y-[1.25rem]`}
+                >
+                  점수
+                </label>
+                <p
+                  className={`text-${
+                    isScoreValidFail ? 'red' : 'gray'
+                  }-500 text-xs tracking-widest font-light mt-1`}
+                >
+                  문제의 점수를 입력해 주세요
+                </p>
+              </div>
+            </div>
+          </div>
+          <div className="flex flex-col gap-1">
+            <p className="text-lg">문제 파일</p>
+            <MyDropzone
+              type="pdf"
+              guideMsg="문제 파일(PDF)을 이곳에 업로드해 주세요"
+              setIsFileUploaded={setIsProblemFileUploadingValidFail}
+              isFileUploaded={isProblemFileUploadingValidFail}
+              initPdfUrl={problemInfo.problemPdfFileUrl}
+              initInAndOutFileUrls={[]}
+              setUploadedPdfFileUrl={setUploadedPdfFileUrl}
+              setUploadedProblemInAndOutFileUrls={
+                setUploadedProblemInAndOutFileUrls
+              }
+            />
+          </div>
+
+          <div className="flex flex-col gap-1 mt-9">
+            <p className="text-lg">입/출력 파일 셋</p>
+            <div>
+              <div className="flex mt-2 mb-4 ml-5">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  height="15"
+                  viewBox="0 -960 960 960"
+                  width="15"
+                  fill="#5762b3"
+                  className="relative left-[-1.375rem] top-[0.1rem]"
+                >
+                  <path d="M440.667-269.333h83.999V-520h-83.999v250.667Zm39.204-337.333q17.796 0 29.962-11.833Q522-630.332 522-647.824q0-18.809-12.021-30.825-12.021-12.017-29.792-12.017-18.52 0-30.354 11.841Q438-666.984 438-648.508q0 17.908 12.038 29.875 12.038 11.967 29.833 11.967Zm.001 547.999q-87.157 0-163.841-33.353-76.684-33.354-133.671-90.34-56.986-56.987-90.34-133.808-33.353-76.821-33.353-164.165 0-87.359 33.412-164.193 33.413-76.834 90.624-134.057 57.211-57.224 133.757-89.987t163.578-32.763q87.394 0 164.429 32.763 77.034 32.763 134.117 90 57.082 57.237 89.916 134.292 32.833 77.056 32.833 164.49 0 87.433-32.763 163.67-32.763 76.236-89.987 133.308-57.223 57.073-134.261 90.608-77.037 33.535-164.45 33.535Zm.461-83.999q140.18 0 238.59-98.744 98.411-98.744 98.411-238.923 0-140.18-98.286-238.59Q620.763-817.334 480-817.334q-139.846 0-238.59 98.286Q142.666-620.763 142.666-480q0 139.846 98.744 238.59t238.923 98.744ZM480-480Z" />
+                </svg>
+                <p
+                  id="helper-checkbox-text"
+                  className="relative left-[-0.8rem] text-xs font-normal text-[#5762b3] dark:text-gray-300"
+                >
+                  입력/출력 파일의 확장자는 서로 다르며, 파일명이 같은 것끼리
+                  하나의 입/출력 세트로 묶입니다.
+                </p>
+              </div>
+              <MyDropzone
+                type="inOut"
+                guideMsg="입/출력 파일(in, out)들을 이곳에 업로드해 주세요"
+                setIsFileUploaded={setIsInAndOutFileUploadingValidFail}
+                isFileUploaded={isInAndOutFileUploadingValidFail}
+                initPdfUrl={''}
+                initInAndOutFileUrls={problemInfo.problemInAndOutFileUrls}
+                setUploadedPdfFileUrl={setUploadedPdfFileUrl}
+                setUploadedProblemInAndOutFileUrls={
+                  setUploadedProblemInAndOutFileUrls
+                }
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-14 pb-2 flex justify-end gap-3">
+          <button
+            onClick={handleCancelExamEdit}
+            className=" px-4 py-[0.4rem] rounded-[0.2rem] font-light"
+          >
+            취소
+          </button>
+          <button
+            onClick={handleEditProblem}
+            className=" text-white bg-[#3870e0] px-4 py-[0.4rem] rounded-[0.2rem] font-light focus:bg-[#3464c2] hover:bg-[#3464c2] box-shadow"
+          >
+            수정
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/exams/[eid]/problems/[problemId]/page.tsx
+++ b/app/exams/[eid]/problems/[problemId]/page.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import Loading from '@/app/loading';
+import dynamic from 'next/dynamic';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+interface DefaultProps {
+  params: {
+    eid: string;
+    problemId: string;
+  };
+}
+
+const PDFViewer = dynamic(() => import('@/app/components/PDFViewer'), {
+  ssr: false,
+});
+
+export default function ExamProblem(props: DefaultProps) {
+  const [isExamProblemReady, setIsExamProblemReady] = useState(false);
+  const [isMarkdownPreviewReady, setIsMarkdownPreviewReady] = useState(false);
+
+  const eid = props.params.eid;
+  const problemId = props.params.problemId;
+
+  const router = useRouter();
+
+  const handleGoToExamProblems = () => {
+    router.push(`/exams/${eid}/problems`);
+  };
+
+  const handleGoToUserContestSubmits = () => {
+    router.push(`/exams/${eid}/problems/${problemId}/submits`);
+  };
+
+  const handleGoToSubmitContestProblemCode = () => {
+    router.push(`/exams/${eid}/problems/${problemId}/submit`);
+  };
+
+  const handleEditProblem = () => {
+    router.push(`/exams/${eid}/problems/${problemId}/edit`);
+  };
+
+  const handleDeleteProblem = () => {
+    const userResponse = confirm('문제를 삭제하시겠습니까?');
+    if (!userResponse) return;
+    alert('문제를 삭제하였습니다.');
+    router.push(`/exams/${eid}/problems`);
+  };
+
+  useEffect(() => {
+    setIsMarkdownPreviewReady(true);
+    setIsExamProblemReady(true);
+  }, []);
+
+  return isExamProblemReady && isMarkdownPreviewReady ? (
+    <div className="mt-6 mb-24 px-5 2lg:px-0 overflow-x-auto">
+      <div className="flex flex-col w-[60rem] mx-auto">
+        <div className="flex flex-col gap-8">
+          <p className="text-2xl font-bold tracking-tight">A+B</p>
+          <div className="flex justify-between pb-3 border-b border-gray-300">
+            <div className="flex gap-3">
+              <span className="font-semibold">
+                시간 제한:
+                <span className="font-mono font-light">
+                  {' '}
+                  <span>1</span>초
+                </span>
+              </span>
+              <span className='relative bottom-[0.055rem] font-thin before:content-["|"]' />
+              <span className="font-semibold">
+                메모리 제한:
+                <span className="font-mono font-light">
+                  {' '}
+                  <span className="mr-1">5</span>MB
+                </span>
+              </span>
+            </div>
+            <div className="flex gap-3">
+              <span className="font-semibold">
+                시험:{' '}
+                <span className="font-light">
+                  2023-01-자료구조(소프트웨어학부 01반)
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex gap-3 justify-end mt-4">
+          <button
+            onClick={handleGoToExamProblems}
+            className="flex gap-[0.375rem] items-center text-white bg-green-500 px-2 py-[0.4rem] rounded-[0.2rem] font-light focus:bg-[#3e9368] hover:bg-[#3e9368] box-shadow"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              height="20"
+              viewBox="0 -960 960 960"
+              width="20"
+              fill="white"
+            >
+              <path d="M320-240h320v-80H320v80Zm0-160h320v-80H320v80ZM240-80q-33 0-56.5-23.5T160-160v-640q0-33 23.5-56.5T240-880h320l240 240v480q0 33-23.5 56.5T720-80H240Zm280-520h200L520-800v200Z" />
+            </svg>
+            문제 목록
+          </button>
+          <button
+            onClick={handleGoToUserContestSubmits}
+            className="flex gap-[0.375rem] items-center text-white bg-[#6860ff] px-2 py-[0.4rem] rounded-[0.2rem] font-light focus:bg-[#5951f0] hover:bg-[#5951f0] box-shadow"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              height="20"
+              viewBox="0 -960 960 960"
+              width="20"
+              fill="white"
+            >
+              <path d="M320-242 80-482l242-242 43 43-199 199 197 197-43 43Zm318 2-43-43 199-199-197-197 43-43 240 240-242 242Z" />
+            </svg>
+            내 제출 현황
+          </button>
+          <button
+            onClick={handleGoToSubmitContestProblemCode}
+            className="flex gap-[0.375rem] items-center text-white bg-[#3870e0] px-3 py-[0.4rem] rounded-[0.2rem] font-light focus:bg-[#3464c2] hover:bg-[#3464c2] box-shadow"
+          >
+            제출하기
+          </button>
+          <button
+            onClick={handleEditProblem}
+            className="flex gap-[0.375rem] items-center text-white bg-[#eba338] px-2 py-[0.4rem] rounded-[0.2rem] font-light focus:bg-[#dc9429] hover:bg-[#dc9429] box-shadow"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              height="20"
+              viewBox="0 -960 960 960"
+              width="20"
+              fill="white"
+            >
+              <path d="M794-666 666-794l42-42q17-17 42.5-16.5T793-835l43 43q17 17 17 42t-17 42l-42 42Zm-42 42L248-120H120v-128l504-504 128 128Z" />
+            </svg>
+            문제 수정
+          </button>
+          <button
+            onClick={handleDeleteProblem}
+            className="flex gap-[0.375rem] items-center text-white bg-red-500 px-2 py-[0.4rem] rounded-[0.2rem] font-light focus:bg-[#e14343] hover:bg-[#e14343] box-shadow"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              height="20"
+              viewBox="0 -960 960 960"
+              width="20"
+              fill="white"
+            >
+              <path d="m361-299 119-121 120 121 47-48-119-121 119-121-47-48-120 121-119-121-48 48 120 121-120 121 48 48ZM261-120q-24 0-42-18t-18-42v-570h-41v-60h188v-30h264v30h188v60h-41v570q0 24-18 42t-42 18H261Z" />
+            </svg>
+            문제 삭제
+          </button>
+        </div>
+
+        <div className="gap-5 border-b mt-8 mb-4 pb-5">
+          <PDFViewer pdfFileURL={'/pdfs/test.pdf'} />
+        </div>
+      </div>
+    </div>
+  ) : (
+    <Loading />
+  );
+}

--- a/app/exams/[eid]/problems/[problemId]/submit/page.tsx
+++ b/app/exams/[eid]/problems/[problemId]/submit/page.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import MyDropzone from '@/app/components/MyDropzone';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+interface DefaultProps {
+  params: {
+    eid: string;
+    problemId: string;
+  };
+}
+
+export default function SubmitExamProblemCode(props: DefaultProps) {
+  const [selectedSubmitLanguage, setSelectedSubmitLanguage] =
+    useState('언어 선택 *');
+  const [uploadedCodeFileUrl, setUploadedCodeFileUrl] = useState('');
+
+  const [
+    isSelectedSubmitLanguageValidFail,
+    setIsSelectedSubmitLanguageValidFail,
+  ] = useState(false);
+  const [isCodeFileUploadingValidFail, setIsCodeFileUploadingValidFail] =
+    useState(false);
+
+  const eid = props.params.eid;
+  const problemId = props.params.eid;
+
+  const router = useRouter();
+
+  const handleGoToExamProblem = () => {
+    router.push(`/exams/${eid}/problems/${problemId}`);
+  };
+
+  const handlSelectSubmitLanguage = (
+    e: React.ChangeEvent<HTMLSelectElement>,
+  ) => {
+    setSelectedSubmitLanguage(e.target.value);
+    setIsSelectedSubmitLanguageValidFail(false);
+  };
+
+  const handleSubmitExamProblemCode = () => {
+    if (selectedSubmitLanguage === '언어 선택 *') {
+      alert('제출 언어를 선택해 주세요');
+      window.scrollTo(0, 0);
+      setIsSelectedSubmitLanguageValidFail(true);
+      return;
+    }
+
+    if (!isCodeFileUploadingValidFail) {
+      alert('소스 코드 파일을 업로드해 주세요');
+      window.scrollTo(0, 0);
+      return;
+    }
+
+    router.push(`/exams/${eid}/problems/${problemId}/submits`);
+  };
+
+  return (
+    <div className="mt-6 mb-24 px-5 2lg:px-0 overflow-x-auto">
+      <div className="flex flex-col w-[60rem] mx-auto">
+        <div className="flex flex-col gap-8">
+          <p className="flex items-center text-2xl font-bold tracking-tight">
+            {' '}
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              height="40"
+              viewBox="0 -960 960 960"
+              width="40"
+              fill="#3478c6"
+            >
+              <path d="M560-240 320-480l240-240 56 56-184 184 184 184-56 56Z" />
+            </svg>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              height="40"
+              viewBox="0 -960 960 960"
+              width="40"
+              className="ml-[-0.75rem]"
+              fill="#3478c6"
+            >
+              <path d="M504-480 320-664l56-56 240 240-240 240-56-56 184-184Z" />
+            </svg>
+            코드 제출
+            <Link
+              href={`/exams/${eid}/problems/${problemId}`}
+              className="mt-1 ml-1 text-base font-medium cursor-pointer hover:underline hover:text-[#0038a8] focus:underline focus:text-[#0038a8] text-[#1048b8]"
+            >
+              (A+B)
+            </Link>
+          </p>
+          <div className="flex justify-between pb-3 border-b border-gray-300">
+            <div className="flex gap-3">
+              <span className="font-semibold">
+                시간 제한:
+                <span className="font-mono font-light">
+                  {' '}
+                  <span>1</span>초
+                </span>
+              </span>
+              <span className='relative bottom-[0.055rem] font-thin before:content-["|"]' />
+              <span className="font-semibold">
+                메모리 제한:
+                <span className="font-mono font-light">
+                  {' '}
+                  <span className="mr-1">5</span>MB
+                </span>
+              </span>
+            </div>
+            <div className="flex gap-3">
+              <span className="font-semibold">
+                시험:{' '}
+                <span className="font-light">
+                  2023-01-자료구조(소프트웨어학부 01반)
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-5 mt-8 pb-5">
+          <div className="w-1/2">
+            <select
+              name="languages"
+              id="lang"
+              className={`text-sm w-full pl-0 py-1 ${
+                selectedSubmitLanguage === '언어 선택 *' &&
+                isSelectedSubmitLanguageValidFail
+                  ? 'text-red-500'
+                  : 'text-gray-500'
+              }   bg-transparent border-0 border-b border-${
+                isSelectedSubmitLanguageValidFail ? 'red-500' : 'gray-400'
+              }  gray-400 appearance-none focus:outline-none focus:ring-0 focus:border-${
+                isSelectedSubmitLanguageValidFail ? 'red' : 'blue'
+              }-500 peer`}
+              value={selectedSubmitLanguage}
+              onChange={handlSelectSubmitLanguage}
+            >
+              <option disabled selected>
+                언어 선택 *
+              </option>
+              <option value="C">C</option>
+              <option value="C++">C++</option>
+              <option value="Java">Java</option>
+              <option value="JavaScript">JavaScript</option>
+              <option value="Python2">Python2</option>
+              <option value="Python3">Python3</option>
+              <option value="Kotlin">Kotlin</option>
+              <option value="Go">Go</option>
+            </select>
+            <p
+              className={`text-${
+                isSelectedSubmitLanguageValidFail ? 'red' : 'gray'
+              }-500 text-xs tracking-widest font-light mt-2`}
+            >
+              제출할 언어를 선택해 주세요
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-1 mt-5">
+            <p className="text-lg">소스 코드 파일</p>
+            <MyDropzone
+              type="code"
+              guideMsg="코드 파일을 이곳에 업로드해 주세요"
+              setIsFileUploaded={setIsCodeFileUploadingValidFail}
+              isFileUploaded={isCodeFileUploadingValidFail}
+              initPdfUrl={''}
+              initInAndOutFileUrls={[]}
+              setUploadedCodeFileUrl={setUploadedCodeFileUrl}
+            />
+          </div>
+        </div>
+
+        <div className="mt-5 pb-2 flex justify-end gap-3">
+          <button
+            onClick={handleGoToExamProblem}
+            className=" px-4 py-[0.4rem] rounded-[0.2rem] font-light"
+          >
+            취소
+          </button>
+          <button
+            onClick={handleSubmitExamProblemCode}
+            className=" text-white bg-[#3870e0] px-3 py-[0.4rem] rounded-[0.2rem] font-light focus:bg-[#3464c2] hover:bg-[#3464c2] box-shadow"
+          >
+            제출하기
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/exams/[eid]/problems/[problemId]/submits/[submitId]/page.tsx
+++ b/app/exams/[eid]/problems/[problemId]/submits/[submitId]/page.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import Loading from '@/app/loading';
+import dynamic from 'next/dynamic';
+import { useRouter } from 'next/navigation';
+import React, { useEffect, useState } from 'react';
+
+interface DefaultProps {
+  params: {
+    eid: string;
+    problemId: string;
+  };
+}
+
+const MarkdownPreview = dynamic(
+  () => import('@uiw/react-markdown-preview').then((mod) => mod.default),
+  { ssr: false },
+);
+
+export default function UserExamSubmit(props: DefaultProps) {
+  const [isMarkdownPreviewReady, setIsMarkdownPreviewReady] = useState(false);
+
+  const eid = props.params.eid;
+  const problemId = props.params.problemId;
+
+  const router = useRouter();
+
+  const handleGoToExamSubmits = () => {
+    router.push(`/exams/${eid}/problems/${problemId}/submits`);
+  };
+
+  useEffect(() => {
+    setIsMarkdownPreviewReady(true);
+  }, []);
+
+  return isMarkdownPreviewReady ? (
+    <div className="mt-6 mb-24 px-5 2lg:px-0 overflow-x-auto">
+      <div className="flex flex-col w-[60rem] mx-auto">
+        <div className="flex justify-end items-center pb-3">
+          <button
+            onClick={handleGoToExamSubmits}
+            className="flex gap-[0.375rem] items-center text-white bg-[#717171] px-2 py-[0.4rem] rounded-[0.2rem] font-light focus:bg-[#686868] hover:bg-[#686868] box-shadow"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              height="17.5"
+              viewBox="0 -960 960 960"
+              width="17.5"
+              fill="white"
+            >
+              <path d="m313-440 196 196q12 12 11.5 28T508-188q-12 11-28 11.5T452-188L188-452q-6-6-8.5-13t-2.5-15q0-8 2.5-15t8.5-13l264-264q11-11 27.5-11t28.5 11q12 12 12 28.5T508-715L313-520h447q17 0 28.5 11.5T800-480q0 17-11.5 28.5T760-440H313Z" />
+            </svg>
+            뒤로가기
+          </button>
+        </div>
+        <div className="border-y border-[#e4e4e4] border-t-2 border-t-gray-400">
+          <MarkdownPreview
+            className="markdown-preview"
+            source={`
+\`\`\`cpp
+#include <iostream>
+
+using namespace std;
+
+int main(int argc, const char* argv[]) {
+  ios_base::sync_with_stdio(false);
+  cin.tie(0);
+
+  int a, b;
+  cin >> a >> b;
+  cout << a + b;
+
+  return 0;
+}
+\`\`\`
+`}
+          />
+        </div>
+
+        <div className="relative mt-10 dark:bg-gray-800 overflow-hidden rounded-sm">
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm text-left text-gray-500 dark:text-gray-400">
+              <thead className="text-xs text-gray-700 uppercase dark:text-gray-400 text-center">
+                <tr>
+                  <th scope="col" className="px-4 py-2">
+                    시험명
+                  </th>
+                  <th scope="col" className="px-4 py-2">
+                    문제명
+                  </th>
+                  <th scope="col" className="px-4 py-2">
+                    결과
+                  </th>
+                  <th scope="col" className="px-4 py-2">
+                    메모리
+                  </th>
+                  <th scope="col" className="px-4 py-2">
+                    시간
+                  </th>
+                  <th scope="col" className="px-4 py-2">
+                    언어
+                  </th>
+                  <th scope="col" className="px-4 py-2">
+                    제출 시간
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr className="border-t dark:border-gray-700 text-xs text-center bg-[#f9f9f9]">
+                  <th
+                    scope="row"
+                    className="py-3 font-medium text-gray-900 whitespace-nowrap dark:text-white"
+                  >
+                    2023-01-자료구조(소프트웨어학부 01반)
+                  </th>
+                  <td className="">A+B</td>
+                  <td className="text-[#0076C0] font-semibold">정답</td>
+                  <td>
+                    <span>1527 </span>
+                    <span className="ml-[-1px] text-red-500">KB</span>
+                  </td>
+                  <td className="">
+                    <span>64 </span>{' '}
+                    <span className="ml-[-1px] text-red-500">ms</span>
+                  </td>
+                  <td className="">C++17</td>
+                  <td className="">2023.09.26 07:00:00</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div>
+          <div className="flex gap-3 justify-end"></div>
+        </div>
+      </div>
+    </div>
+  ) : (
+    <Loading />
+  );
+}

--- a/app/exams/[eid]/problems/[problemId]/submits/components/NoneUserExamSubmitListItem.tsx
+++ b/app/exams/[eid]/problems/[problemId]/submits/components/NoneUserExamSubmitListItem.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+export default function NoneUserExamSubmitListItem() {
+  return (
+    <tr className="border-b dark:border-gray-700 text-xs text-center">
+      <th
+        scope="row"
+        className="px-4 py-3 font-medium text-gray-900 whitespace-nowrap dark:text-white"
+      >
+        1
+      </th>
+      <td className="text-sm">조회된 제출 정보가 없습니다</td>
+      <td className="font-medium">-</td>
+      <td className="font-medium">-</td>
+      <td className="font-medium">-</td>
+      <td className="font-medium">-</td>
+      <td className="font-medium">-</td>
+    </tr>
+  );
+}

--- a/app/exams/[eid]/problems/[problemId]/submits/components/UserExamSubmitList.tsx
+++ b/app/exams/[eid]/problems/[problemId]/submits/components/UserExamSubmitList.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import UserExamSubmitListItem from './UserExamSubmitListItem';
+import NoneUserExamSubmitListItem from './NoneUserExamSubmitListItem';
+
+interface ExamSubmitListProps {
+  eid: string;
+  problemId: string;
+}
+
+export default function UserExamSubmitList({
+  eid,
+  problemId,
+}: ExamSubmitListProps) {
+  const [isSubmitListReady, setIsSumbitListReady] = useState(false);
+
+  const numberOfItems = 10;
+
+  useEffect(() => {
+    setIsSumbitListReady(true);
+  }, []);
+
+  return isSubmitListReady ? (
+    <tbody>
+      {Array.from({ length: numberOfItems }, (_, idx) => (
+        <UserExamSubmitListItem key={idx} eid={eid} problemId={problemId} />
+      ))}
+    </tbody>
+  ) : (
+    <NoneUserExamSubmitListItem />
+  );
+}

--- a/app/exams/[eid]/problems/[problemId]/submits/components/UserExamSubmitListItem.tsx
+++ b/app/exams/[eid]/problems/[problemId]/submits/components/UserExamSubmitListItem.tsx
@@ -1,0 +1,43 @@
+import { useRouter } from 'next/navigation';
+import React from 'react';
+
+interface ExamSubmitListItemProps {
+  eid: string;
+  problemId: string;
+}
+
+export default function UserExamSubmitListItem({
+  eid,
+  problemId,
+}: ExamSubmitListItemProps) {
+  const router = useRouter();
+
+  return (
+    <tr
+      className="border-b dark:border-gray-700 text-xs text-center cursor-pointer hover:bg-gray-50 focus:bg-gray-50"
+      onClick={(e) => {
+        router.push(
+          `/exams/${eid}/problems/${problemId}/submits/${'65445155c4fc3d9d4396ae0e'}`,
+        );
+      }}
+    >
+      <th
+        scope="row"
+        className="px-4 py-3 font-medium text-gray-900 whitespace-nowrap dark:text-white"
+      >
+        1
+      </th>
+      <td className="">A+B</td>
+      <td className="text-[#0076C0] font-semibold">정답</td>
+      <td>
+        <span>1527 </span>
+        <span className="ml-[-1px] text-red-500">KB</span>
+      </td>
+      <td className="">
+        <span>64 </span> <span className="ml-[-1px] text-red-500">ms</span>
+      </td>
+      <td className="">C++17</td>
+      <td className="">2023.09.26 07:00:00</td>
+    </tr>
+  );
+}

--- a/app/exams/[eid]/problems/[problemId]/submits/page.tsx
+++ b/app/exams/[eid]/problems/[problemId]/submits/page.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import Link from 'next/link';
+import UserExamSubmitList from './components/UserExamSubmitList';
+
+interface DefaultProps {
+  params: {
+    eid: string;
+    problemId: string;
+  };
+}
+
+export default function UserExamSubmits(props: DefaultProps) {
+  const eid = props.params.eid;
+  const problemId = props.params.problemId;
+
+  return (
+    <div className="mt-2 px-5 2lg:px-0 overflow-x-auto">
+      <div className="flex flex-col w-[60rem] mx-auto">
+        <div className="flex flex-col gap-8">
+          <p className="flex items-center text-2xl font-semibold tracking-tight">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              height="40"
+              viewBox="0 -960 960 960"
+              width="40"
+              fill="#3478c6"
+            >
+              <path d="M560-240 320-480l240-240 56 56-184 184 184 184-56 56Z" />
+            </svg>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              height="40"
+              viewBox="0 -960 960 960"
+              width="40"
+              className="ml-[-0.75rem]"
+              fill="#3478c6"
+            >
+              <path d="M504-480 320-664l56-56 240 240-240 240-56-56 184-184Z" />
+            </svg>
+            내 제출 현황
+            <Link
+              href={`/exams/${eid}/problems/${problemId}`}
+              className="mt-1 ml-1 text-base font-medium cursor-pointer hover:underline hover:text-[#0038a8] focus:underline focus:text-[#0038a8] text-[#1048b8]"
+            >
+              (A+B)
+            </Link>
+          </p>
+          <div className="flex justify-end pb-3 border-gray-300">
+            <div className="flex gap-3">
+              <span className="font-semibold">
+                시험:{' '}
+                <span className="font-light">
+                  2023-01-자료구조(소프트웨어학부 01반)
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <section className="dark:bg-gray-900">
+          <div className="mx-auto w-full">
+            <div className="border dark:bg-gray-800 relative overflow-hidden rounded-sm">
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm text-left text-gray-500 dark:text-gray-400">
+                  <thead className="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-gray-700 dark:text-gray-400 text-center">
+                    <tr>
+                      <th scope="col" className="px-4 py-2">
+                        번호
+                      </th>
+                      <th scope="col" className="px-4 py-2">
+                        문제명
+                      </th>
+                      <th scope="col" className="px-4 py-2">
+                        결과
+                      </th>
+                      <th scope="col" className="px-4 py-2">
+                        메모리
+                      </th>
+                      <th scope="col" className="px-4 py-2">
+                        시간
+                      </th>
+                      <th scope="col" className="px-4 py-2">
+                        언어
+                      </th>
+                      <th scope="col" className="px-4 py-2">
+                        제출 시간
+                      </th>
+                    </tr>
+                  </thead>
+                  <UserExamSubmitList eid={eid} problemId={problemId} />
+                </table>
+              </div>
+            </div>
+            <nav
+              className="flex flex-col md:flex-row text-xs justify-between items-start md:items-center space-y-3 md:space-y-0 pl-1 mt-3"
+              aria-label="Table navigation"
+            >
+              <span className="text-gray-500 dark:text-gray-400">
+                <span className="text-gray-500 dark:text-white"> 1 - 10</span>{' '}
+                of
+                <span className="text-gray-500 dark:text-white"> 1000</span>
+              </span>
+              <ul className="inline-flex items-stretch -space-x-px">
+                <li>
+                  <a
+                    href="#"
+                    className="flex items-center justify-center h-full py-1.5 px-[0.3rem] ml-0 text-gray-500 bg-white rounded-l-lg border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
+                  >
+                    <span className="sr-only">Previous</span>
+                    <svg
+                      className="w-5 h-5"
+                      aria-hidden="true"
+                      fill="currentColor"
+                      viewBox="0 0 20 20"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        fillRule="evenodd"
+                        d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
+                        clipRule="evenodd"
+                      />
+                    </svg>
+                  </a>
+                </li>
+                <li>
+                  <a
+                    href="#"
+                    className="flex items-center justify-center text-sm py-2 px-3 leading-tight text-gray-400 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
+                  >
+                    1
+                  </a>
+                </li>
+                <li>
+                  <a
+                    href="#"
+                    className="flex items-center justify-center text-sm py-2 px-3 leading-tight text-gray-400 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
+                  >
+                    2
+                  </a>
+                </li>
+                <li>
+                  <a
+                    href="#"
+                    aria-current="page"
+                    className="flex items-center justify-center text-sm z-10 py-2 px-3 leading-tight text-primary-600 bg-primary-50 border border-primary-300 hover:bg-primary-100 hover:text-primary-700 dark:border-gray-700 dark:bg-gray-700 dark:text-white"
+                  >
+                    3
+                  </a>
+                </li>
+                <li>
+                  <a
+                    href="#"
+                    className="flex items-center justify-center text-sm py-2 px-3 leading-tight text-gray-400 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
+                  >
+                    ...
+                  </a>
+                </li>
+                <li>
+                  <a
+                    href="#"
+                    className="flex items-center justify-center text-sm py-2 px-3 leading-tight text-gray-400 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
+                  >
+                    100
+                  </a>
+                </li>
+                <li>
+                  <a
+                    href="#"
+                    className="flex items-center justify-center h-full py-1.5 px-[0.3rem] leading-tight text-gray-500 bg-white rounded-r-lg border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
+                  >
+                    <span className="sr-only">Next</span>
+                    <svg
+                      className="w-5 h-5"
+                      aria-hidden="true"
+                      fill="currentColor"
+                      viewBox="0 0 20 20"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        fillRule="evenodd"
+                        d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                        clipRule="evenodd"
+                      />
+                    </svg>
+                  </a>
+                </li>
+              </ul>
+            </nav>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/app/exams/[eid]/problems/components/ExamProblemList.tsx
+++ b/app/exams/[eid]/problems/components/ExamProblemList.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import {
+  DragDropContext,
+  Draggable,
+  DropResult,
+  Droppable,
+} from 'react-beautiful-dnd';
+import { useRouter } from 'next/navigation';
+import NoneExamProblemListItem from './NoneExamProblemListItem';
+
+interface ExamProblemListProps {
+  eid: string;
+  isChagingExamProblemOrderActivate: boolean;
+}
+
+export default function ExamProblemList({
+  eid,
+  isChagingExamProblemOrderActivate,
+}: ExamProblemListProps) {
+  const [isProblemListReady, setIsProblemListReady] = useState(false);
+  const [winReady, setwinReady] = useState(false);
+
+  const [datas, setDatas] = useState([
+    { id: '650ae1a19c2734584192d58e', idx: 'A', problemTitle: 'A+B' },
+    { id: '650af3809c2734584192d5b2', idx: 'B', problemTitle: 'A-B' },
+    { id: '650af7209c2734584192d603', idx: 'C', problemTitle: '삼각형' },
+    { id: '650af7379c2734584192d612', idx: 'D', problemTitle: '피보나치 수' },
+    { id: '650ce0110b8de0052a8cb971', idx: 'E', problemTitle: '순열의 개수' },
+    { id: '650ce0110b8de0052a8cb925', idx: 'F', problemTitle: '가방 정리' },
+    { id: '650ce0110b8de0052a1cb976', idx: 'G', problemTitle: '카드 색칠' },
+  ]);
+
+  const router = useRouter();
+
+  const handleChange = (result: DropResult) => {
+    if (!result.destination) return;
+    console.log(result);
+    const items = [...datas];
+    const [reorderedItem] = items.splice(result.source.index, 1);
+    items.splice(result.destination.index, 0, reorderedItem);
+
+    setDatas(items);
+  };
+
+  const handleGoToExamProblem = (id: string) => {
+    router.push(`/exams/${eid}/problems/${id}`);
+  };
+
+  useEffect(() => {
+    setIsProblemListReady(true);
+    setwinReady(true);
+  }, []);
+
+  console.log(datas);
+
+  return isProblemListReady && winReady ? (
+    <div className="mb-14">
+      {/* 드래그 영역 */}
+      <DragDropContext onDragEnd={handleChange}>
+        {/* 드래그 놓을 수 있는 영역 */}
+        <Droppable droppableId="DropLand">
+          {/* 드래그 Div 생성 */}
+          {(provided, snapshot) => (
+            // CCS가 적용된 Div
+            <div
+              {...provided.droppableProps}
+              ref={provided.innerRef}
+              className="flex flex-col gap-4 pl-3"
+            >
+              {datas.map((data, idx) => (
+                <div key={data.id} className="flex items-center gap-3">
+                  <div className="w-full">
+                    <Draggable draggableId={data.id} index={idx}>
+                      {(provided, snapshot) => (
+                        <div
+                          ref={
+                            isChagingExamProblemOrderActivate
+                              ? provided.innerRef
+                              : null
+                          }
+                          {...provided.draggableProps}
+                          {...provided.dragHandleProps}
+                        >
+                          <div
+                            onClick={() => handleGoToExamProblem(data.id)}
+                            className="flex items-center gap-2 w-full border p-2 cursor-pointer hover:bg-gray-50 focus:bg-gray-50 rounded-sm shadow-sm"
+                          >
+                            {!isChagingExamProblemOrderActivate ? (
+                              <span className="text-base text-[#333]">
+                                {String.fromCharCode('A'.charCodeAt(0) + idx)}
+                                <span className="text-gray-500">{')'}</span>
+                              </span>
+                            ) : (
+                              <svg
+                                xmlns="http://www.w3.org/2000/svg"
+                                height="20"
+                                viewBox="0 -960 960 960"
+                                width="20"
+                                fill="#94989d"
+                              >
+                                <path d="M356-188.769q-22.308 0-36.769-15.462-14.462-15.461-14.462-35.769 0-22.308 14.462-36.769 14.461-14.462 36.769-14.462t36.769 14.462q14.462 14.461 14.462 36.769 0 20.308-14.462 35.769-14.461 15.462-36.769 15.462Zm248 0q-22.308 0-36.769-15.462-14.462-15.461-14.462-35.769 0-22.308 14.462-36.769 14.461-14.462 36.769-14.462t36.769 14.462q14.462 14.461 14.462 36.769 0 20.308-14.462 35.769-14.461 15.462-36.769 15.462Zm-248-240q-22.308 0-36.769-14.462-14.462-14.461-14.462-36.769t14.462-36.769q14.461-14.462 36.769-14.462t36.769 14.462q14.462 14.461 14.462 36.769t-14.462 36.769Q378.308-428.769 356-428.769Zm248 0q-22.308 0-36.769-14.462-14.462-14.461-14.462-36.769t14.462-36.769q14.461-14.462 36.769-14.462t36.769 14.462q14.462 14.461 14.462 36.769t-14.462 36.769Q626.308-428.769 604-428.769Zm-248-240q-22.308 0-36.769-14.462-14.462-14.461-14.462-36.769t14.462-36.769q14.461-14.462 36.769-14.462t36.769 14.462q14.462 14.461 14.462 36.769t-14.462 36.769Q378.308-668.769 356-668.769Zm248 0q-22.308 0-36.769-14.462-14.462-14.461-14.462-36.769t14.462-36.769q14.461-14.462 36.769-14.462t36.769 14.462q14.462 14.461 14.462 36.769t-14.462 36.769Q626.308-668.769 604-668.769Z" />
+                              </svg>
+                            )}
+                            <span className="ml-1 text-[#0076C0] hover:underline focus:underline">
+                              {data.problemTitle}
+                            </span>
+                          </div>
+                        </div>
+                      )}
+                    </Draggable>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </Droppable>
+      </DragDropContext>
+    </div>
+  ) : (
+    <NoneExamProblemListItem />
+  );
+}

--- a/app/exams/[eid]/problems/components/NoneExamProblemListItem.tsx
+++ b/app/exams/[eid]/problems/components/NoneExamProblemListItem.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export default function NoneExamProblemListItem() {
+  return (
+    <div className="flex items-center gap-2 w-full border p-2 rounded-sm shadow-sm">
+      <span className="ml-1 text-[#555] hover:underline focus:underline">
+        등록된 문제가 없습니다
+      </span>
+    </div>
+  );
+}

--- a/app/exams/[eid]/problems/page.tsx
+++ b/app/exams/[eid]/problems/page.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import Loading from '@/app/loading';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import React, { useEffect, useRef, useState } from 'react';
+import ExamProblemList from './components/ExamProblemList';
+
+interface DefaultProps {
+  params: {
+    eid: string;
+  };
+}
+
+export default function ExamProblems(props: DefaultProps) {
+  const [isExamProblemListReady, setIsExamProblemListReady] = useState(false);
+  const [
+    isChagingExamProblemOrderActivate,
+    setIsChangingExamProblemOrderActivate,
+  ] = useState(false);
+
+  const changingProblemOrderBtnRef = useRef<HTMLButtonElement>(null);
+
+  const eid = props.params.eid;
+
+  const [todos, setTodos] = useState([
+    { id: '650ae1a19c2734584192d58e', problemTitle: 'A+B' },
+    { id: '650af3809c2734584192d5b2', problemTitle: 'A-B' },
+    { id: '650af7209c2734584192d603', problemTitle: '삼각형' },
+    { id: '650af7379c2734584192d612', problemTitle: '피보나치 수' },
+    { id: '650ce0110b8de0052a8cb971', problemTitle: '순열의 개수' },
+    { id: '650ce0110b8de0052a8cb925', problemTitle: '가방 정리' },
+    { id: '650ce0110b8de0052a1cb976', problemTitle: '카드 색칠' },
+  ]);
+
+  const router = useRouter();
+
+  const handleChangeProblemOrder = () => {
+    changingProblemOrderBtnRef.current?.blur();
+    setIsChangingExamProblemOrderActivate((prev) => !prev);
+    if (isChagingExamProblemOrderActivate) {
+      alert('문제 순서를 변경하였습니다.');
+    }
+  };
+
+  const handleRegisterExamProblem = () => {
+    router.push(`/exams/${eid}/problems/register`);
+  };
+
+  useEffect(() => {
+    setIsExamProblemListReady(true);
+  }, []);
+
+  return isExamProblemListReady ? (
+    <div className="mt-6 mb-24 px-5 2lg:px-0 overflow-x-auto">
+      <div className="flex flex-col w-[60rem] mx-auto">
+        <div className="flex flex-col gap-8">
+          <p className="text-2xl font-bold tracking-tight">
+            <span className="mr-1">📃</span> 문제 목록
+            <Link
+              href={`/exams/${eid}`}
+              className="mt-1 ml-1 text-base font-medium cursor-pointer hover:underline hover:text-[#0038a8] focus:underline focus:text-[#0038a8] text-[#1048b8]"
+            >
+              (시험: 2023-01-자료구조(소프트웨어학부 01반))
+            </Link>
+          </p>
+          <div className="flex justify-between items-center pb-3 border-b border-gray-300">
+            <div className="flex gap-3">
+              {!isChagingExamProblemOrderActivate && (
+                <>
+                  <button
+                    onClick={handleRegisterExamProblem}
+                    className="flex gap-[0.375rem] items-center text-white bg-green-500 px-2 py-[0.4rem] rounded-[0.2rem] font-light focus:bg-[#3e9368] hover:bg-[#3e9368] box-shadow"
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      height="20"
+                      viewBox="0 -960 960 960"
+                      width="20"
+                      fill="white"
+                    >
+                      <path d="M320-240h320v-80H320v80Zm0-160h320v-80H320v80ZM240-80q-33 0-56.5-23.5T160-160v-640q0-33 23.5-56.5T240-880h320l240 240v480q0 33-23.5 56.5T720-80H240Zm280-520h200L520-800v200Z" />
+                    </svg>
+                    문제 등록
+                  </button>
+                </>
+              )}
+
+              <button
+                onClick={handleChangeProblemOrder}
+                ref={changingProblemOrderBtnRef}
+                className="flex gap-[0.375rem] items-center text-white bg-[#ff5fb1] px-2 py-[0.4rem] rounded-[0.2rem] font-light focus:bg-[#f555a8] hover:bg-[#f555a8] box-shadow"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  height="23"
+                  viewBox="0 -960 960 960"
+                  width="23"
+                  fill="white"
+                >
+                  <path d="M241.5-478.5q0 44.5 16.75 87T311-313l13 13v-61.5q0-15.5 11-26.5t26.5-11q15.5 0 26.5 11t11 26.5v157q0 15.5-11 26.5t-26.5 11h-157q-15.5 0-26.5-11t-11-26.5q0-15.5 11-26.5t26.5-11H277l-18-17q-49.5-46.5-71-103.75T166.5-478.5q0-91.5 47-167t126.5-115q13.5-7 27.5-.5t19 21.5q5 14.5-.25 28.25T367.5-690q-58 31.5-92 87.75t-34 123.75Zm477-3q0-44.5-16.75-87T649-647l-13-13v61.5q0 15.5-11 26.5t-26.5 11q-15.5 0-26.5-11t-11-26.5v-157q0-15.5 11-26.5t26.5-11h157q15.5 0 26.5 11t11 26.5q0 15.5-11 26.5t-26.5 11H683l18 17q48 48 70.25 104.5t22.25 115q0 91.5-47 166.5t-126 115q-13.5 7-27.75.75T573.5-220.5q-5-14.5.25-28.25T592.5-270q58-31.5 92-87.75t34-123.75Z" />
+                </svg>
+                {isChagingExamProblemOrderActivate ? (
+                  <>저장하기</>
+                ) : (
+                  <>순서 변경</>
+                )}
+              </button>
+            </div>
+            <div className="mt-3">
+              <span className="font-semibold">
+                시험 시간:{' '}
+                <span className="text-red-500 font-bold">41분 3초 후 종료</span>
+              </span>
+            </div>
+          </div>
+
+          <section className="dark:bg-gray-900">
+            <div className="mx-auto w-full">
+              <div className="dark:bg-gray-800 relative overflow-hidden rounded-sm">
+                <div className="overflow-x-auto">
+                  <ExamProblemList
+                    eid={eid}
+                    isChagingExamProblemOrderActivate={
+                      isChagingExamProblemOrderActivate
+                    }
+                  />
+                </div>
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  ) : (
+    <Loading />
+  );
+}

--- a/app/exams/[eid]/problems/register/page.tsx
+++ b/app/exams/[eid]/problems/register/page.tsx
@@ -1,0 +1,292 @@
+'use client';
+
+import MyDropzone from '@/app/components/MyDropzone';
+import { useRouter } from 'next/navigation';
+import { useRef, useState } from 'react';
+
+interface DefaultProps {
+  params: {
+    eid: string;
+  };
+}
+
+export default function RegisterExamProblem(props: DefaultProps) {
+  const [problemName, setProblemName] = useState('');
+  const [maxExeTime, setMaxExeTime] = useState<number>();
+  const [maxMemCap, setMaxMemCap] = useState<number>();
+  const [uploadedProblemPdfFileUrl, setUploadedPdfFileUrl] = useState('');
+  const [uploadedProblemInAndOutFileUrls, setUploadedProblemInAndOutFileUrls] =
+    useState<string[]>();
+
+  const [isProblemNameValidFail, setIsProblemNameValidFail] = useState(false);
+  const [isMaxExeTimeValidFail, setIsMaxExeTimeValidFail] = useState(false);
+  const [isMaxMemCapValidFail, setIsMaxMemCapValidFail] = useState(false);
+  const [isProblemFileUploadingValidFail, setIsProblemFileUploadingValidFail] =
+    useState(false);
+  const [
+    isInAndOutFileUploadingValidFail,
+    setIsInAndOutFileUploadingValidFail,
+  ] = useState(false);
+
+  const problemNameRef = useRef<HTMLInputElement>(null);
+  const maxExeTimeRef = useRef<HTMLInputElement>(null);
+  const maxMemCapRef = useRef<HTMLInputElement>(null);
+
+  const eid = props.params.eid;
+
+  const router = useRouter();
+
+  const handleProblemNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setProblemName(e.target.value);
+    setIsProblemNameValidFail(false);
+  };
+
+  const handleMaxExeTimeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setMaxExeTime(parseInt(e.target.value));
+    setIsMaxExeTimeValidFail(false);
+  };
+
+  const handleMaxMemCapChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setMaxMemCap(parseInt(e.target.value));
+    setIsMaxMemCapValidFail(false);
+  };
+
+  const handleCancelProblemRegister = () => {
+    const userResponse = confirm('문제 등록을 취소하시겠습니까?');
+    if (!userResponse) return;
+
+    router.push(`/exams/${eid}/problems`);
+  };
+
+  const handleRegisterProblem = () => {
+    if (!problemName) {
+      alert('문제명을 입력해 주세요');
+      window.scrollTo(0, 0);
+      problemNameRef.current?.focus();
+      setIsProblemNameValidFail(true);
+      return;
+    }
+
+    if (!maxExeTime) {
+      alert('최대 실행 시간을 입력해 주세요');
+      window.scrollTo(0, 0);
+      maxExeTimeRef.current?.focus();
+      setIsMaxExeTimeValidFail(true);
+      return;
+    }
+
+    if (!maxMemCap) {
+      alert('최대 메모리 사용량을 입력해 주세요');
+      window.scrollTo(0, 0);
+      maxMemCapRef.current?.focus();
+      setIsMaxMemCapValidFail(true);
+      return;
+    }
+
+    if (!isProblemFileUploadingValidFail) {
+      alert('문제 파일(PDF)을 업로드해 주세요');
+      window.scrollTo(0, 0);
+      return;
+    }
+
+    if (!isInAndOutFileUploadingValidFail) {
+      alert('입/출력 파일 셋(in/out)을 업로드해 주세요');
+      window.scrollTo(0, document.body.scrollHeight);
+      return;
+    }
+
+    alert('등록 기능 개발 예정');
+
+    // console.log('PDF: ', uploadedProblemPdfFileUrl);
+    // console.log('In/Out: ', uploadedProblemInAndOutFileUrls);
+  };
+
+  return (
+    <div className="mt-2 px-5 2lg:px-0 overflow-x-auto">
+      <div className="flex flex-col w-[60rem] mx-auto">
+        <p className="text-2xl font-semibold">시험 문제 등록</p>
+
+        <div className="flex flex-col gap-5">
+          <div className="flex flex-col gap-5 mt-5 mb-8">
+            <div className="flex flex-col relative z-0 w-1/2 group">
+              <input
+                type="text"
+                name="floating_first_name"
+                className={`block pt-3 pb-[0.175rem] pl-0 pr-0 w-full font-normal text-gray-900 bg-transparent border-0 border-b border-gray-400 appearance-none dark:text-white dark:border-gray-600 dark:focus:border-${
+                  isProblemNameValidFail ? 'pink' : 'blue'
+                }-500 focus:border-${
+                  isProblemNameValidFail ? 'red' : 'blue'
+                }-500 focus:outline-none focus:ring-0 peer`}
+                placeholder=" "
+                required
+                value={problemName}
+                ref={problemNameRef}
+                onChange={handleProblemNameChange}
+              />
+              <label
+                htmlFor="floating_first_name"
+                className={`peer-focus:font-light absolute text-base left-[0.1rem] font-light text-${
+                  isProblemNameValidFail ? 'red' : 'gray'
+                }-500 dark:text-gray-400 duration-300 transform -translate-y-5 scale-75 top-3 -z-10 origin-[0] peer-focus:left-[0.1rem] peer-focus:text-${
+                  isProblemNameValidFail ? 'red' : 'blue'
+                }-600 peer-focus:dark:text-${
+                  isProblemNameValidFail ? 'red' : 'blue'
+                }-500 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0 peer-focus:scale-75 peer-focus:-translate-y-[1.25rem]`}
+              >
+                문제명
+              </label>
+              <p
+                className={`text-${
+                  isProblemNameValidFail ? 'red' : 'gray'
+                }-500 text-xs tracking-widest font-light mt-1`}
+              >
+                문제명을 입력해 주세요
+              </p>
+            </div>
+
+            <div className="flex gap-5">
+              <div className="flex flex-col relative z-0 w-1/3 group">
+                <input
+                  type="number"
+                  name="floating_first_name"
+                  className={`block pt-3 pb-[0.175rem] pl-0 pr-0 w-full font-normal text-gray-900 bg-transparent border-0 border-b border-gray-400 appearance-none dark:text-white dark:border-gray-600 dark:focus:border-${
+                    isMaxExeTimeValidFail ? 'pink' : 'blue'
+                  }-500 focus:border-${
+                    isMaxExeTimeValidFail ? 'red' : 'blue'
+                  }-500 focus:outline-none focus:ring-0 peer`}
+                  placeholder=" "
+                  required
+                  value={maxExeTime}
+                  ref={maxExeTimeRef}
+                  onChange={handleMaxExeTimeChange}
+                />
+                <label
+                  htmlFor="floating_first_name"
+                  className={`peer-focus:font-light absolute text-base left-[0.1rem] font-light text-${
+                    isMaxExeTimeValidFail ? 'red' : 'gray'
+                  }-500 dark:text-gray-400 duration-300 transform -translate-y-5 scale-75 top-3 -z-10 origin-[0] peer-focus:left-[0.1rem] peer-focus:text-${
+                    isMaxExeTimeValidFail ? 'red' : 'blue'
+                  }-600 peer-focus:dark:text-${
+                    isMaxExeTimeValidFail ? 'red' : 'blue'
+                  }-500 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0 peer-focus:scale-75 peer-focus:-translate-y-[1.25rem]`}
+                >
+                  최대 실행 시간
+                </label>
+                <p
+                  className={`text-${
+                    isMaxExeTimeValidFail ? 'red' : 'gray'
+                  }-500 text-xs tracking-widest font-light mt-1`}
+                >
+                  테스트 당 최대 수행 시간을 ms 단위로 입력해 주세요
+                </p>
+              </div>
+
+              <div className="flex flex-col relative z-0 w-1/3 group">
+                <input
+                  type="number"
+                  name="floating_first_name"
+                  className={`block pt-3 pb-[0.175rem] pl-0 pr-0 w-full font-normal text-gray-900 bg-transparent border-0 border-b border-gray-400 appearance-none dark:text-white dark:border-gray-600 dark:focus:border-${
+                    isMaxMemCapValidFail ? 'pink' : 'blue'
+                  }-500 focus:border-${
+                    isMaxMemCapValidFail ? 'red' : 'blue'
+                  }-500 focus:outline-none focus:ring-0 peer`}
+                  placeholder=" "
+                  required
+                  value={maxMemCap}
+                  ref={maxMemCapRef}
+                  onChange={handleMaxMemCapChange}
+                />
+                <label
+                  htmlFor="floating_first_name"
+                  className={`peer-focus:font-light absolute text-base left-[0.1rem] font-light text-${
+                    isMaxMemCapValidFail ? 'red' : 'gray'
+                  }-500 dark:text-gray-400 duration-300 transform -translate-y-5 scale-75 top-3 -z-10 origin-[0] peer-focus:left-[0.1rem] peer-focus:text-${
+                    isMaxMemCapValidFail ? 'red' : 'blue'
+                  }-600 peer-focus:dark:text-${
+                    isMaxMemCapValidFail ? 'red' : 'blue'
+                  }-500 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0 peer-focus:scale-75 peer-focus:-translate-y-[1.25rem]`}
+                >
+                  최대 메모리 사용량
+                </label>
+                <p
+                  className={`text-${
+                    isMaxMemCapValidFail ? 'red' : 'gray'
+                  }-500 text-xs tracking-widest font-light mt-1`}
+                >
+                  테스트 당 최대 사용 메모리를 MB 단위로 입력해 주세요
+                </p>
+              </div>
+            </div>
+          </div>
+          <div className="flex flex-col gap-1">
+            <p className="text-lg">문제 파일</p>
+            <MyDropzone
+              type="pdf"
+              guideMsg="문제 파일(PDF)을 이곳에 업로드해 주세요"
+              setIsFileUploaded={setIsProblemFileUploadingValidFail}
+              isFileUploaded={isProblemFileUploadingValidFail}
+              initPdfUrl={''}
+              initInAndOutFileUrls={[]}
+              setUploadedPdfFileUrl={setUploadedPdfFileUrl}
+              setUploadedProblemInAndOutFileUrls={
+                setUploadedProblemInAndOutFileUrls
+              }
+            />
+          </div>
+
+          <div className="flex flex-col gap-1 mt-9">
+            <p className="text-lg">입/출력 파일 셋</p>
+            <div>
+              <div className="flex mt-2 mb-4 ml-5">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  height="15"
+                  viewBox="0 -960 960 960"
+                  width="15"
+                  fill="#5762b3"
+                  className="relative left-[-1.375rem] top-[0.1rem]"
+                >
+                  <path d="M440.667-269.333h83.999V-520h-83.999v250.667Zm39.204-337.333q17.796 0 29.962-11.833Q522-630.332 522-647.824q0-18.809-12.021-30.825-12.021-12.017-29.792-12.017-18.52 0-30.354 11.841Q438-666.984 438-648.508q0 17.908 12.038 29.875 12.038 11.967 29.833 11.967Zm.001 547.999q-87.157 0-163.841-33.353-76.684-33.354-133.671-90.34-56.986-56.987-90.34-133.808-33.353-76.821-33.353-164.165 0-87.359 33.412-164.193 33.413-76.834 90.624-134.057 57.211-57.224 133.757-89.987t163.578-32.763q87.394 0 164.429 32.763 77.034 32.763 134.117 90 57.082 57.237 89.916 134.292 32.833 77.056 32.833 164.49 0 87.433-32.763 163.67-32.763 76.236-89.987 133.308-57.223 57.073-134.261 90.608-77.037 33.535-164.45 33.535Zm.461-83.999q140.18 0 238.59-98.744 98.411-98.744 98.411-238.923 0-140.18-98.286-238.59Q620.763-817.334 480-817.334q-139.846 0-238.59 98.286Q142.666-620.763 142.666-480q0 139.846 98.744 238.59t238.923 98.744ZM480-480Z" />
+                </svg>
+                <p
+                  id="helper-checkbox-text"
+                  className="relative left-[-0.8rem] text-xs font-normal text-[#5762b3] dark:text-gray-300"
+                >
+                  입력/출력 파일의 확장자는 서로 다르며, 파일명이 같은 것끼리
+                  하나의 입/출력 세트로 묶입니다.
+                </p>
+              </div>
+              <MyDropzone
+                type="inOut"
+                guideMsg="입/출력 파일(in, out)들을 이곳에 업로드해 주세요"
+                setIsFileUploaded={setIsInAndOutFileUploadingValidFail}
+                isFileUploaded={isInAndOutFileUploadingValidFail}
+                initPdfUrl={''}
+                initInAndOutFileUrls={[]}
+                setUploadedPdfFileUrl={setUploadedPdfFileUrl}
+                setUploadedProblemInAndOutFileUrls={
+                  setUploadedProblemInAndOutFileUrls
+                }
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-14 pb-2 flex justify-end gap-3">
+          <button
+            onClick={handleCancelProblemRegister}
+            className=" px-4 py-[0.4rem] rounded-[0.2rem] font-light"
+          >
+            취소
+          </button>
+          <button
+            onClick={handleRegisterProblem}
+            className=" text-white bg-[#3870e0] px-4 py-[0.4rem] rounded-[0.2rem] font-light focus:bg-[#3464c2] hover:bg-[#3464c2] box-shadow"
+          >
+            등록
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 👀 이슈

resolve #107 

## 📌 개요

**시험** 게시글 페이지 내에서 `문제 목록` 버튼 클릭 시 대회에 대한
문제를 등록/조회할 수 있는 페이지들을 일괄적으로 추가하였습니다.

## 👩‍💻 작업 사항

- **시험**에 대한 `문제 목록` 관련 페이지 추가

## ✅ 참고 사항

- 추가된 `시험 문제 목록` 관련 페이지 UI

https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/7a5a647b-e4b1-4b49-adf9-103fc246e925