### PR TITLE
[feat]: 대회 목록 조회 기능 추가 (#145)

### DIFF
--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -13,13 +13,13 @@ const logout = () => {
 };
 
 // (로그인 한) 사용자 정보 조회 API
-const getCurrentUserInfo = () => {
+const fetchCurrentUserInfo = () => {
   return axiosInstance.get('/auth/me');
 };
 
 export default function Navbar() {
   const getCurrentUserInfoMutation = useMutation({
-    mutationFn: getCurrentUserInfo,
+    mutationFn: fetchCurrentUserInfo,
     onSuccess: (data) => {
       const resData = data.data.data;
       const { no, name, email, university, department, phone, role } = resData;

--- a/app/components/RenderPaginationButtons.tsx
+++ b/app/components/RenderPaginationButtons.tsx
@@ -1,0 +1,69 @@
+export const RenderPaginationButtons = (
+  currentPage: number,
+  totalPages: number,
+  handlePagination: (page: number) => void,
+) => {
+  let buttons: JSX.Element[] = [];
+  let startPage, endPage;
+
+  if (totalPages <= 3) {
+    startPage = 1;
+    endPage = totalPages;
+  } else {
+    if (currentPage <= 2) {
+      startPage = 1;
+      endPage = 3;
+    } else if (currentPage >= totalPages - 1) {
+      startPage = totalPages - 2;
+      endPage = totalPages;
+    } else {
+      startPage = currentPage - 1;
+      endPage = currentPage + 1;
+    }
+  }
+
+  if (startPage > 1) {
+    buttons.push(
+      <li key="first-ellipsis">
+        <button
+          onClick={() => handlePagination(1)}
+          className="flex items-center justify-center text-sm py-2 px-3 leading-tight text-gray-400 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
+        >
+          ...
+        </button>
+      </li>,
+    );
+  }
+
+  for (let i = startPage; i <= endPage; i++) {
+    buttons.push(
+      <li key={i}>
+        <button
+          onClick={() => handlePagination(i)}
+          className={`text-sm py-2 px-3 leading-tight ${
+            currentPage === i
+              ? 'text-primary-600 bg-primary-50 border border-primary-300'
+              : 'text-gray-400 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700'
+          } dark:border-gray-700 dark:hover:bg-gray-700 dark:hover:text-white`}
+        >
+          {i}
+        </button>
+      </li>,
+    );
+  }
+
+  if (endPage < totalPages) {
+    buttons.push(
+      <li key="last-ellipsis">
+        <button
+          onClick={() => handlePagination(totalPages)}
+          className="flex items-center justify-center text-sm py-2 px-3 leading-tight text-gray-400 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
+        >
+          ...
+        </button>
+      </li>,
+    );
+  }
+
+  return buttons; // 항상 buttons 배열을 반환합니다.
+};

--- a/app/contests/components/ContestList.tsx
+++ b/app/contests/components/ContestList.tsx
@@ -1,34 +1,159 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
 import ContestListItem from './ContestListItem';
 import NoneContestListItem from './NoneContestListItem';
 import Loading from '@/app/loading';
+import axiosInstance from '../../utils/axiosInstance';
+import { useQuery } from '@tanstack/react-query';
+import { ContestInfo } from '@/app/components/Contests/ContestList';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { RenderPaginationButtons } from '@/app/components/RenderPaginationButtons';
+import useDebounce from '@/app/hooks/useDebounce';
 
-export default function ContestList() {
-  const [isLoading, setIsLoading] = useState(true);
-  const [isContestListEmpty, setIsContestListEmpty] = useState(true);
+interface ContestListProps {
+  searchQuery: string;
+}
+
+// 시험 목록 반환 API (10개 게시글 단위로)
+const fetchExams = async (page: number, searchQuery: string) => {
+  const response = await axiosInstance.get(
+    `${process.env.NEXT_PUBLIC_API_VERSION}/contest/?page=${page}&limit=10&sort=-createdAt&q=title=${searchQuery}`,
+  );
+  return response.data;
+};
+
+export default function ContestList({ searchQuery }: ContestListProps) {
+  const debouncedSearchQuery = useDebounce(searchQuery, 400);
+
+  const params = useSearchParams();
+
+  const page = Number(params?.get('page')) || 1;
+
+  const { isPending, data } = useQuery({
+    queryKey: ['examList', page, debouncedSearchQuery],
+    queryFn: () => fetchExams(page, searchQuery),
+  });
+
+  const router = useRouter();
+
+  const resData = data?.data;
+  const startItemNum = (resData?.page - 1) * 10 + 1;
+  const endItemNum = startItemNum - 1 + resData?.documents.length;
+  const totalPages = Math.ceil(resData?.total / 10);
+
+  const handlePagination = (newPage: number) => {
+    if (newPage < 1 || newPage > totalPages) return;
+    router.push(`/contests?page=${newPage}`);
+  };
 
   useEffect(() => {
-    setIsLoading(false);
-    setIsContestListEmpty(false);
-  }, []);
+    // page가 유효한 양의 정수가 아닌 경우, /contests?page=1로 리다이렉트
+    if (!params?.has('page') || !Number.isInteger(page) || page < 1) {
+      router.replace('/contests?page=1');
+    }
+  }, [page, params, router]);
 
-  if (isLoading) return <Loading />;
-  if (isContestListEmpty) return <NoneContestListItem />;
+  if (isPending) return <Loading />;
 
   return (
-    <tbody>
-      <ContestListItem />
-      <ContestListItem />
-      <ContestListItem />
-      <ContestListItem />
-      <ContestListItem />
-      <ContestListItem />
-      <ContestListItem />
-      <ContestListItem />
-      <ContestListItem />
-      <ContestListItem />
-    </tbody>
+    <div className="mx-auto w-full">
+      <div className="border dark:bg-gray-800 relative overflow-hidden rounded-sm">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm text-left text-gray-500 dark:text-gray-400">
+            <thead className="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-gray-700 dark:text-gray-400 text-center">
+              <tr>
+                <th scope="col" className="px-4 py-2">
+                  번호
+                </th>
+                <th scope="col" className="px-4 py-2">
+                  대회명
+                </th>
+                <th scope="col" className="px-4 py-2">
+                  신청기간
+                </th>
+                <th scope="col" className="px-4 py-2">
+                  대회시간
+                </th>
+                <th scope="col" className="px-4 py-2">
+                  작성일
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {resData?.documents.length === 0 && <NoneContestListItem />}
+              {resData?.documents.map(
+                (contestInfo: ContestInfo, index: number) => (
+                  <ContestListItem
+                    contestInfo={contestInfo}
+                    total={resData.total}
+                    page={page}
+                    index={index}
+                    key={index}
+                  />
+                ),
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <nav
+        className="flex flex-col md:flex-row text-xs justify-between items-start md:items-center space-y-3 md:space-y-0 pl-1 mt-3"
+        aria-label="Table navigation"
+      >
+        <span className="text-gray-500 dark:text-gray-400">
+          <span className="text-gray-500 dark:text-white">
+            {startItemNum} - {endItemNum}
+          </span>{' '}
+          of{' '}
+          <span className="text-gray-500 dark:text-white">{resData.total}</span>
+        </span>
+        <ul className="inline-flex items-stretch -space-x-px">
+          <li>
+            <button
+              onClick={() => handlePagination(Number(page) - 1)}
+              className="flex items-center justify-center h-full py-1.5 px-[0.3rem] ml-0 text-gray-500 bg-white rounded-l-lg border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
+            >
+              <span className="sr-only">Previous</span>
+              <svg
+                className="w-5 h-5"
+                aria-hidden="true"
+                fill="currentColor"
+                viewBox="0 0 20 20"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </button>
+          </li>
+          {RenderPaginationButtons(page, totalPages, handlePagination)}
+          <li>
+            <button
+              onClick={() => handlePagination(Number(page) + 1)}
+              className="flex items-center justify-center h-full py-1.5 px-[0.3rem] leading-tight text-gray-500 bg-white rounded-r-lg border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
+            >
+              <span className="sr-only">Next</span>
+              <svg
+                className="w-5 h-5"
+                aria-hidden="true"
+                fill="currentColor"
+                viewBox="0 0 20 20"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </button>
+          </li>
+        </ul>
+      </nav>
+    </div>
   );
 }

--- a/app/contests/components/ContestListItem.tsx
+++ b/app/contests/components/ContestListItem.tsx
@@ -1,9 +1,23 @@
 'use client';
 
+import { ContestInfo } from '@/app/components/Contests/ContestList';
+import {
+  formatDateToYYMMDDHHMM,
+  formatDateToYYMMDD,
+} from '@/app/utils/formatDate';
 import { useRouter } from 'next/navigation';
 import React from 'react';
 
-export default function ContestListItem() {
+interface ContestProps {
+  contestInfo: ContestInfo;
+  total: number;
+  page: number;
+  index: number;
+}
+
+export default function ContestListItem(props: ContestProps) {
+  const { contestInfo, total, page, index } = props;
+
   const router = useRouter();
 
   return (
@@ -15,18 +29,23 @@ export default function ContestListItem() {
     >
       <th
         scope="row"
-        className="px-4 py-3 font-medium text-gray-900 whitespace-nowrap dark:text-white"
+        className="px-4 py-3 font-normal text-gray-900 whitespace-nowrap dark:text-white"
       >
-        1
+        {total - (page - 1) * 10 - index}
       </th>
-      <td className="hover:underline focus:underline">
-        2023년 제2회 충청북도 대학생 프로그래밍 경진대회 본선
+      <td className="hover:underline focus:underline">{contestInfo.title}</td>
+      <td className="font-medium">
+        {contestInfo.applyingPeriod ? (
+          <>~ {formatDateToYYMMDDHHMM(contestInfo.applyingPeriod.end)}</>
+        ) : (
+          <>~ {formatDateToYYMMDDHHMM(contestInfo.testPeriod.start)}</>
+        )}
       </td>
-      <td className="font-medium">~ 2023.06.26. 03:00</td>
-      <td className="text-red-500 font-medium">~ 2023.06.26. 06:00</td>
-      <td className="font-medium">62명</td>
-      <td className="font-medium">신재혁</td>
-      <td className="">2023.05.09</td>
+      <td className="text-red-500 font-medium">
+        {formatDateToYYMMDDHHMM(contestInfo.testPeriod?.start)} ~{' '}
+        {formatDateToYYMMDDHHMM(contestInfo.testPeriod?.end)}
+      </td>
+      <td className="">{formatDateToYYMMDD(contestInfo.createdAt)}</td>
     </tr>
   );
 }

--- a/app/contests/page.tsx
+++ b/app/contests/page.tsx
@@ -1,9 +1,17 @@
+'use client';
+
 import Link from 'next/link';
 import ContestList from './components/ContestList';
 import Image from 'next/image';
 import trophyImg from '@/public/images/trophy.png';
+import { useState } from 'react';
+import { userInfoStore } from '../store/UserInfo';
 
 export default function Contests() {
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const userInfo = userInfoStore((state: any) => state.userInfo);
+
   return (
     <div className="mt-2 px-5 2lg:px-0 overflow-x-auto">
       <div className="flex flex-col w-[60rem] mx-auto">
@@ -27,6 +35,8 @@ export default function Contests() {
                 className="block pl-7 pt-3 pb-[0.175rem] pr-0 w-full font-normal text-gray-900 bg-transparent border-0 border-b border-gray-400 appearance-none dark:text-white dark:border-gray-600 dark:focus:border-blue-500 focus:outline-none focus:ring-0 focus:border-blue-600 peer"
                 placeholder=" "
                 required
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
               />
               <div className="absolute pt-[0.9rem] left-[-0.9rem] flex items-center pl-3 pointer-events-none">
                 <svg
@@ -46,154 +56,28 @@ export default function Contests() {
                 검색
               </label>
               <p className="text-gray-500 text-xs tracking-widest font-light mt-1">
-                대회명, 작성자로 검색
+                대회명으로 검색
               </p>
             </div>
-            <div className="relative ml-auto mt-auto bottom-[-0.75rem]">
-              <div className="flex justify-end mb-2">
-                <div className="flex">
-                  <Link
-                    href="contests/register"
-                    className="text-[#f9fafb] bg-[#3a8af9] px-4 py-[0.5rem] rounded-[6px] focus:bg-[#1c6cdb] hover:bg-[#1c6cdb]"
-                  >
-                    등록하기
-                  </Link>
+            {userInfo.role === 'operator' && (
+              <div className="relative ml-auto mt-auto bottom-[-0.75rem]">
+                <div className="flex justify-end mb-2">
+                  <div className="flex">
+                    <Link
+                      href="contests/register"
+                      className="text-[#f9fafb] bg-[#3a8af9] px-4 py-[0.5rem] rounded-[6px] focus:bg-[#1c6cdb] hover:bg-[#1c6cdb]"
+                    >
+                      등록하기
+                    </Link>
+                  </div>
                 </div>
               </div>
-            </div>
+            )}
           </div>
         </form>
 
         <section className="dark:bg-gray-900">
-          <div className="mx-auto w-full">
-            <div className="border dark:bg-gray-800 relative overflow-hidden rounded-sm">
-              <div className="overflow-x-auto">
-                <table className="w-full text-sm text-left text-gray-500 dark:text-gray-400">
-                  <thead className="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-gray-700 dark:text-gray-400 text-center">
-                    <tr>
-                      <th scope="col" className="px-4 py-2">
-                        번호
-                      </th>
-                      <th scope="col" className="px-4 py-2">
-                        대회명
-                      </th>
-                      <th scope="col" className="px-4 py-2">
-                        신청기간
-                      </th>
-                      <th scope="col" className="px-4 py-2">
-                        대회시간
-                      </th>
-                      <th scope="col" className="px-4 py-2">
-                        참가자
-                      </th>
-                      <th scope="col" className="px-4 py-2">
-                        작성자
-                      </th>
-                      <th scope="col" className="px-4 py-2">
-                        작성일
-                      </th>
-                    </tr>
-                  </thead>
-                  <ContestList />
-                </table>
-              </div>
-            </div>
-            <nav
-              className="flex flex-col md:flex-row text-xs justify-between items-start md:items-center space-y-3 md:space-y-0 pl-1 mt-3"
-              aria-label="Table navigation"
-            >
-              <span className="text-gray-500 dark:text-gray-400">
-                <span className="text-gray-500 dark:text-white"> 1 - 10</span>{' '}
-                of
-                <span className="text-gray-500 dark:text-white"> 1000</span>
-              </span>
-              <ul className="inline-flex items-stretch -space-x-px">
-                <li>
-                  <a
-                    href="#"
-                    className="flex items-center justify-center h-full py-1.5 px-[0.3rem] ml-0 text-gray-500 bg-white rounded-l-lg border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
-                  >
-                    <span className="sr-only">Previous</span>
-                    <svg
-                      className="w-5 h-5"
-                      aria-hidden="true"
-                      fill="currentColor"
-                      viewBox="0 0 20 20"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        fillRule="evenodd"
-                        d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
-                        clipRule="evenodd"
-                      />
-                    </svg>
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="#"
-                    className="flex items-center justify-center text-sm py-2 px-3 leading-tight text-gray-400 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
-                  >
-                    1
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="#"
-                    className="flex items-center justify-center text-sm py-2 px-3 leading-tight text-gray-400 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
-                  >
-                    2
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="#"
-                    aria-current="page"
-                    className="flex items-center justify-center text-sm z-10 py-2 px-3 leading-tight text-primary-600 bg-primary-50 border border-primary-300 hover:bg-primary-100 hover:text-primary-700 dark:border-gray-700 dark:bg-gray-700 dark:text-white"
-                  >
-                    3
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="#"
-                    className="flex items-center justify-center text-sm py-2 px-3 leading-tight text-gray-400 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
-                  >
-                    ...
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="#"
-                    className="flex items-center justify-center text-sm py-2 px-3 leading-tight text-gray-400 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
-                  >
-                    100
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="#"
-                    className="flex items-center justify-center h-full py-1.5 px-[0.3rem] leading-tight text-gray-500 bg-white rounded-r-lg border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
-                  >
-                    <span className="sr-only">Next</span>
-                    <svg
-                      className="w-5 h-5"
-                      aria-hidden="true"
-                      fill="currentColor"
-                      viewBox="0 0 20 20"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        fillRule="evenodd"
-                        d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-                        clipRule="evenodd"
-                      />
-                    </svg>
-                  </a>
-                </li>
-              </ul>
-            </nav>
-          </div>
+          <ContestList searchQuery={searchQuery} />
         </section>
       </div>
     </div>

--- a/app/hooks/useDebounce.ts
+++ b/app/hooks/useDebounce.ts
@@ -1,0 +1,21 @@
+import { useState, useEffect } from 'react';
+
+function useDebounce(value: string, delay: number): string {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    // 지연 시간 후에 value 업데이트
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    // Cleanup 함수에서 timer를 clear
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]); // value 또는 delay가 변경될 때마다 effect 실행
+
+  return debouncedValue;
+}
+
+export default useDebounce;

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -25,7 +25,7 @@ const login = (userAccountInfo: UserLoginInfoType) => {
 };
 
 // (로그인 한) 사용자 정보 조회 API
-const getCurrentUserInfo = () => {
+const fetchCurrentUserInfo = () => {
   return axiosInstance.get('/auth/me');
 };
 
@@ -94,7 +94,7 @@ export default function Login() {
   });
 
   const getCurrentUserInfoMutation = useMutation({
-    mutationFn: getCurrentUserInfo,
+    mutationFn: fetchCurrentUserInfo,
     onSuccess: (data) => {
       const resData = data.data.data;
       const { no, name, email, university, department, phone, role } = resData;

--- a/app/utils/formatDate.ts
+++ b/app/utils/formatDate.ts
@@ -1,0 +1,33 @@
+export function formatDateToYYMMDDHHMM(dateString: string): string {
+  // Date 객체 생성
+  const date = new Date(dateString);
+
+  // 연도, 월, 일, 시간, 분을 추출
+  const year = date.getFullYear().toString().slice(-2);
+  const month = date.getMonth() + 1; // getMonth()는 0부터 시작하므로 1을 더함
+  const day = date.getDate();
+  const hours = date.getHours();
+  const minutes = date.getMinutes();
+
+  // 각 부분을 두 자리 문자열로 변환 (예: '01', '02', ...)
+  const monthStr = month.toString().padStart(2, '0');
+  const dayStr = day.toString().padStart(2, '0');
+  const hoursStr = hours.toString().padStart(2, '0');
+  const minutesStr = minutes.toString().padStart(2, '0');
+
+  // 최종 형식으로 문자열 구성
+  return `${year}/${monthStr}/${dayStr} ${hoursStr}:${minutesStr}`;
+}
+
+export function formatDateToYYMMDD(dateString: string): string {
+  // Date 객체 생성
+  const date = new Date(dateString);
+
+  // 연도, 월, 일을 추출
+  const year = date.getFullYear().toString().slice(-2); // 연도의 마지막 두 자리
+  const month = (date.getMonth() + 1).toString().padStart(2, '0'); // getMonth()는 0부터 시작하므로 1을 더함
+  const day = date.getDate().toString().padStart(2, '0');
+
+  // 'YY/MM/DD' 형식으로 문자열 구성
+  return `${year}/${month}/${day}`;
+}


### PR DESCRIPTION
## 👀 이슈

resolve #145 

## 📌 개요

현재 `Navbar`에 존재하는 `대회` 메뉴 클릭 시 해당 게시글 목록이
표시되는 페이지로 라우팅되는데, 이때 목록 내용을 실제 서버로부터 받아와 표시하기
위해 해당 기능을 추가하고자 하였습니다.

## 👩‍💻 작업 사항

- `대회` 목록 조회 기능 추가

## ✅ 참고 사항

- 기능 추가 전 프론트 사이드에서 게시글 목록 데이터를 하드 코딩했던 UI

<img width="1202" alt="Screenshot 2024-01-26 at 1 50 41 PM" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/36b58db4-0b56-429e-992c-5ef1aba8a60c">

- 기능 추가 후 **대회 목록 조회** 기능 사용 UI

https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/dd6a8851-8ec6-4c54-80a8-aec4d374f486