### PR TITLE
[feat]: 연습문제 코드 제출 목록 관련 페이지 일괄 추가 (#134)

### DIFF
--- a/app/contests/[cid]/problems/[problemId]/submit/page.tsx
+++ b/app/contests/[cid]/problems/[problemId]/submit/page.tsx
@@ -1,9 +1,11 @@
 'use client';
 
 import MyDropzone from '@/app/components/MyDropzone';
+import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
+import codeImg from '@/public/images/code.png';
 
 interface DefaultProps {
   params: {
@@ -58,37 +60,30 @@ export default function SubmitContestProblemCode(props: DefaultProps) {
   };
 
   return (
-    <div className="mt-6 mb-24 px-5 2lg:px-0 overflow-x-auto">
+    <div className="mt-2 mb-24 px-5 2lg:px-0 overflow-x-auto">
       <div className="flex flex-col w-[60rem] mx-auto">
         <div className="flex flex-col gap-8">
           <p className="flex items-center text-2xl font-bold tracking-tight">
-            {' '}
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              height="40"
-              viewBox="0 -960 960 960"
-              width="40"
-              fill="#3478c6"
-            >
-              <path d="M560-240 320-480l240-240 56 56-184 184 184 184-56 56Z" />
-            </svg>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              height="40"
-              viewBox="0 -960 960 960"
-              width="40"
-              className="ml-[-0.75rem]"
-              fill="#3478c6"
-            >
-              <path d="M504-480 320-664l56-56 240 240-240 240-56-56 184-184Z" />
-            </svg>
-            코드 제출
-            <Link
-              href={`/contests/${cid}/problems/${problemId}`}
-              className="mt-1 ml-1 text-base font-medium cursor-pointer hover:underline hover:text-[#0038a8] focus:underline focus:text-[#0038a8] text-[#1048b8]"
-            >
-              (A+B)
-            </Link>
+            <Image
+              src={codeImg}
+              alt="trophy"
+              width={70}
+              height={0}
+              quality={100}
+              className="ml-[-1rem] drop-shadow-lg fade-in-fast"
+            />
+
+            <div className="lift-up">
+              <span className="ml-4 text-3xl font-semibold tracking-wide">
+                코드 제출
+              </span>
+              <Link
+                href={`/contests/${cid}/problems/${problemId}`}
+                className="mt-1 ml-1 text-xl font-medium cursor-pointer hover:underline hover:text-[#0038a8] focus:underline focus:text-[#0038a8] text-[#1048b8]"
+              >
+                (A+B)
+              </Link>
+            </div>
           </p>
           <div className="flex justify-between pb-3 border-b border-gray-300">
             <div className="flex gap-3">

--- a/app/contests/[cid]/problems/[problemId]/submits/page.tsx
+++ b/app/contests/[cid]/problems/[problemId]/submits/page.tsx
@@ -33,7 +33,7 @@ export default function UserContestSubmits(props: DefaultProps) {
           <p className="flex items-center text-2xl font-semibold tracking-tight">
             <Image
               src={codeImg}
-              alt="trophy"
+              alt="code"
               width={70}
               height={0}
               quality={100}
@@ -45,7 +45,7 @@ export default function UserContestSubmits(props: DefaultProps) {
               </span>
               <Link
                 href={`/contests/${cid}/problems/${problemId}`}
-                className="mt-1 ml-1 text-base font-medium cursor-pointer hover:underline hover:text-[#0038a8] focus:underline focus:text-[#0038a8] text-[#1048b8]"
+                className="mt-1 ml-1 text-xl font-medium cursor-pointer hover:underline hover:text-[#0038a8] focus:underline focus:text-[#0038a8] text-[#1048b8]"
               >
                 (A+B)
               </Link>

--- a/app/contests/[cid]/problems/[problemId]/submits/page.tsx
+++ b/app/contests/[cid]/problems/[problemId]/submits/page.tsx
@@ -40,7 +40,7 @@ export default function UserContestSubmits(props: DefaultProps) {
               className="ml-[-1rem] drop-shadow-lg fade-in-fast"
             />
             <div className="lift-up">
-              <span className="ml-4 lift-up text-3xl font-semibold tracking-wide">
+              <span className="ml-4 text-3xl font-semibold tracking-wide">
                 내 제출 현황
               </span>
               <Link

--- a/app/contests/[cid]/problems/page.tsx
+++ b/app/contests/[cid]/problems/page.tsx
@@ -58,19 +58,19 @@ export default function ContestProblems(props: DefaultProps) {
           <p className="flex items-center text-2xl font-bold tracking-tight">
             <Image
               src={listImg}
-              alt="trophy"
+              alt="list"
               width={70}
               height={0}
               quality={100}
               className="ml-[-1rem] drop-shadow-lg fade-in-fast"
             />
             <div className="lift-up">
-              <span className="ml-2 lift-up text-3xl font-semibold tracking-wide">
+              <span className="ml-2 text-3xl font-semibold tracking-wide">
                 문제 목록
               </span>
               <Link
                 href={`/contests/${cid}`}
-                className="mt-1 ml-1 text-base font-medium cursor-pointer hover:underline hover:text-[#0038a8] focus:underline focus:text-[#0038a8] text-[#1048b8]"
+                className="mt-1 ml-1 text-xl font-medium cursor-pointer hover:underline hover:text-[#0038a8] focus:underline focus:text-[#0038a8] text-[#1048b8]"
               >
                 (대회: 2023년 제2회 충청북도 대학생 프로그래밍 경진대회 본선)
               </Link>

--- a/app/contests/[cid]/ranklist/page.tsx
+++ b/app/contests/[cid]/ranklist/page.tsx
@@ -54,7 +54,7 @@ export default function ContestRankList(props: DefaultProps) {
               </span>
               <Link
                 href={`/contests/${cid}`}
-                className="mt-1 ml-1 text-base font-medium cursor-pointer hover:underline hover:text-[#0038a8] focus:underline focus:text-[#0038a8] text-[#1048b8]"
+                className="mt-1 ml-1 text-xl font-medium cursor-pointer hover:underline hover:text-[#0038a8] focus:underline focus:text-[#0038a8] text-[#1048b8]"
               >
                 (2023년 제2회 충청북도 대학생 프로그래밍 경진대회 본선)
               </Link>

--- a/app/contests/[cid]/submits/page.tsx
+++ b/app/contests/[cid]/submits/page.tsx
@@ -38,7 +38,7 @@ export default function UsersContestSubmits(props: DefaultProps) {
           />
 
           <div className="lift-up">
-            <span className="ml-4 lift-up text-3xl font-semibold tracking-wide">
+            <span className="ml-4 text-3xl font-semibold tracking-wide">
               문제 목록
             </span>
             <Link

--- a/app/contests/[cid]/submits/page.tsx
+++ b/app/contests/[cid]/submits/page.tsx
@@ -43,7 +43,7 @@ export default function UsersContestSubmits(props: DefaultProps) {
             </span>
             <Link
               href={`/contests/${cid}`}
-              className="mt-1 ml-1 text-base font-medium cursor-pointer hover:underline hover:text-[#0038a8] focus:underline focus:text-[#0038a8] text-[#1048b8]"
+              className="mt-1 ml-1 text-xl font-medium cursor-pointer hover:underline hover:text-[#0038a8] focus:underline focus:text-[#0038a8] text-[#1048b8]"
             >
               (대회: 2023년 제2회 충청북도 대학생 프로그래밍 경진대회 본선)
             </Link>

--- a/app/exams/[eid]/problems/[problemId]/submit/page.tsx
+++ b/app/exams/[eid]/problems/[problemId]/submit/page.tsx
@@ -1,9 +1,11 @@
 'use client';
 
 import MyDropzone from '@/app/components/MyDropzone';
+import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
+import codeImg from '@/public/images/code.png';
 
 interface DefaultProps {
   params: {
@@ -62,33 +64,25 @@ export default function SubmitExamProblemCode(props: DefaultProps) {
       <div className="flex flex-col w-[60rem] mx-auto">
         <div className="flex flex-col gap-8">
           <p className="flex items-center text-2xl font-bold tracking-tight">
-            {' '}
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              height="40"
-              viewBox="0 -960 960 960"
-              width="40"
-              fill="#3478c6"
-            >
-              <path d="M560-240 320-480l240-240 56 56-184 184 184 184-56 56Z" />
-            </svg>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              height="40"
-              viewBox="0 -960 960 960"
-              width="40"
-              className="ml-[-0.75rem]"
-              fill="#3478c6"
-            >
-              <path d="M504-480 320-664l56-56 240 240-240 240-56-56 184-184Z" />
-            </svg>
-            코드 제출
-            <Link
-              href={`/exams/${eid}/problems/${problemId}`}
-              className="mt-1 ml-1 text-base font-medium cursor-pointer hover:underline hover:text-[#0038a8] focus:underline focus:text-[#0038a8] text-[#1048b8]"
-            >
-              (A+B)
-            </Link>
+            <Image
+              src={codeImg}
+              alt="trophy"
+              width={70}
+              height={0}
+              quality={100}
+              className="ml-[-1rem] drop-shadow-lg fade-in-fast"
+            />
+            <div className="lift-up">
+              <span className="ml-4 text-3xl font-semibold tracking-wide">
+                코드 제출
+              </span>
+              <Link
+                href={`/exams/${eid}/problems/${problemId}`}
+                className="mt-1 ml-1 text-xl font-medium cursor-pointer hover:underline hover:text-[#0038a8] focus:underline focus:text-[#0038a8] text-[#1048b8]"
+              >
+                (A+B)
+              </Link>
+            </div>
           </p>
           <div className="flex justify-between pb-3 border-b border-gray-300">
             <div className="flex gap-3">

--- a/app/exams/[eid]/problems/[problemId]/submits/page.tsx
+++ b/app/exams/[eid]/problems/[problemId]/submits/page.tsx
@@ -40,7 +40,7 @@ export default function UserExamSubmits(props: DefaultProps) {
               className="ml-[-1rem] drop-shadow-lg fade-in-fast"
             />
             <div className="lift-up">
-              <span className="ml-4 lift-up text-3xl font-semibold tracking-wide">
+              <span className="ml-4 text-3xl font-semibold tracking-wide">
                 내 제출 현황
               </span>
               <Link

--- a/app/exams/[eid]/problems/[problemId]/submits/page.tsx
+++ b/app/exams/[eid]/problems/[problemId]/submits/page.tsx
@@ -33,7 +33,7 @@ export default function UserExamSubmits(props: DefaultProps) {
           <p className="flex items-center text-2xl font-semibold tracking-tight">
             <Image
               src={codeImg}
-              alt="trophy"
+              alt="code"
               width={70}
               height={0}
               quality={100}
@@ -45,7 +45,7 @@ export default function UserExamSubmits(props: DefaultProps) {
               </span>
               <Link
                 href={`/exams/${eid}/problems/${problemId}`}
-                className="mt-1 ml-1 text-base font-medium cursor-pointer hover:underline hover:text-[#0038a8] focus:underline focus:text-[#0038a8] text-[#1048b8]"
+                className="mt-1 ml-1 text-xl font-medium cursor-pointer hover:underline hover:text-[#0038a8] focus:underline focus:text-[#0038a8] text-[#1048b8]"
               >
                 (A+B)
               </Link>

--- a/app/exams/[eid]/problems/page.tsx
+++ b/app/exams/[eid]/problems/page.tsx
@@ -62,19 +62,19 @@ export default function ExamProblems(props: DefaultProps) {
           <p className="flex items-center text-2xl font-bold tracking-tight">
             <Image
               src={listImg}
-              alt="trophy"
+              alt="list"
               width={70}
               height={0}
               quality={100}
               className="ml-[-1rem] drop-shadow-lg fade-in-fast"
             />
             <div className="lift-up">
-              <span className="ml-2 lift-up text-3xl font-semibold tracking-wide">
+              <span className="ml-2 text-3xl font-semibold tracking-wide">
                 문제 목록
               </span>
               <Link
                 href={`/exams/${eid}`}
-                className="mt-1 ml-1 text-base font-medium cursor-pointer hover:underline hover:text-[#0038a8] focus:underline focus:text-[#0038a8] text-[#1048b8]"
+                className="mt-1 ml-1 text-xl font-medium cursor-pointer hover:underline hover:text-[#0038a8] focus:underline focus:text-[#0038a8] text-[#1048b8]"
               >
                 (시험: 2023-01-자료구조(소프트웨어학부 01반))
               </Link>

--- a/app/exams/[eid]/submits/page.tsx
+++ b/app/exams/[eid]/submits/page.tsx
@@ -37,7 +37,7 @@ export default function UsersExamSubmits(props: DefaultProps) {
             className="ml-[-1rem] drop-shadow-lg fade-in-fast"
           />
           <div className="lift-up">
-            <span className="ml-4 lift-up text-3xl font-semibold tracking-wide">
+            <span className="ml-4 text-3xl font-semibold tracking-wide">
               코드 제출 목록
             </span>
             <Link

--- a/app/exams/[eid]/submits/page.tsx
+++ b/app/exams/[eid]/submits/page.tsx
@@ -42,7 +42,7 @@ export default function UsersExamSubmits(props: DefaultProps) {
             </span>
             <Link
               href={`/exams/${eid}`}
-              className="mt-1 ml-1 text-base font-medium cursor-pointer hover:underline hover:text-[#0038a8] focus:underline focus:text-[#0038a8] text-[#1048b8]"
+              className="mt-1 ml-1 text-xl font-medium cursor-pointer hover:underline hover:text-[#0038a8] focus:underline focus:text-[#0038a8] text-[#1048b8]"
             >
               (시험: 23년 1학기말 코딩 테스트)
             </Link>

--- a/app/exams/page.tsx
+++ b/app/exams/page.tsx
@@ -11,7 +11,7 @@ export default function Exams() {
         <p className="h-16 flex items-center text-3xl font-semibold tracking-wide">
           <Image
             src={examImg}
-            alt="trophy"
+            alt="exam"
             width={80}
             height={0}
             quality={100}

--- a/app/notices/page.tsx
+++ b/app/notices/page.tsx
@@ -11,7 +11,7 @@ export default function Notices() {
         <p className="h-16 flex items-center text-3xl font-semibold tracking-wide">
           <Image
             src={bellImg}
-            alt="trophy"
+            alt="bell"
             width={67.5}
             height={0}
             quality={100}

--- a/app/practices/[pid]/page.tsx
+++ b/app/practices/[pid]/page.tsx
@@ -22,6 +22,18 @@ export default function PracticeProblem(props: DefaultProps) {
 
   const router = useRouter();
 
+  const handleGoToPracticeProblems = () => {
+    router.push(`/practices`);
+  };
+
+  const handleGoToUserPracticeSubmits = () => {
+    router.push(`/practices/${pid}/submits`);
+  };
+
+  const handleGoToSubmitPracticeProblemCode = () => {
+    router.push(`/practices/${pid}/submit`);
+  };
+
   const handleEditPractice = () => {
     router.push(`/practices/${pid}/edit`);
   };
@@ -71,7 +83,7 @@ export default function PracticeProblem(props: DefaultProps) {
 
         <div className="flex gap-3 justify-end mt-4">
           <button
-            onClick={() => alert('개발 예정')}
+            onClick={handleGoToPracticeProblems}
             className="flex gap-[0.375rem] items-center text-white bg-green-500 px-2 py-[0.4rem] rounded-[0.2rem] font-light focus:bg-[#3e9368] hover:bg-[#3e9368] box-shadow"
           >
             <svg
@@ -86,7 +98,7 @@ export default function PracticeProblem(props: DefaultProps) {
             문제 목록
           </button>
           <button
-            onClick={() => alert('개발 예정')}
+            onClick={handleGoToUserPracticeSubmits}
             className="flex gap-[0.375rem] items-center text-white bg-[#6860ff] px-2 py-[0.4rem] rounded-[0.2rem] font-light focus:bg-[#5951f0] hover:bg-[#5951f0] box-shadow"
           >
             <svg
@@ -101,7 +113,7 @@ export default function PracticeProblem(props: DefaultProps) {
             내 제출 현황
           </button>
           <button
-            onClick={() => alert('개발 예정')}
+            onClick={handleGoToSubmitPracticeProblemCode}
             className="flex gap-[0.375rem] items-center text-white bg-[#3870e0] px-3 py-[0.4rem] rounded-[0.2rem] font-light focus:bg-[#3464c2] hover:bg-[#3464c2] box-shadow"
           >
             제출하기

--- a/app/practices/[pid]/submit/page.tsx
+++ b/app/practices/[pid]/submit/page.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+import MyDropzone from '@/app/components/MyDropzone';
+import Image from 'next/image';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import codeImg from '@/public/images/code.png';
+
+interface DefaultProps {
+  params: {
+    pid: string;
+    problemId: string;
+  };
+}
+
+export default function SubmitPracticeProblemCode(props: DefaultProps) {
+  const [selectedSubmitLanguage, setSelectedSubmitLanguage] =
+    useState('언어 선택 *');
+  const [uploadedCodeFileUrl, setUploadedCodeFileUrl] = useState('');
+
+  const [
+    isSelectedSubmitLanguageValidFail,
+    setIsSelectedSubmitLanguageValidFail,
+  ] = useState(false);
+  const [isCodeFileUploadingValidFail, setIsCodeFileUploadingValidFail] =
+    useState(false);
+
+  const pid = props.params.pid;
+  const problemId = props.params.pid;
+
+  const router = useRouter();
+
+  const handleGoToPracticeProblem = () => {
+    router.push(`/practices/${pid}`);
+  };
+
+  const handlSelectSubmitLanguage = (
+    e: React.ChangeEvent<HTMLSelectElement>,
+  ) => {
+    setSelectedSubmitLanguage(e.target.value);
+    setIsSelectedSubmitLanguageValidFail(false);
+  };
+
+  const handleSubmitPracticeProblemCode = () => {
+    if (selectedSubmitLanguage === '언어 선택 *') {
+      alert('제출 언어를 선택해 주세요');
+      window.scrollTo(0, 0);
+      setIsSelectedSubmitLanguageValidFail(true);
+      return;
+    }
+
+    if (!isCodeFileUploadingValidFail) {
+      alert('소스 코드 파일을 업로드해 주세요');
+      window.scrollTo(0, 0);
+      return;
+    }
+
+    router.push(`/practices/${pid}/submits`);
+  };
+
+  return (
+    <div className="mt-6 mb-24 px-5 2lg:px-0 overflow-x-auto">
+      <div className="flex flex-col w-[60rem] mx-auto">
+        <div className="flex flex-col gap-8">
+          <p className="flex items-center text-2xl font-bold tracking-tight">
+            <Image
+              src={codeImg}
+              alt="trophy"
+              width={70}
+              height={0}
+              quality={100}
+              className="ml-[-1rem] drop-shadow-lg fade-in-fast"
+            />
+            <div className="lift-up">
+              <span className="ml-4 text-3xl font-semibold tracking-wide">
+                코드 제출
+              </span>
+              <Link
+                href={`/practices/${pid}`}
+                className="mt-1 ml-1 text-xl font-medium cursor-pointer hover:underline hover:text-[#0038a8] focus:underline focus:text-[#0038a8] text-[#1048b8]"
+              >
+                (A+B)
+              </Link>
+            </div>
+          </p>
+          <div className="flex justify-between pb-3 border-b border-gray-300">
+            <div className="flex gap-3">
+              <span className="font-semibold">
+                시간 제한:
+                <span className="font-mono font-light">
+                  {' '}
+                  <span>1</span>초
+                </span>
+              </span>
+              <span className='relative bottom-[0.055rem] font-thin before:content-["|"]' />
+              <span className="font-semibold">
+                메모리 제한:
+                <span className="font-mono font-light">
+                  {' '}
+                  <span className="mr-1">5</span>MB
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-5 mt-8 pb-5">
+          <div className="w-1/2">
+            <select
+              name="languages"
+              id="lang"
+              className={`text-sm w-full pl-0 py-1 ${
+                selectedSubmitLanguage === '언어 선택 *' &&
+                isSelectedSubmitLanguageValidFail
+                  ? 'text-red-500'
+                  : 'text-gray-500'
+              }   bg-transparent border-0 border-b border-${
+                isSelectedSubmitLanguageValidFail ? 'red-500' : 'gray-400'
+              }  gray-400 appearance-none focus:outline-none focus:ring-0 focus:border-${
+                isSelectedSubmitLanguageValidFail ? 'red' : 'blue'
+              }-500 peer`}
+              value={selectedSubmitLanguage}
+              onChange={handlSelectSubmitLanguage}
+            >
+              <option disabled selected>
+                언어 선택 *
+              </option>
+              <option value="C">C</option>
+              <option value="C++">C++</option>
+              <option value="Java">Java</option>
+              <option value="JavaScript">JavaScript</option>
+              <option value="Python2">Python2</option>
+              <option value="Python3">Python3</option>
+              <option value="Kotlin">Kotlin</option>
+              <option value="Go">Go</option>
+            </select>
+            <p
+              className={`text-${
+                isSelectedSubmitLanguageValidFail ? 'red' : 'gray'
+              }-500 text-xs tracking-widest font-light mt-2`}
+            >
+              제출할 언어를 선택해 주세요
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-1 mt-5">
+            <p className="text-lg">소스 코드 파일</p>
+            <MyDropzone
+              type="code"
+              guideMsg="코드 파일을 이곳에 업로드해 주세요"
+              setIsFileUploaded={setIsCodeFileUploadingValidFail}
+              isFileUploaded={isCodeFileUploadingValidFail}
+              initPdfUrl={''}
+              initInAndOutFileUrls={[]}
+              setUploadedCodeFileUrl={setUploadedCodeFileUrl}
+            />
+          </div>
+        </div>
+
+        <div className="mt-5 pb-2 flex justify-end gap-3">
+          <button
+            onClick={handleGoToPracticeProblem}
+            className=" px-4 py-[0.4rem] rounded-[0.2rem] font-light"
+          >
+            취소
+          </button>
+          <button
+            onClick={handleSubmitPracticeProblemCode}
+            className=" text-white bg-[#3870e0] px-3 py-[0.4rem] rounded-[0.2rem] font-light focus:bg-[#3464c2] hover:bg-[#3464c2] box-shadow"
+          >
+            제출하기
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/practices/[pid]/submits/[submitId]/page.tsx
+++ b/app/practices/[pid]/submits/[submitId]/page.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import Loading from '@/app/loading';
+import dynamic from 'next/dynamic';
+import { useRouter } from 'next/navigation';
+import React, { useEffect, useState } from 'react';
+
+interface DefaultProps {
+  params: {
+    pid: string;
+    problemId: string;
+  };
+}
+
+const MarkdownPreview = dynamic(
+  () => import('@uiw/react-markdown-preview').then((mod) => mod.default),
+  { ssr: false },
+);
+
+export default function UserPracticeSubmit(props: DefaultProps) {
+  const [isLoading, setIsLoading] = useState(true);
+
+  const pid = props.params.pid;
+  const problemId = props.params.problemId;
+
+  const router = useRouter();
+
+  const handleGoToPracticeSubmits = () => {
+    router.push(`/practices/${pid}/submits`);
+  };
+
+  useEffect(() => {
+    setIsLoading(false);
+  }, []);
+
+  if (isLoading) return <Loading />;
+
+  return (
+    <div className="mt-6 mb-24 px-5 2lg:px-0 overflow-x-auto">
+      <div className="flex flex-col w-[60rem] mx-auto">
+        <div className="flex justify-end items-center pb-3">
+          <button
+            onClick={handleGoToPracticeSubmits}
+            className="flex gap-[0.375rem] items-center text-white bg-[#717171] px-2 py-[0.4rem] rounded-[0.2rem] font-light focus:bg-[#686868] hover:bg-[#686868] box-shadow"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              height="17.5"
+              viewBox="0 -960 960 960"
+              width="17.5"
+              fill="white"
+            >
+              <path d="m313-440 196 196q12 12 11.5 28T508-188q-12 11-28 11.5T452-188L188-452q-6-6-8.5-13t-2.5-15q0-8 2.5-15t8.5-13l264-264q11-11 27.5-11t28.5 11q12 12 12 28.5T508-715L313-520h447q17 0 28.5 11.5T800-480q0 17-11.5 28.5T760-440H313Z" />
+            </svg>
+            뒤로가기
+          </button>
+        </div>
+        <div className="border-y border-[#e4e4e4] border-t-2 border-t-gray-400">
+          <MarkdownPreview
+            className="markdown-preview"
+            source={`
+\`\`\`cpp
+#include <iostream>
+
+using namespace std;
+
+int main(int argc, const char* argv[]) {
+  ios_base::sync_with_stdio(false);
+  cin.tie(0);
+
+  int a, b;
+  cin >> a >> b;
+  cout << a + b;
+
+  return 0;
+}
+\`\`\`
+`}
+          />
+        </div>
+
+        <div className="relative mt-10 dark:bg-gray-800 overflow-hidden rounded-sm">
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm text-left text-gray-500 dark:text-gray-400">
+              <thead className="text-xs text-gray-700 uppercase dark:text-gray-400 text-center">
+                <tr>
+                  <th scope="col" className="px-4 py-2">
+                    문제명
+                  </th>
+                  <th scope="col" className="px-4 py-2">
+                    결과
+                  </th>
+                  <th scope="col" className="px-4 py-2">
+                    메모리
+                  </th>
+                  <th scope="col" className="px-4 py-2">
+                    시간
+                  </th>
+                  <th scope="col" className="px-4 py-2">
+                    언어
+                  </th>
+                  <th scope="col" className="px-4 py-2">
+                    제출 시간
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr className="border-t dark:border-gray-700 text-xs text-center bg-[#f9f9f9]">
+                  <th
+                    scope="row"
+                    className="py-3 font-medium text-gray-900 whitespace-nowrap dark:text-white"
+                  >
+                    A+B
+                  </th>
+                  <td className="text-[#0076C0] font-semibold">정답</td>
+                  <td>
+                    <span>1527 </span>
+                    <span className="ml-[-1px] text-red-500">KB</span>
+                  </td>
+                  <td className="">
+                    <span>64 </span>{' '}
+                    <span className="ml-[-1px] text-red-500">ms</span>
+                  </td>
+                  <td className="">C++17</td>
+                  <td className="">2023.09.26 07:00:00</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div>
+          <div className="flex gap-3 justify-end"></div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/practices/[pid]/submits/components/NoneUserPracticeSubmitListItem.tsx
+++ b/app/practices/[pid]/submits/components/NoneUserPracticeSubmitListItem.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function NoneUserExamSubmitListItem() {
+  return (
+    <tr className="border-b dark:border-gray-700 text-xs text-center">
+      <th
+        scope="row"
+        className="px-4 py-3 font-medium text-gray-900 whitespace-nowrap dark:text-white"
+      >
+        1
+      </th>
+      <td className="text-sm">조회된 제출 정보가 없습니다</td>
+    </tr>
+  );
+}

--- a/app/practices/[pid]/submits/components/UserPracticeSubmitList.tsx
+++ b/app/practices/[pid]/submits/components/UserPracticeSubmitList.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import UserPracticeSubmitListItem from './UserPracticeSubmitListItem';
+import NoneUserPracticeSubmitListItem from './NoneUserPracticeSubmitListItem';
+import Loading from '@/app/loading';
+
+interface ExamSubmitListProps {
+  pid: string;
+  problemId: string;
+}
+
+export default function UserExamSubmitList({
+  pid,
+  problemId,
+}: ExamSubmitListProps) {
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSubmitListEmpty, setIsSumbitListEmpty] = useState(true);
+
+  const numberOfItems = 10;
+
+  useEffect(() => {
+    setIsLoading(false);
+    setIsSumbitListEmpty(false);
+  }, []);
+
+  if (isLoading) return <Loading />;
+  if (isSubmitListEmpty) return <NoneUserPracticeSubmitListItem />;
+
+  return (
+    <tbody>
+      {Array.from({ length: numberOfItems }, (_, idx) => (
+        <UserPracticeSubmitListItem key={idx} pid={pid} problemId={problemId} />
+      ))}
+    </tbody>
+  );
+}

--- a/app/practices/[pid]/submits/components/UserPracticeSubmitListItem.tsx
+++ b/app/practices/[pid]/submits/components/UserPracticeSubmitListItem.tsx
@@ -1,0 +1,40 @@
+import { useRouter } from 'next/navigation';
+import React from 'react';
+
+interface PracticeSubmitListItemProps {
+  pid: string;
+  problemId: string;
+}
+
+export default function UserPracticeSubmitListItem({
+  pid,
+  problemId,
+}: PracticeSubmitListItemProps) {
+  const router = useRouter();
+
+  return (
+    <tr
+      className="border-b dark:border-gray-700 text-xs text-center cursor-pointer hover:bg-gray-50 focus:bg-gray-50"
+      onClick={(e) => {
+        router.push(`/practices/${pid}/submits/${'65445155c4fc3d9d4396ae0e'}`);
+      }}
+    >
+      <th
+        scope="row"
+        className="px-4 py-3 font-medium text-gray-900 whitespace-nowrap dark:text-white"
+      >
+        1
+      </th>
+      <td className="text-[#0076C0] font-semibold">정답</td>
+      <td>
+        <span>1527 </span>
+        <span className="ml-[-1px] text-red-500">KB</span>
+      </td>
+      <td className="">
+        <span>64 </span> <span className="ml-[-1px] text-red-500">ms</span>
+      </td>
+      <td className="">C++17</td>
+      <td className="">2023.09.26 07:00:00</td>
+    </tr>
+  );
+}

--- a/app/practices/[pid]/submits/page.tsx
+++ b/app/practices/[pid]/submits/page.tsx
@@ -1,0 +1,187 @@
+'use client';
+
+import Link from 'next/link';
+import UserPracticeSubmitList from './components/UserPracticeSubmitList';
+import { useEffect, useState } from 'react';
+import Loading from '@/app/loading';
+import Image from 'next/image';
+import codeImg from '@/public/images/code.png';
+
+interface DefaultProps {
+  params: {
+    pid: string;
+    problemId: string;
+  };
+}
+
+export default function UserPracticeSubmits(props: DefaultProps) {
+  const [isLoading, setIsLoading] = useState(true);
+
+  const pid = props.params.pid;
+  const problemId = props.params.problemId;
+
+  useEffect(() => {
+    setIsLoading(false);
+  }, []);
+
+  if (isLoading) return <Loading />;
+
+  return (
+    <div className="mt-2 px-5 2lg:px-0 overflow-x-auto">
+      <div className="flex flex-col w-[60rem] mx-auto">
+        <div className="flex flex-col mb-8">
+          <p className="flex items-center text-2xl font-semibold tracking-tight">
+            <Image
+              src={codeImg}
+              alt="code"
+              width={70}
+              height={0}
+              quality={100}
+              className="ml-[-1rem] drop-shadow-lg fade-in-fast"
+            />
+            <div className="lift-up">
+              <span className="ml-4 lift-up text-3xl font-semibold tracking-wide">
+                내 제출 현황
+              </span>
+              <Link
+                href={`/practices/${pid}`}
+                className="mt-1 ml-1 text-xl font-medium cursor-pointer hover:underline hover:text-[#0038a8] focus:underline focus:text-[#0038a8] text-[#1048b8]"
+              >
+                (A+B)
+              </Link>
+            </div>
+          </p>
+        </div>
+
+        <section className="dark:bg-gray-900">
+          <div className="mx-auto w-full">
+            <div className="border dark:bg-gray-800 relative overflow-hidden rounded-sm">
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm text-left text-gray-500 dark:text-gray-400">
+                  <thead className="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-gray-700 dark:text-gray-400 text-center">
+                    <tr>
+                      <th scope="col" className="px-4 py-2">
+                        번호
+                      </th>
+                      <th scope="col" className="px-4 py-2">
+                        결과
+                      </th>
+                      <th scope="col" className="px-4 py-2">
+                        메모리
+                      </th>
+                      <th scope="col" className="px-4 py-2">
+                        시간
+                      </th>
+                      <th scope="col" className="px-4 py-2">
+                        언어
+                      </th>
+                      <th scope="col" className="px-4 py-2">
+                        제출 시간
+                      </th>
+                    </tr>
+                  </thead>
+                  <UserPracticeSubmitList pid={pid} problemId={problemId} />
+                </table>
+              </div>
+            </div>
+            <nav
+              className="flex flex-col md:flex-row text-xs justify-between items-start md:items-center space-y-3 md:space-y-0 pl-1 mt-3"
+              aria-label="Table navigation"
+            >
+              <span className="text-gray-500 dark:text-gray-400">
+                <span className="text-gray-500 dark:text-white"> 1 - 10</span>{' '}
+                of
+                <span className="text-gray-500 dark:text-white"> 1000</span>
+              </span>
+              <ul className="inline-flex items-stretch -space-x-px">
+                <li>
+                  <a
+                    href="#"
+                    className="flex items-center justify-center h-full py-1.5 px-[0.3rem] ml-0 text-gray-500 bg-white rounded-l-lg border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
+                  >
+                    <span className="sr-only">Previous</span>
+                    <svg
+                      className="w-5 h-5"
+                      aria-hidden="true"
+                      fill="currentColor"
+                      viewBox="0 0 20 20"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        fillRule="evenodd"
+                        d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
+                        clipRule="evenodd"
+                      />
+                    </svg>
+                  </a>
+                </li>
+                <li>
+                  <a
+                    href="#"
+                    className="flex items-center justify-center text-sm py-2 px-3 leading-tight text-gray-400 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
+                  >
+                    1
+                  </a>
+                </li>
+                <li>
+                  <a
+                    href="#"
+                    className="flex items-center justify-center text-sm py-2 px-3 leading-tight text-gray-400 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
+                  >
+                    2
+                  </a>
+                </li>
+                <li>
+                  <a
+                    href="#"
+                    aria-current="page"
+                    className="flex items-center justify-center text-sm z-10 py-2 px-3 leading-tight text-primary-600 bg-primary-50 border border-primary-300 hover:bg-primary-100 hover:text-primary-700 dark:border-gray-700 dark:bg-gray-700 dark:text-white"
+                  >
+                    3
+                  </a>
+                </li>
+                <li>
+                  <a
+                    href="#"
+                    className="flex items-center justify-center text-sm py-2 px-3 leading-tight text-gray-400 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
+                  >
+                    ...
+                  </a>
+                </li>
+                <li>
+                  <a
+                    href="#"
+                    className="flex items-center justify-center text-sm py-2 px-3 leading-tight text-gray-400 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
+                  >
+                    100
+                  </a>
+                </li>
+                <li>
+                  <a
+                    href="#"
+                    className="flex items-center justify-center h-full py-1.5 px-[0.3rem] leading-tight text-gray-500 bg-white rounded-r-lg border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
+                  >
+                    <span className="sr-only">Next</span>
+                    <svg
+                      className="w-5 h-5"
+                      aria-hidden="true"
+                      fill="currentColor"
+                      viewBox="0 0 20 20"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        fillRule="evenodd"
+                        d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                        clipRule="evenodd"
+                      />
+                    </svg>
+                  </a>
+                </li>
+              </ul>
+            </nav>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/app/practices/[pid]/submits/page.tsx
+++ b/app/practices/[pid]/submits/page.tsx
@@ -40,7 +40,7 @@ export default function UserPracticeSubmits(props: DefaultProps) {
               className="ml-[-1rem] drop-shadow-lg fade-in-fast"
             />
             <div className="lift-up">
-              <span className="ml-4 lift-up text-3xl font-semibold tracking-wide">
+              <span className="ml-4 text-3xl font-semibold tracking-wide">
                 내 제출 현황
               </span>
               <Link

--- a/app/practices/page.tsx
+++ b/app/practices/page.tsx
@@ -11,7 +11,7 @@ export default function Practices() {
         <p className="h-16 flex items-center text-3xl font-semibold tracking-wide">
           <Image
             src={pencilImg}
-            alt="trophy"
+            alt="pencil"
             width={72.5}
             height={0}
             quality={100}


### PR DESCRIPTION
## 👀 이슈

resolve #134 

## 📌 개요

연습문제 게시글 페이지 내에서 라우팅되는 **코드 제출 목록** 관련 페이지들을
일괄적으로 추가하였습니다.

## 👩‍💻 작업 사항

- **연습문제** 코드 제출 목록 관련 페이지 컴포넌트 일괄 추가
- 일부 페이지 컴포넌트 내 `Image` 컴포넌트 alt 속성명 정정
- 일부 페이지 컴포넌트 소제목 UI 스타일 변경

## ✅ 참고 사항

- 추가된 `연습문제` 코드 제출 목록 관련 페이지 UI

https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/16b3c631-5095-442a-881c-d900b2351e76