### PR TITLE
[feat]: 시험 목록 조회 기능 추가 (#149)

### DIFF
--- a/app/contests/components/ContestList.tsx
+++ b/app/contests/components/ContestList.tsx
@@ -15,7 +15,7 @@ interface ContestListProps {
   searchQuery: string;
 }
 
-// 시험 목록 반환 API (10개 게시글 단위로)
+// 대회 목록 반환 API (10개 게시글 단위로)
 const fetchExams = async (page: number, searchQuery: string) => {
   const response = await axiosInstance.get(
     `${process.env.NEXT_PUBLIC_API_VERSION}/contest/?page=${page}&limit=10&sort=-createdAt&q=title=${searchQuery}`,
@@ -31,7 +31,7 @@ export default function ContestList({ searchQuery }: ContestListProps) {
   const page = Number(params?.get('page')) || 1;
 
   const { isPending, data } = useQuery({
-    queryKey: ['examList', page, debouncedSearchQuery],
+    queryKey: ['contestList', page, debouncedSearchQuery],
     queryFn: () => fetchExams(page, searchQuery),
   });
 

--- a/app/contests/components/ContestListItem.tsx
+++ b/app/contests/components/ContestListItem.tsx
@@ -8,14 +8,14 @@ import {
 import { useRouter } from 'next/navigation';
 import React from 'react';
 
-interface ContestProps {
+interface ContestListItemProps {
   contestInfo: ContestInfo;
   total: number;
   page: number;
   index: number;
 }
 
-export default function ContestListItem(props: ContestProps) {
+export default function ContestListItem(props: ContestListItemProps) {
   const { contestInfo, total, page, index } = props;
 
   const router = useRouter();

--- a/app/exams/components/ExamList.tsx
+++ b/app/exams/components/ExamList.tsx
@@ -4,31 +4,154 @@ import React, { useEffect, useState } from 'react';
 import ExamListItem from './ExamListItem';
 import NoneExamListItem from './NoneExamListItem';
 import Loading from '@/app/loading';
+import axiosInstance from '@/app/utils/axiosInstance';
+import useDebounce from '@/app/hooks/useDebounce';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useQuery } from '@tanstack/react-query';
+import { ExamInfo } from '@/app/components/exams/ExamList';
+import { RenderPaginationButtons } from '@/app/components/RenderPaginationButtons';
 
-export default function ExamList() {
-  const [isLoading, setIsLoading] = useState(true);
-  const [isExamListEmpty, setIsExamListEmpty] = useState(true);
+interface ExamListProps {
+  searchQuery: string;
+}
+
+// 시험 목록 반환 API (10개 게시글 단위로)
+const fetchExams = async (page: number, searchQuery: string) => {
+  const response = await axiosInstance.get(
+    `${process.env.NEXT_PUBLIC_API_VERSION}/assignment/?page=${page}&limit=10&sort=-createdAt&q=title,course,writer=${searchQuery}`,
+  );
+  return response.data;
+};
+
+export default function ExamList({ searchQuery }: ExamListProps) {
+  const debouncedSearchQuery = useDebounce(searchQuery, 400);
+
+  const params = useSearchParams();
+
+  const page = Number(params?.get('page')) || 1;
+
+  const { isPending, data } = useQuery({
+    queryKey: ['examList', page, debouncedSearchQuery],
+    queryFn: () => fetchExams(page, searchQuery),
+  });
+
+  const router = useRouter();
+
+  const resData = data?.data;
+  const startItemNum = (resData?.page - 1) * 10 + 1;
+  const endItemNum = startItemNum - 1 + resData?.documents.length;
+  const totalPages = Math.ceil(resData?.total / 10);
+
+  const handlePagination = (newPage: number) => {
+    if (newPage < 1 || newPage > totalPages) return;
+    router.push(`/exams?page=${newPage}`);
+  };
 
   useEffect(() => {
-    setIsLoading(false);
-    setIsExamListEmpty(false);
-  }, []);
+    // page가 유효한 양의 정수가 아닌 경우, /exams?page=1로 리다이렉트
+    if (!params?.has('page') || !Number.isInteger(page) || page < 1) {
+      router.replace('/exams?page=1');
+    }
+  }, [page, params, router]);
 
-  if (isLoading) return <Loading />;
-  if (isExamListEmpty) return <NoneExamListItem />;
+  if (isPending) return <Loading />;
 
   return (
-    <tbody>
-      <ExamListItem />
-      <ExamListItem />
-      <ExamListItem />
-      <ExamListItem />
-      <ExamListItem />
-      <ExamListItem />
-      <ExamListItem />
-      <ExamListItem />
-      <ExamListItem />
-      <ExamListItem />
-    </tbody>
+    <div className="mx-auto w-full">
+      <div className="border dark:bg-gray-800 relative overflow-hidden rounded-sm">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm text-left text-gray-500 dark:text-gray-400">
+            <thead className="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-gray-700 dark:text-gray-400 text-center">
+              <tr>
+                <th scope="col" className="px-4 py-2">
+                  번호
+                </th>
+                <th scope="col" className="px-4 py-2">
+                  시험명
+                </th>
+                <th scope="col" className="px-4 py-2">
+                  수업명
+                </th>
+                <th scope="col" className="px-4 py-2">
+                  작성자
+                </th>
+                <th scope="col" className="px-4 py-2">
+                  시험 시간
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {resData?.documents.length === 0 && <NoneExamListItem />}
+              {resData?.documents.map((examInfo: ExamInfo, index: number) => (
+                <ExamListItem
+                  examInfo={examInfo}
+                  total={resData.total}
+                  page={page}
+                  index={index}
+                  key={index}
+                />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <nav
+        className="flex flex-col md:flex-row text-xs justify-between items-start md:items-center space-y-3 md:space-y-0 pl-1 mt-3"
+        aria-label="Table navigation"
+      >
+        <span className="text-gray-500 dark:text-gray-400">
+          <span className="text-gray-500 dark:text-white">
+            {startItemNum} - {endItemNum}
+          </span>{' '}
+          of{' '}
+          <span className="text-gray-500 dark:text-white">{resData.total}</span>
+        </span>
+        <ul className="inline-flex items-stretch -space-x-px">
+          <li>
+            <button
+              onClick={() => handlePagination(Number(page) - 1)}
+              className="flex items-center justify-center h-full py-1.5 px-[0.3rem] ml-0 text-gray-500 bg-white rounded-l-lg border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
+            >
+              <span className="sr-only">Previous</span>
+              <svg
+                className="w-5 h-5"
+                aria-hidden="true"
+                fill="currentColor"
+                viewBox="0 0 20 20"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </button>
+          </li>
+          {RenderPaginationButtons(page, totalPages, handlePagination)}
+          <li>
+            <button
+              onClick={() => handlePagination(Number(page) + 1)}
+              className="flex items-center justify-center h-full py-1.5 px-[0.3rem] leading-tight text-gray-500 bg-white rounded-r-lg border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
+            >
+              <span className="sr-only">Next</span>
+              <svg
+                className="w-5 h-5"
+                aria-hidden="true"
+                fill="currentColor"
+                viewBox="0 0 20 20"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </button>
+          </li>
+        </ul>
+      </nav>
+    </div>
   );
 }

--- a/app/exams/components/ExamListItem.tsx
+++ b/app/exams/components/ExamListItem.tsx
@@ -1,9 +1,21 @@
 'use client';
 
+import { ContestInfo } from '@/app/components/Contests/ContestList';
+import { ExamInfo } from '@/app/components/exams/ExamList';
+import { formatDateToYYMMDDHHMM } from '@/app/utils/formatDate';
 import { useRouter } from 'next/navigation';
 import React from 'react';
 
-export default function ExamListItem() {
+interface ExamListItemProps {
+  examInfo: ExamInfo;
+  total: number;
+  page: number;
+  index: number;
+}
+
+export default function ExamListItem(props: ExamListItemProps) {
+  const { examInfo, total, page, index } = props;
+
   const router = useRouter();
 
   return (
@@ -17,14 +29,15 @@ export default function ExamListItem() {
         scope="row"
         className="px-4 py-3 font-medium text-gray-900 whitespace-nowrap dark:text-white"
       >
-        1
+        {total - (page - 1) * 10 - index}
       </th>
-      <td className="hover:underline focus:underline">코딩테스트 1차</td>
-      <td className="font-medium">2023-01-자료구조(소프트웨어학부 01반)</td>
-      <td className="font-medium">노서영</td>
+      <td className="hover:underline focus:underline">{examInfo.title}</td>
+      <td className="font-medium">{examInfo.course}</td>
+      <td className="font-medium">{examInfo.writer.name}</td>
       <td className="font-medium">
         <span className="text-red-500 ">
-          2023.06.26. 03:00<span> ~ </span>2023.06.26. 03:00
+          {formatDateToYYMMDDHHMM(examInfo.testPeriod?.start)} ~{' '}
+          {formatDateToYYMMDDHHMM(examInfo.testPeriod?.end)}
         </span>
       </td>
     </tr>

--- a/app/exams/page.tsx
+++ b/app/exams/page.tsx
@@ -1,10 +1,17 @@
-import React from 'react';
+'use client';
+
+import React, { useState } from 'react';
 import Link from 'next/link';
 import ExamList from './components/ExamList';
 import Image from 'next/image';
 import examImg from '@/public/images/exam.png';
+import { userInfoStore } from '../store/UserInfo';
 
 export default function Exams() {
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const userInfo = userInfoStore((state: any) => state.userInfo);
+
   return (
     <div className="mt-2 px-5 2lg:px-0 overflow-x-auto">
       <div className="flex flex-col w-[60rem] mx-auto">
@@ -28,6 +35,8 @@ export default function Exams() {
                 className="block pl-7 pt-3 pb-[0.175rem] pr-0 w-full font-normal text-gray-900 bg-transparent border-0 border-b border-gray-400 appearance-none dark:text-white dark:border-gray-600 dark:focus:border-blue-500 focus:outline-none focus:ring-0 focus:border-blue-600 peer"
                 placeholder=" "
                 required
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
               />
               <div className="absolute pt-[0.9rem] left-[-0.9rem] flex items-center pl-3 pointer-events-none">
                 <svg
@@ -48,7 +57,7 @@ export default function Exams() {
                 검색
               </label>
               <p className="text-gray-500 text-xs tracking-widest font-light mt-1">
-                시험명, 교수명으로 검색
+                시험명, 수업명, 작성자로 검색
               </p>
             </div>
             <div className="relative ml-auto mt-auto bottom-[-0.75rem]">
@@ -67,129 +76,7 @@ export default function Exams() {
         </form>
 
         <section className="dark:bg-gray-900">
-          <div className="mx-auto w-full">
-            <div className="border dark:bg-gray-800 relative overflow-hidden rounded-sm">
-              <div className="overflow-x-auto">
-                <table className="w-full text-sm text-left text-gray-500 dark:text-gray-400">
-                  <thead className="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-gray-700 dark:text-gray-400 text-center">
-                    <tr>
-                      <th scope="col" className="px-4 py-2">
-                        번호
-                      </th>
-                      <th scope="col" className="px-4 py-2">
-                        시험명
-                      </th>
-                      <th scope="col" className="px-4 py-2">
-                        수업명
-                      </th>
-                      <th scope="col" className="px-4 py-2">
-                        교수명
-                      </th>
-                      <th scope="col" className="px-4 py-2">
-                        시험 시간
-                      </th>
-                    </tr>
-                  </thead>
-                  <ExamList />
-                </table>
-              </div>
-            </div>
-            <nav
-              className="flex flex-col md:flex-row text-xs justify-between items-start md:items-center space-y-3 md:space-y-0 pl-1 mt-3"
-              aria-label="Table navigation"
-            >
-              <span className="text-gray-500 dark:text-gray-400">
-                <span className="text-gray-500 dark:text-white"> 1 - 10</span>{' '}
-                of
-                <span className="text-gray-500 dark:text-white"> 1000</span>
-              </span>
-              <ul className="inline-flex items-stretch -space-x-px">
-                <li>
-                  <a
-                    href="#"
-                    className="flex items-center justify-center h-full py-1.5 px-[0.3rem] ml-0 text-gray-500 bg-white rounded-l-lg border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
-                  >
-                    <span className="sr-only">Previous</span>
-                    <svg
-                      className="w-5 h-5"
-                      aria-hidden="true"
-                      fill="currentColor"
-                      viewBox="0 0 20 20"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        fillRule="evenodd"
-                        d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
-                        clipRule="evenodd"
-                      />
-                    </svg>
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="#"
-                    className="flex items-center justify-center text-sm py-2 px-3 leading-tight text-gray-400 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
-                  >
-                    1
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="#"
-                    className="flex items-center justify-center text-sm py-2 px-3 leading-tight text-gray-400 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
-                  >
-                    2
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="#"
-                    aria-current="page"
-                    className="flex items-center justify-center text-sm z-10 py-2 px-3 leading-tight text-primary-600 bg-primary-50 border border-primary-300 hover:bg-primary-100 hover:text-primary-700 dark:border-gray-700 dark:bg-gray-700 dark:text-white"
-                  >
-                    3
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="#"
-                    className="flex items-center justify-center text-sm py-2 px-3 leading-tight text-gray-400 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
-                  >
-                    ...
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="#"
-                    className="flex items-center justify-center text-sm py-2 px-3 leading-tight text-gray-400 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
-                  >
-                    100
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="#"
-                    className="flex items-center justify-center h-full py-1.5 px-[0.3rem] leading-tight text-gray-500 bg-white rounded-r-lg border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
-                  >
-                    <span className="sr-only">Next</span>
-                    <svg
-                      className="w-5 h-5"
-                      aria-hidden="true"
-                      fill="currentColor"
-                      viewBox="0 0 20 20"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        fillRule="evenodd"
-                        d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-                        clipRule="evenodd"
-                      />
-                    </svg>
-                  </a>
-                </li>
-              </ul>
-            </nav>
-          </div>
+          <ExamList searchQuery={searchQuery} />
         </section>
       </div>
     </div>

--- a/app/utils/axiosInstance.ts
+++ b/app/utils/axiosInstance.ts
@@ -1,10 +1,10 @@
 import axios from 'axios';
 
-const instance = axios.create({
+const axiosInstance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_URL,
 });
 
-instance.interceptors.request.use(
+axiosInstance.interceptors.request.use(
   (config) => {
     const accessToken = localStorage.getItem('access-token');
     if (accessToken) config.headers['x-access-token'] = accessToken;
@@ -16,7 +16,7 @@ instance.interceptors.request.use(
   },
 );
 
-instance.interceptors.response.use(
+axiosInstance.interceptors.response.use(
   (response) => {
     // 응답 데이터를 처리
     return response;
@@ -35,4 +35,4 @@ instance.interceptors.response.use(
   },
 );
 
-export default instance;
+export default axiosInstance;


### PR DESCRIPTION
## 👀 이슈

resolve #149 

## 📌 개요

현재 `Navbar`에 존재하는 `시험` 메뉴 클릭 시 해당 게시글 목록이
표시되는 페이지로 라우팅되는데, 이때 목록 내용을 실제 서버로부터 받아와 표시하기
위해 해당 기능을 추가하였습니다.

## 👩‍💻 작업 사항

- `시험` 목록 조회 기능 추가

## ✅ 참고 사항

- 기능 추가 전 프론트 사이드에서 게시글 목록 데이터를 하드 코딩했던 UI

![Screenshot 2024-01-27 at 4 32 21 PM](https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/4520fdf0-3da6-4aa0-ad29-1ed782311162)

- 기능 추가 후 UI

https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/d3400b6d-3247-4207-b3a3-d7fb1f37a252