### PR TITLE
[feat]: 연습문제 목록 조회 기능 추가 (#151)

### DIFF
--- a/app/components/Contests/ContestList.tsx
+++ b/app/components/Contests/ContestList.tsx
@@ -6,43 +6,7 @@ import { useQuery } from '@tanstack/react-query';
 import ContestListItem from './ContestListItem';
 import NoneContestListItem from './NoneContestListItem';
 import DummyContestListemItem from './DummyContestListemItem';
-
-export interface ContestInfo {
-  password: string | null;
-  isPassword: boolean;
-  problems: string[];
-  applyingPeriod: {
-    start: string;
-    end: string;
-  } | null;
-  contestants: string[];
-  _id: string;
-  title: string;
-  content: string;
-  testPeriod: {
-    start: string; // Date 타입으로 변환할 수도 있습니다.
-    end: string; // Date 타입으로 변환할 수도 있습니다.
-  };
-  writer: {
-    center?: any; // 'null'이거나 더 구체적인 타입이 필요할 수 있습니다.
-    permissions: string[];
-    _id: string;
-    no: string;
-    name: string;
-    email: string;
-    phone: string;
-    department: string;
-    university: string;
-    position: string;
-    role: string;
-    joinedAt: string; // Date 타입으로 변환할 수도 있습니다.
-    updatedAt: string; // Date 타입으로 변환할 수도 있습니다.
-    __v: number;
-  };
-  createdAt: string; // Date 타입으로 변환할 수도 있습니다.
-  updatedAt: string; // Date 타입으로 변환할 수도 있습니다.
-  __v: number;
-}
+import { ContestInfo } from '@/app/types/contest';
 
 const fetchProgressingContests = () => {
   return axiosInstance.get(

--- a/app/components/Contests/ContestListItem.tsx
+++ b/app/components/Contests/ContestListItem.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import React from 'react';
-import { ContestInfo } from './ContestList';
 import { formatDateToYYMMDDHHMM } from '@/app/utils/formatDate';
+import { ContestInfo } from '@/app/types/contest';
 
 interface ContestProps {
   contestInfo: ContestInfo;

--- a/app/components/exams/ExamList.tsx
+++ b/app/components/exams/ExamList.tsx
@@ -5,39 +5,7 @@ import axiosInstance from '../../utils/axiosInstance';
 import { useQuery } from '@tanstack/react-query';
 import NoneExamListItem from './NoneExamListItem';
 import ExamListItem from './ExamListItem';
-
-export interface ExamInfo {
-  problems: string[];
-  students: string[];
-  _id: string;
-  title: string;
-  course: string;
-  content: string;
-  password: string;
-  testPeriod: {
-    start: string; // Date 타입으로 변환할 수도 있습니다.
-    end: string; // Date 타입으로 변환할 수도 있습니다.
-  };
-  writer: {
-    center?: any; // 'null'이거나 더 구체적인 타입이 필요할 수 있습니다.
-    permissions: string[];
-    _id: string;
-    no: string;
-    name: string;
-    email: string;
-    phone: string;
-    department: string;
-    university: string;
-    position: string;
-    role: string;
-    joinedAt: string; // Date 타입으로 변환할 수도 있습니다.
-    updatedAt: string; // Date 타입으로 변환할 수도 있습니다.
-    __v: number;
-  };
-  createdAt: string; // Date 타입으로 변환할 수도 있습니다.
-  updatedAt: string; // Date 타입으로 변환할 수도 있습니다.
-  __v: number;
-}
+import { ExamInfo } from '@/app/types/exam';
 
 // 시험 목록 반환 API (최근 데이터 3개까지)
 const fetchExams = () => {

--- a/app/components/exams/ExamListItem.tsx
+++ b/app/components/exams/ExamListItem.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import React from 'react';
-import { ExamInfo } from './ExamList';
+import { ExamInfo } from '@/app/types/exam';
 import { formatDateToYYMMDDHHMM } from '@/app/utils/formatDate';
 
 interface ExamProps {

--- a/app/contests/components/ContestList.tsx
+++ b/app/contests/components/ContestList.tsx
@@ -5,9 +5,9 @@ import NoneContestListItem from './NoneContestListItem';
 import Loading from '@/app/loading';
 import axiosInstance from '../../utils/axiosInstance';
 import { useQuery } from '@tanstack/react-query';
-import { ContestInfo } from '@/app/components/Contests/ContestList';
+import { ContestInfo } from '@/app/types/contest';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { RenderPaginationButtons } from '@/app/components/RenderPaginationButtons';
 import useDebounce from '@/app/hooks/useDebounce';
 
@@ -16,7 +16,7 @@ interface ContestListProps {
 }
 
 // 대회 목록 반환 API (10개 게시글 단위로)
-const fetchExams = async (page: number, searchQuery: string) => {
+const fetchContests = async (page: number, searchQuery: string) => {
   const response = await axiosInstance.get(
     `${process.env.NEXT_PUBLIC_API_VERSION}/contest/?page=${page}&limit=10&sort=-createdAt&q=title=${searchQuery}`,
   );
@@ -32,7 +32,7 @@ export default function ContestList({ searchQuery }: ContestListProps) {
 
   const { isPending, data } = useQuery({
     queryKey: ['contestList', page, debouncedSearchQuery],
-    queryFn: () => fetchExams(page, searchQuery),
+    queryFn: () => fetchContests(page, searchQuery),
   });
 
   const router = useRouter();

--- a/app/contests/components/ContestListItem.tsx
+++ b/app/contests/components/ContestListItem.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ContestInfo } from '@/app/components/Contests/ContestList';
+import { ContestInfo } from '@/app/types/contest';
 import {
   formatDateToYYMMDDHHMM,
   formatDateToYYMMDD,

--- a/app/exams/components/ExamList.tsx
+++ b/app/exams/components/ExamList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import ExamListItem from './ExamListItem';
 import NoneExamListItem from './NoneExamListItem';
 import Loading from '@/app/loading';
@@ -8,7 +8,7 @@ import axiosInstance from '@/app/utils/axiosInstance';
 import useDebounce from '@/app/hooks/useDebounce';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
-import { ExamInfo } from '@/app/components/exams/ExamList';
+import { ExamInfo } from '@/app/types/exam';
 import { RenderPaginationButtons } from '@/app/components/RenderPaginationButtons';
 
 interface ExamListProps {

--- a/app/exams/components/ExamListItem.tsx
+++ b/app/exams/components/ExamListItem.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { ContestInfo } from '@/app/components/Contests/ContestList';
-import { ExamInfo } from '@/app/components/exams/ExamList';
+import { ExamInfo } from '@/app/types/exam';
 import { formatDateToYYMMDDHHMM } from '@/app/utils/formatDate';
 import { useRouter } from 'next/navigation';
 import React from 'react';

--- a/app/exams/page.tsx
+++ b/app/exams/page.tsx
@@ -57,21 +57,23 @@ export default function Exams() {
                 검색
               </label>
               <p className="text-gray-500 text-xs tracking-widest font-light mt-1">
-                시험명, 수업명, 작성자로 검색
+                시험명, 수업명, 작성자명으로 검색
               </p>
             </div>
-            <div className="relative ml-auto mt-auto bottom-[-0.75rem]">
-              <div className="flex justify-end mb-2">
-                <div className="flex">
-                  <Link
-                    href="exams/register"
-                    className="text-[#f9fafb] bg-[#3a8af9] px-4 py-[0.5rem] rounded-[6px] focus:bg-[#1c6cdb] hover:bg-[#1c6cdb]"
-                  >
-                    등록하기
-                  </Link>
+            {userInfo.role === 'operator' && (
+              <div className="relative ml-auto mt-auto bottom-[-0.75rem]">
+                <div className="flex justify-end mb-2">
+                  <div className="flex">
+                    <Link
+                      href="exams/register"
+                      className="text-[#f9fafb] bg-[#3a8af9] px-4 py-[0.5rem] rounded-[6px] focus:bg-[#1c6cdb] hover:bg-[#1c6cdb]"
+                    >
+                      등록하기
+                    </Link>
+                  </div>
                 </div>
               </div>
-            </div>
+            )}
           </div>
         </form>
 

--- a/app/notices/components/NoticeListItem.tsx
+++ b/app/notices/components/NoticeListItem.tsx
@@ -24,7 +24,6 @@ export default function NoticeListItem() {
       </td>
       <td className="font-medium">신재혁</td>
       <td className="font-medium">2023.06.26</td>
-      <td className="font-medium">5</td>
     </tr>
   );
 }

--- a/app/notices/page.tsx
+++ b/app/notices/page.tsx
@@ -48,7 +48,7 @@ export default function Notices() {
                 검색
               </label>
               <p className="text-gray-500 text-xs tracking-widest font-light mt-1">
-                제목, 내용, 작성자로 검색
+                제목, 작성자명으로 검색
               </p>
             </div>
             <div className="relative ml-auto mt-auto bottom-[-0.75rem]">
@@ -73,20 +73,17 @@ export default function Notices() {
                 <table className="w-full text-sm text-left text-gray-500 dark:text-gray-400">
                   <thead className="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-gray-700 dark:text-gray-400 text-center">
                     <tr>
-                      <th scope="col" className="px-4 py-2">
+                      <th scope="col" className="w-[3.75rem] px-4 py-2">
                         번호
                       </th>
                       <th scope="col" className="px-4 py-2">
                         제목
                       </th>
-                      <th scope="col" className="px-4 py-2">
+                      <th scope="col" className="w-32 px-4 py-2">
                         작성자
                       </th>
-                      <th scope="col" className="px-4 py-2">
+                      <th scope="col" className="w-36 px-4 py-2">
                         작성일
-                      </th>
-                      <th scope="col" className="px-4 py-2">
-                        조회수
                       </th>
                     </tr>
                   </thead>

--- a/app/practices/components/PracticeList.tsx
+++ b/app/practices/components/PracticeList.tsx
@@ -1,34 +1,157 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
-import PracticeListItem from './PracticeListItem';
+import React, { useEffect } from 'react';
 import NonePracticeListItem from './NonePracticeListItem';
 import Loading from '@/app/loading';
+import axiosInstance from '@/app/utils/axiosInstance';
+import useDebounce from '@/app/hooks/useDebounce';
+import { useSearchParams } from 'next/navigation';
+import { useQuery } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+import PracticeListItem from './PracticeListItem';
+import { PracticeInfo } from '@/app/types/practice';
+import { RenderPaginationButtons } from '@/app/components/RenderPaginationButtons';
 
-export default function PracticeList() {
-  const [isLoading, setIsLoading] = useState(true);
-  const [isPracticeListEmpty, setIsPracticeListEmpty] = useState(true);
+interface PracticeListProps {
+  searchQuery: string;
+}
+
+// 연습문제 목록 반환 API (10개 게시글 단위로)
+const fetchPractices = async (page: number, searchQuery: string) => {
+  const response = await axiosInstance.get(
+    `${process.env.NEXT_PUBLIC_API_VERSION}/practice/?page=${page}&limit=10&sort=-createdAt&q=title,writer=${searchQuery}`,
+  );
+  return response.data;
+};
+
+export default function PracticeList({ searchQuery }: PracticeListProps) {
+  const debouncedSearchQuery = useDebounce(searchQuery, 400);
+
+  const params = useSearchParams();
+
+  const page = Number(params?.get('page')) || 1;
+
+  const { isPending, data } = useQuery({
+    queryKey: ['practiceList', page, debouncedSearchQuery],
+    queryFn: () => fetchPractices(page, searchQuery),
+  });
+
+  const router = useRouter();
+
+  const resData = data?.data;
+  const startItemNum = (resData?.page - 1) * 10 + 1;
+  const endItemNum = startItemNum - 1 + resData?.documents.length;
+  const totalPages = Math.ceil(resData?.total / 10);
+
+  const handlePagination = (newPage: number) => {
+    if (newPage < 1 || newPage > totalPages) return;
+    router.push(`/practices?page=${newPage}`);
+  };
 
   useEffect(() => {
-    setIsLoading(false);
-    setIsPracticeListEmpty(false);
-  }, []);
+    // page가 유효한 양의 정수가 아닌 경우, /practices?page=1로 리다이렉트
+    if (!params?.has('page') || !Number.isInteger(page) || page < 1) {
+      router.replace('/practices?page=1');
+    }
+  }, [page, params, router]);
 
-  if (isLoading) return <Loading />;
-  if (isPracticeListEmpty) return <NonePracticeListItem />;
+  if (isPending) return <Loading />;
 
   return (
-    <tbody>
-      <PracticeListItem />
-      <PracticeListItem />
-      <PracticeListItem />
-      <PracticeListItem />
-      <PracticeListItem />
-      <PracticeListItem />
-      <PracticeListItem />
-      <PracticeListItem />
-      <PracticeListItem />
-      <PracticeListItem />
-    </tbody>
+    <div className="mx-auto w-full">
+      <div className="border dark:bg-gray-800 relative overflow-hidden rounded-sm">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm text-left text-gray-500 dark:text-gray-400">
+            <thead className="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-gray-700 dark:text-gray-400 text-center">
+              <tr>
+                <th scope="col" className="w-[3.75rem] px-4 py-2">
+                  번호
+                </th>
+                <th scope="col" className="px-4 py-2">
+                  문제명
+                </th>
+                <th scope="col" className="w-16 px-4 py-2">
+                  난이도
+                </th>
+                <th scope="col" className="w-32 px-4 py-2">
+                  작성자
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {resData?.documents.length === 0 && <NonePracticeListItem />}
+              {resData?.documents.map(
+                (practiceInfo: PracticeInfo, index: number) => (
+                  <PracticeListItem
+                    practiceInfo={practiceInfo}
+                    total={resData.total}
+                    page={page}
+                    index={index}
+                    key={index}
+                  />
+                ),
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <nav
+        className="flex flex-col md:flex-row text-xs justify-between items-start md:items-center space-y-3 md:space-y-0 pl-1 mt-3"
+        aria-label="Table navigation"
+      >
+        <span className="text-gray-500 dark:text-gray-400">
+          <span className="text-gray-500 dark:text-white">
+            {startItemNum} - {endItemNum}
+          </span>{' '}
+          of{' '}
+          <span className="text-gray-500 dark:text-white">{resData.total}</span>
+        </span>
+        <ul className="inline-flex items-stretch -space-x-px">
+          <li>
+            <button
+              onClick={() => handlePagination(Number(page) - 1)}
+              className="flex items-center justify-center h-full py-1.5 px-[0.3rem] ml-0 text-gray-500 bg-white rounded-l-lg border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
+            >
+              <span className="sr-only">Previous</span>
+              <svg
+                className="w-5 h-5"
+                aria-hidden="true"
+                fill="currentColor"
+                viewBox="0 0 20 20"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </button>
+          </li>
+          {RenderPaginationButtons(page, totalPages, handlePagination)}
+          <li>
+            <button
+              onClick={() => handlePagination(Number(page) + 1)}
+              className="flex items-center justify-center h-full py-1.5 px-[0.3rem] leading-tight text-gray-500 bg-white rounded-r-lg border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
+            >
+              <span className="sr-only">Next</span>
+              <svg
+                className="w-5 h-5"
+                aria-hidden="true"
+                fill="currentColor"
+                viewBox="0 0 20 20"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </button>
+          </li>
+        </ul>
+      </nav>
+    </div>
   );
 }

--- a/app/practices/components/PracticeListItem.tsx
+++ b/app/practices/components/PracticeListItem.tsx
@@ -1,9 +1,19 @@
 'use client';
 
+import { PracticeInfo } from '@/app/types/practice';
 import { useRouter } from 'next/navigation';
 import React from 'react';
 
-export default function PracticeListItem() {
+interface PracticeListItemProps {
+  practiceInfo: PracticeInfo;
+  total: number;
+  page: number;
+  index: number;
+}
+
+export default function PracticeListItem(props: PracticeListItemProps) {
+  const { practiceInfo, total, page, index } = props;
+
   const router = useRouter();
 
   return (
@@ -17,10 +27,11 @@ export default function PracticeListItem() {
         scope="row"
         className="px-4 py-3 font-medium text-gray-900 whitespace-nowrap dark:text-white"
       >
-        1
+        {total - (page - 1) * 10 - index}
       </th>
-      <td className="hover:underline focus:underline">A+B</td>
-      <td className="font-medium">신재혁</td>
+      <td className="hover:underline focus:underline">{practiceInfo.title}</td>
+      <td className="">{practiceInfo.score}</td>
+      <td className="font-medium">{practiceInfo.writer.name}</td>
     </tr>
   );
 }

--- a/app/practices/page.tsx
+++ b/app/practices/page.tsx
@@ -1,10 +1,17 @@
-import React from 'react';
+'use client';
+
+import React, { useState } from 'react';
 import Link from 'next/link';
 import PracticeList from './components/PracticeList';
 import Image from 'next/image';
 import pencilImg from '@/public/images/pencil.png';
+import { userInfoStore } from '../store/UserInfo';
 
 export default function Practices() {
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const userInfo = userInfoStore((state: any) => state.userInfo);
+
   return (
     <div className="mt-2 px-5 2lg:px-0 overflow-x-auto">
       <div className="flex flex-col w-[60rem] mx-auto">
@@ -28,6 +35,8 @@ export default function Practices() {
                 className="block pl-7 pt-3 pb-[0.175rem] pr-0 w-full font-normal text-gray-900 bg-transparent border-0 border-b border-gray-400 appearance-none dark:text-white dark:border-gray-600 dark:focus:border-blue-500 focus:outline-none focus:ring-0 focus:border-blue-600 peer"
                 placeholder=" "
                 required
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
               />
               <div className="absolute pt-[0.9rem] left-[-0.9rem] flex items-center pl-3 pointer-events-none">
                 <svg
@@ -51,139 +60,25 @@ export default function Practices() {
                 문제명, 작성자명으로 검색
               </p>
             </div>
-            <div className="relative ml-auto mt-auto bottom-[-0.75rem]">
-              <div className="flex justify-end mb-2">
-                <div className="flex">
-                  <Link
-                    href="/practices/register"
-                    className="text-[#f9fafb] bg-[#3a8af9] px-4 py-[0.5rem] rounded-[6px] focus:bg-[#1c6cdb] hover:bg-[#1c6cdb]"
-                  >
-                    등록하기
-                  </Link>
+            {userInfo.role === 'operator' && (
+              <div className="relative ml-auto mt-auto bottom-[-0.75rem]">
+                <div className="flex justify-end mb-2">
+                  <div className="flex">
+                    <Link
+                      href="/practices/register"
+                      className="text-[#f9fafb] bg-[#3a8af9] px-4 py-[0.5rem] rounded-[6px] focus:bg-[#1c6cdb] hover:bg-[#1c6cdb]"
+                    >
+                      등록하기
+                    </Link>
+                  </div>
                 </div>
               </div>
-            </div>
+            )}
           </div>
         </form>
 
         <section className="dark:bg-gray-900">
-          <div className="mx-auto w-full">
-            <div className="border dark:bg-gray-800 relative overflow-hidden rounded-sm">
-              <div className="overflow-x-auto">
-                <table className="w-full text-sm text-left text-gray-500 dark:text-gray-400">
-                  <thead className="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-gray-700 dark:text-gray-400 text-center">
-                    <tr>
-                      <th scope="col" className="px-4 py-2">
-                        번호
-                      </th>
-                      <th scope="col" className="px-4 py-2">
-                        문제명
-                      </th>
-                      <th scope="col" className="px-4 py-2">
-                        작성자
-                      </th>
-                    </tr>
-                  </thead>
-                  <PracticeList />
-                </table>
-              </div>
-            </div>
-            <nav
-              className="flex flex-col md:flex-row text-xs justify-between items-start md:items-center space-y-3 md:space-y-0 pl-1 mt-3"
-              aria-label="Table navigation"
-            >
-              <span className="text-gray-500 dark:text-gray-400">
-                <span className="text-gray-500 dark:text-white"> 1 - 10</span>{' '}
-                of
-                <span className="text-gray-500 dark:text-white"> 1000</span>
-              </span>
-              <ul className="inline-flex items-stretch -space-x-px">
-                <li>
-                  <a
-                    href="#"
-                    className="flex items-center justify-center h-full py-1.5 px-[0.3rem] ml-0 text-gray-500 bg-white rounded-l-lg border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
-                  >
-                    <span className="sr-only">Previous</span>
-                    <svg
-                      className="w-5 h-5"
-                      aria-hidden="true"
-                      fill="currentColor"
-                      viewBox="0 0 20 20"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        fillRule="evenodd"
-                        d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
-                        clipRule="evenodd"
-                      />
-                    </svg>
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="#"
-                    className="flex items-center justify-center text-sm py-2 px-3 leading-tight text-gray-400 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
-                  >
-                    1
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="#"
-                    className="flex items-center justify-center text-sm py-2 px-3 leading-tight text-gray-400 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
-                  >
-                    2
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="#"
-                    aria-current="page"
-                    className="flex items-center justify-center text-sm z-10 py-2 px-3 leading-tight text-primary-600 bg-primary-50 border border-primary-300 hover:bg-primary-100 hover:text-primary-700 dark:border-gray-700 dark:bg-gray-700 dark:text-white"
-                  >
-                    3
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="#"
-                    className="flex items-center justify-center text-sm py-2 px-3 leading-tight text-gray-400 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
-                  >
-                    ...
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="#"
-                    className="flex items-center justify-center text-sm py-2 px-3 leading-tight text-gray-400 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
-                  >
-                    100
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="#"
-                    className="flex items-center justify-center h-full py-1.5 px-[0.3rem] leading-tight text-gray-500 bg-white rounded-r-lg border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
-                  >
-                    <span className="sr-only">Next</span>
-                    <svg
-                      className="w-5 h-5"
-                      aria-hidden="true"
-                      fill="currentColor"
-                      viewBox="0 0 20 20"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        fillRule="evenodd"
-                        d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-                        clipRule="evenodd"
-                      />
-                    </svg>
-                  </a>
-                </li>
-              </ul>
-            </nav>
-          </div>
+          <PracticeList searchQuery={searchQuery} />
         </section>
       </div>
     </div>

--- a/app/types/contest.ts
+++ b/app/types/contest.ts
@@ -1,0 +1,36 @@
+export interface ContestInfo {
+  password: string | null;
+  isPassword: boolean;
+  problems: string[];
+  applyingPeriod: {
+    start: string;
+    end: string;
+  } | null;
+  contestants: string[];
+  _id: string;
+  title: string;
+  content: string;
+  testPeriod: {
+    start: string; // Date 타입으로 변환할 수도 있습니다.
+    end: string; // Date 타입으로 변환할 수도 있습니다.
+  };
+  writer: {
+    center?: any; // 'null'이거나 더 구체적인 타입이 필요할 수 있습니다.
+    permissions: string[];
+    _id: string;
+    no: string;
+    name: string;
+    email: string;
+    phone: string;
+    department: string;
+    university: string;
+    position: string;
+    role: string;
+    joinedAt: string; // Date 타입으로 변환할 수도 있습니다.
+    updatedAt: string; // Date 타입으로 변환할 수도 있습니다.
+    __v: number;
+  };
+  createdAt: string; // Date 타입으로 변환할 수도 있습니다.
+  updatedAt: string; // Date 타입으로 변환할 수도 있습니다.
+  __v: number;
+}

--- a/app/types/exam.ts
+++ b/app/types/exam.ts
@@ -1,0 +1,32 @@
+export interface ExamInfo {
+  problems: string[];
+  students: string[];
+  _id: string;
+  title: string;
+  course: string;
+  content: string;
+  password: string;
+  testPeriod: {
+    start: string; // Date 타입으로 변환할 수도 있습니다.
+    end: string; // Date 타입으로 변환할 수도 있습니다.
+  };
+  writer: {
+    center?: any; // 'null'이거나 더 구체적인 타입이 필요할 수 있습니다.
+    permissions: string[];
+    _id: string;
+    no: string;
+    name: string;
+    email: string;
+    phone: string;
+    department: string;
+    university: string;
+    position: string;
+    role: string;
+    joinedAt: string; // Date 타입으로 변환할 수도 있습니다.
+    updatedAt: string; // Date 타입으로 변환할 수도 있습니다.
+    __v: number;
+  };
+  createdAt: string; // Date 타입으로 변환할 수도 있습니다.
+  updatedAt: string; // Date 타입으로 변환할 수도 있습니다.
+  __v: number;
+}

--- a/app/types/practice.ts
+++ b/app/types/practice.ts
@@ -1,0 +1,24 @@
+export interface PracticeInfo {
+  parentId: null | string;
+  parentType: string;
+  published: null | boolean;
+  score: number;
+  _id: string;
+  title: string;
+  content: string;
+  ioSet: {
+    inFile: string;
+    outFile: string;
+  }[];
+  options: {
+    maxRealTime: number;
+    maxMemory: number;
+  };
+  writer: {
+    _id: string;
+    name: string;
+  };
+  createdAt: string; // Date 타입으로 변환할 수도 있습니다.
+  updatedAt: string; // Date 타입으로 변환할 수도 있습니다.
+  __v: number;
+}


### PR DESCRIPTION
## 👀 이슈

resolve #151 

## 📌 개요

현재 `Navbar`에 존재하는 `연습문제` 메뉴 클릭 시 해당 게시글 목록이
표시되는 페이지로 라우팅되는데, 이때 목록 내용을 실제 서버로부터 받아와 표시하기
위해 해당 기능을 추가하였습니다.

## 👩‍💻 작업 사항

- `연습문제` 목록 조회 기능 추가

## ✅ 참고 사항

- 기능 추가 전 프론트 사이드에서 게시글 목록 데이터를 하드 코딩했던 UI

![Screenshot 2024-01-27 at 7 31 58 PM](https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/57e5306a-4e61-4602-943b-1442cb681cd0)

- 기능 추가 후 UI

https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/d41e596b-6ba7-4ef4-86c2-a4bb76e8b3ae