### PR TITLE
[feat]: {메뉴 페이지} 소제목 UI 높이 일괄 설정 (#123)

### DIFF
--- a/app/contests/page.tsx
+++ b/app/contests/page.tsx
@@ -5,7 +5,7 @@ export default function Contests() {
   return (
     <div className="mt-2 px-5 2lg:px-0 overflow-x-auto">
       <div className="flex flex-col w-[60rem] mx-auto">
-        <p className="flex items-center text-3xl font-semibold tracking-wide">
+        <p className="h-16 flex items-center text-3xl font-semibold tracking-wide">
           <img
             src="/images/trophy.png"
             alt="trophy"

--- a/app/exams/page.tsx
+++ b/app/exams/page.tsx
@@ -6,7 +6,7 @@ export default function Exams() {
   return (
     <div className="mt-2 px-5 2lg:px-0 overflow-x-auto">
       <div className="flex flex-col w-[60rem] mx-auto">
-        <p className="flex items-center text-3xl font-semibold tracking-wide">
+        <p className="h-16 flex items-center text-3xl font-semibold tracking-wide">
           <img
             src="/images/exam.png"
             alt="exam"

--- a/app/notices/page.tsx
+++ b/app/notices/page.tsx
@@ -6,7 +6,7 @@ export default function Notices() {
   return (
     <div className="mt-2 px-5 2lg:px-0 overflow-x-auto">
       <div className="flex flex-col w-[60rem] mx-auto">
-        <p className="flex items-center text-3xl font-semibold tracking-wide">
+        <p className="h-16 flex items-center text-3xl font-semibold tracking-wide">
           <img
             src="/images/notice.png"
             alt="exam"

--- a/app/practices/page.tsx
+++ b/app/practices/page.tsx
@@ -6,11 +6,11 @@ export default function Practices() {
   return (
     <div className="mt-2 px-5 2lg:px-0 overflow-x-auto">
       <div className="flex flex-col w-[60rem] mx-auto">
-        <p className="flex items-center text-3xl font-semibold tracking-wide">
+        <p className="h-16 flex items-center text-3xl font-semibold tracking-wide">
           <img
             src="/images/practice.png"
             alt="exam"
-            style={{ width: '5rem' }}
+            style={{ width: '4.5rem' }}
             className="ml-[-1rem] drop-shadow-md scale-90 fade-in-fast"
           />
           <span className="ml-3 lift-up">연습문제 목록</span>


### PR DESCRIPTION
## 👀 이슈

resolve #125 

## 📌 개요

(#123) 작업을 통해 변경한 UI가 페이지 새로고침 시에 UI 영역의 높이가 설정되어 있지 않아서
페이지 내 다른 요소의 높이가 모두 변동되는 문제가 있어 소제목 UI 영역의 높이를 별도로 설정
하였습니다.

## 👩‍💻 작업 사항

- **메뉴 페이지(대회/시험/연습문제/공지사항)** 소제목 UI 높이 설정

## ✅ 참고 사항

없습니다
