### PR TITLE
[fix]: {사용자 정보 조회} 함수 범위 변경 (#143)

### DIFF
--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -6,11 +6,15 @@ import ChannelService from '../third-party/ChannelTalk';
 import { userInfoStore } from '../store/UserInfo';
 import axiosInstance from '../utils/axiosInstance';
 import { useMutation } from '@tanstack/react-query';
-import { getCurrentUserInfo } from '../login/page';
 
 // 로그아웃 API
 const logout = () => {
   return axiosInstance.get(`${process.env.NEXT_PUBLIC_AUTH_URL}/logout`);
+};
+
+// (로그인 한) 사용자 정보 조회 API
+const getCurrentUserInfo = () => {
+  return axiosInstance.get('/auth/me');
 };
 
 export default function Navbar() {

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -25,7 +25,7 @@ const login = (userAccountInfo: UserLoginInfoType) => {
 };
 
 // (로그인 한) 사용자 정보 조회 API
-export const getCurrentUserInfo = () => {
+const getCurrentUserInfo = () => {
   return axiosInstance.get('/auth/me');
 };
 


### PR DESCRIPTION
## 👀 이슈

resolve #143 

## 📌 개요

로그인 페이지 컴포넌트에서 **사용자 정보 조회** 함수를 정의하였는데,
해당 함수의 export 키워드 사용으로 인해 프로젝트 빌드 시 에러가 발생하여
이를 해결하고자 export 키워드를 제거하였습니다.

## 👩‍💻 작업 사항

- 로그인 페이지 컴포넌트 내에 **사용자 정보 조회** 함수 export 키워드 제거
- `Navbar` 컴포넌트 내에 **사용자 정보 조회** 함수 정의

## ✅ 참고 사항

없습니다