### PR TITLE
[feat]: 관리자 권한이 요구되는 페이지 컴포넌트 내 관리자 권한 확인 기능 추가 (#157)

### DIFF
--- a/app/contests/[cid]/edit/page.tsx
+++ b/app/contests/[cid]/edit/page.tsx
@@ -1,6 +1,9 @@
 'use client';
 
 import Loading from '@/app/loading';
+import { userInfoStore } from '@/app/store/UserInfo';
+import { UserInfo } from '@/app/types/user';
+import { fetchCurrentUserInfo } from '@/app/utils/fetchCurrentUserInfo';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
 import React, { useEffect, useRef, useState } from 'react';
@@ -53,6 +56,8 @@ export default function EditContest(props: DefaultProps) {
     isCheckedUsingContestProblemsPwd: true,
     contestProblemsPwd: 'dfkjnfdhreiu5435',
   };
+
+  const updateUserInfo = userInfoStore((state: any) => state.updateUserInfo);
 
   const [isLoading, setIsLoading] = useState(true);
   const [contestName, setContestName] = useState(contestInfo.title);
@@ -172,9 +177,17 @@ export default function EditContest(props: DefaultProps) {
     alert('수정 기능 개발 예정');
   };
 
+  // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
-    setIsLoading(false);
-  }, []);
+    fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
+      if (res.isAuth && res.role !== 'operator') {
+        alert('접근 권한이 없습니다.');
+        router.back();
+        return;
+      }
+      setIsLoading(false);
+    });
+  }, [updateUserInfo, router]);
 
   if (isLoading) return <Loading />;
 

--- a/app/contests/[cid]/problems/[problemId]/edit/page.tsx
+++ b/app/contests/[cid]/problems/[problemId]/edit/page.tsx
@@ -2,6 +2,9 @@
 
 import MyDropzone from '@/app/components/MyDropzone';
 import Loading from '@/app/loading';
+import { userInfoStore } from '@/app/store/UserInfo';
+import { UserInfo } from '@/app/types/user';
+import { fetchCurrentUserInfo } from '@/app/utils/fetchCurrentUserInfo';
 import { useRouter } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 
@@ -28,6 +31,8 @@ export default function EditContestProblem(props: DefaultProps) {
       'http://localhost:3000/in_and_out/3.out',
     ],
   };
+
+  const updateUserInfo = userInfoStore((state: any) => state.updateUserInfo);
 
   const [isLoading, setIsLoading] = useState(true);
   const [problemName, setProblemName] = useState(problemInfo.title);
@@ -139,9 +144,17 @@ export default function EditContestProblem(props: DefaultProps) {
     // console.log('In/Out: ', uploadedProblemInAndOutFileUrls);
   };
 
+  // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
-    setIsLoading(false);
-  }, []);
+    fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
+      if (res.isAuth && res.role !== 'operator') {
+        alert('접근 권한이 없습니다.');
+        router.back();
+        return;
+      }
+      setIsLoading(false);
+    });
+  }, [updateUserInfo, router]);
 
   if (isLoading) return <Loading />;
 

--- a/app/contests/[cid]/problems/register/page.tsx
+++ b/app/contests/[cid]/problems/register/page.tsx
@@ -1,8 +1,12 @@
 'use client';
 
 import MyDropzone from '@/app/components/MyDropzone';
+import Loading from '@/app/loading';
+import { userInfoStore } from '@/app/store/UserInfo';
+import { UserInfo } from '@/app/types/user';
+import { fetchCurrentUserInfo } from '@/app/utils/fetchCurrentUserInfo';
 import { useRouter } from 'next/navigation';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 interface DefaultProps {
   params: {
@@ -11,6 +15,9 @@ interface DefaultProps {
 }
 
 export default function RegisterContestProblem(props: DefaultProps) {
+  const updateUserInfo = userInfoStore((state: any) => state.updateUserInfo);
+
+  const [isLoading, setIsLoading] = useState(true);
   const [problemName, setProblemName] = useState('');
   const [maxExeTime, setMaxExeTime] = useState<number>();
   const [maxMemCap, setMaxMemCap] = useState<number>();
@@ -116,6 +123,20 @@ export default function RegisterContestProblem(props: DefaultProps) {
     // console.log('PDF: ', uploadedProblemPdfFileUrl);
     // console.log('In/Out: ', uploadedProblemInAndOutFileUrls);
   };
+
+  // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
+  useEffect(() => {
+    fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
+      if (res.isAuth && res.role !== 'operator') {
+        alert('접근 권한이 없습니다.');
+        router.back();
+        return;
+      }
+      setIsLoading(false);
+    });
+  }, [updateUserInfo, router]);
+
+  if (isLoading) return <Loading />;
 
   return (
     <div className="mt-2 px-5 2lg:px-0 overflow-x-auto">

--- a/app/contests/[cid]/submits/[submitId]/page.tsx
+++ b/app/contests/[cid]/submits/[submitId]/page.tsx
@@ -1,6 +1,9 @@
 'use client';
 
 import Loading from '@/app/loading';
+import { userInfoStore } from '@/app/store/UserInfo';
+import { UserInfo } from '@/app/types/user';
+import { fetchCurrentUserInfo } from '@/app/utils/fetchCurrentUserInfo';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
 import React, { useEffect, useState } from 'react';
@@ -17,6 +20,8 @@ const MarkdownPreview = dynamic(
 );
 
 export default function UsersContestSubmit(props: DefaultProps) {
+  const updateUserInfo = userInfoStore((state: any) => state.updateUserInfo);
+
   const [isLoading, setIsLoading] = useState(true);
 
   const cid = props.params.cid;
@@ -27,9 +32,17 @@ export default function UsersContestSubmit(props: DefaultProps) {
     router.push(`/contests/${cid}/submits`);
   };
 
+  // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
-    setIsLoading(false);
-  }, []);
+    fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
+      if (res.isAuth && res.role !== 'operator') {
+        alert('접근 권한이 없습니다.');
+        router.back();
+        return;
+      }
+      setIsLoading(false);
+    });
+  }, [updateUserInfo, router]);
 
   if (isLoading) return <Loading />;
 

--- a/app/contests/[cid]/submits/page.tsx
+++ b/app/contests/[cid]/submits/page.tsx
@@ -6,6 +6,10 @@ import { useEffect, useState } from 'react';
 import Loading from '@/app/loading';
 import Image from 'next/image';
 import codeImg from '@/public/images/code.png';
+import { userInfoStore } from '@/app/store/UserInfo';
+import { fetchCurrentUserInfo } from '@/app/utils/fetchCurrentUserInfo';
+import { UserInfo } from '@/app/types/user';
+import { useRouter } from 'next/navigation';
 
 interface DefaultProps {
   params: {
@@ -14,15 +18,27 @@ interface DefaultProps {
 }
 
 export default function UsersContestSubmits(props: DefaultProps) {
+  const updateUserInfo = userInfoStore((state: any) => state.updateUserInfo);
+
   const [isLoading, setIsLoading] = useState(true);
 
-  useEffect(() => {
-    setIsLoading(false);
-  }, []);
-
-  if (isLoading) return <Loading />;
+  const router = useRouter();
 
   const cid = props.params.cid;
+
+  // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
+  useEffect(() => {
+    fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
+      if (res.isAuth && res.role !== 'operator') {
+        alert('접근 권한이 없습니다.');
+        router.back();
+        return;
+      }
+      setIsLoading(false);
+    });
+  }, [updateUserInfo, router]);
+
+  if (isLoading) return <Loading />;
 
   return (
     <div className="mt-2 px-5 2lg:px-0 overflow-x-auto">
@@ -39,7 +55,7 @@ export default function UsersContestSubmits(props: DefaultProps) {
 
           <div className="lift-up">
             <span className="ml-4 text-3xl font-semibold tracking-wide">
-              문제 목록
+              코드 제출 목록
             </span>
             <Link
               href={`/contests/${cid}`}

--- a/app/exams/[eid]/edit/page.tsx
+++ b/app/exams/[eid]/edit/page.tsx
@@ -1,6 +1,9 @@
 'use client';
 
 import Loading from '@/app/loading';
+import { userInfoStore } from '@/app/store/UserInfo';
+import { UserInfo } from '@/app/types/user';
+import { fetchCurrentUserInfo } from '@/app/utils/fetchCurrentUserInfo';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
@@ -57,6 +60,8 @@ export default function EditExam(props: DefaultProps) {
     isCheckedUsingExamPwd: true,
     examPwd: 'owrejreoi12321',
   };
+
+  const updateUserInfo = userInfoStore((state: any) => state.updateUserInfo);
 
   const [isLoading, setIsLoading] = useState(true);
   const [examName, setExamName] = useState(examInfo.examName);
@@ -150,9 +155,17 @@ export default function EditExam(props: DefaultProps) {
     alert('수정 기능 개발 예정');
   };
 
+  // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
-    setIsLoading(false);
-  }, []);
+    fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
+      if (res.isAuth && res.role !== 'operator') {
+        alert('접근 권한이 없습니다.');
+        router.back();
+        return;
+      }
+      setIsLoading(false);
+    });
+  }, [updateUserInfo, router]);
 
   if (isLoading) return <Loading />;
 

--- a/app/exams/[eid]/problems/[problemId]/edit/page.tsx
+++ b/app/exams/[eid]/problems/[problemId]/edit/page.tsx
@@ -2,6 +2,9 @@
 
 import MyDropzone from '@/app/components/MyDropzone';
 import Loading from '@/app/loading';
+import { userInfoStore } from '@/app/store/UserInfo';
+import { UserInfo } from '@/app/types/user';
+import { fetchCurrentUserInfo } from '@/app/utils/fetchCurrentUserInfo';
 import { useRouter } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 
@@ -28,6 +31,8 @@ export default function EditExamProblem(props: DefaultProps) {
       'http://localhost:3000/in_and_out/3.out',
     ],
   };
+
+  const updateUserInfo = userInfoStore((state: any) => state.updateUserInfo);
 
   const [isLoading, setIsLoading] = useState(true);
   const [problemName, setProblemName] = useState(problemInfo.title);
@@ -139,9 +144,17 @@ export default function EditExamProblem(props: DefaultProps) {
     // console.log('In/Out: ', uploadedProblemInAndOutFileUrls);
   };
 
+  // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
-    setIsLoading(false);
-  }, []);
+    fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
+      if (res.isAuth && res.role !== 'operator') {
+        alert('접근 권한이 없습니다.');
+        router.back();
+        return;
+      }
+      setIsLoading(false);
+    });
+  }, [updateUserInfo, router]);
 
   if (isLoading) return <Loading />;
 

--- a/app/exams/[eid]/problems/register/page.tsx
+++ b/app/exams/[eid]/problems/register/page.tsx
@@ -1,8 +1,12 @@
 'use client';
 
 import MyDropzone from '@/app/components/MyDropzone';
+import Loading from '@/app/loading';
+import { userInfoStore } from '@/app/store/UserInfo';
+import { UserInfo } from '@/app/types/user';
+import { fetchCurrentUserInfo } from '@/app/utils/fetchCurrentUserInfo';
 import { useRouter } from 'next/navigation';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 interface DefaultProps {
   params: {
@@ -11,6 +15,9 @@ interface DefaultProps {
 }
 
 export default function RegisterExamProblem(props: DefaultProps) {
+  const updateUserInfo = userInfoStore((state: any) => state.updateUserInfo);
+
+  const [isLoading, setIsLoading] = useState(true);
   const [problemName, setProblemName] = useState('');
   const [maxExeTime, setMaxExeTime] = useState<number>();
   const [maxMemCap, setMaxMemCap] = useState<number>();
@@ -100,6 +107,20 @@ export default function RegisterExamProblem(props: DefaultProps) {
     // console.log('PDF: ', uploadedProblemPdfFileUrl);
     // console.log('In/Out: ', uploadedProblemInAndOutFileUrls);
   };
+
+  // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
+  useEffect(() => {
+    fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
+      if (res.isAuth && res.role !== 'operator') {
+        alert('접근 권한이 없습니다.');
+        router.back();
+        return;
+      }
+      setIsLoading(false);
+    });
+  }, [updateUserInfo, router]);
+
+  if (isLoading) return <Loading />;
 
   return (
     <div className="mt-2 px-5 2lg:px-0 overflow-x-auto">

--- a/app/exams/[eid]/submits/[submitId]/page.tsx
+++ b/app/exams/[eid]/submits/[submitId]/page.tsx
@@ -1,6 +1,9 @@
 'use client';
 
 import Loading from '@/app/loading';
+import { userInfoStore } from '@/app/store/UserInfo';
+import { UserInfo } from '@/app/types/user';
+import { fetchCurrentUserInfo } from '@/app/utils/fetchCurrentUserInfo';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
 import React, { useEffect, useState } from 'react';
@@ -17,6 +20,8 @@ const MarkdownPreview = dynamic(
 );
 
 export default function UsersExamSubmit(props: DefaultProps) {
+  const updateUserInfo = userInfoStore((state: any) => state.updateUserInfo);
+
   const [isLoading, setIsLoading] = useState(true);
 
   const eid = props.params.eid;
@@ -27,9 +32,17 @@ export default function UsersExamSubmit(props: DefaultProps) {
     router.push(`/exams/${eid}/submits`);
   };
 
+  // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
-    setIsLoading(false);
-  }, []);
+    fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
+      if (res.isAuth && res.role !== 'operator') {
+        alert('접근 권한이 없습니다.');
+        router.back();
+        return;
+      }
+      setIsLoading(false);
+    });
+  }, [updateUserInfo, router]);
 
   if (isLoading) return <Loading />;
 

--- a/app/exams/[eid]/submits/page.tsx
+++ b/app/exams/[eid]/submits/page.tsx
@@ -6,6 +6,10 @@ import { useEffect, useState } from 'react';
 import Loading from '@/app/loading';
 import Image from 'next/image';
 import codeImg from '@/public/images/code.png';
+import { fetchCurrentUserInfo } from '@/app/utils/fetchCurrentUserInfo';
+import { UserInfo } from '@/app/types/user';
+import { userInfoStore } from '@/app/store/UserInfo';
+import { useRouter } from 'next/navigation';
 
 interface DefaultProps {
   params: {
@@ -14,15 +18,27 @@ interface DefaultProps {
 }
 
 export default function UsersExamSubmits(props: DefaultProps) {
+  const updateUserInfo = userInfoStore((state: any) => state.updateUserInfo);
+
   const [isLoading, setIsLoading] = useState(true);
 
-  useEffect(() => {
-    setIsLoading(false);
-  }, []);
-
-  if (isLoading) return <Loading />;
+  const router = useRouter();
 
   const eid = props.params.eid;
+
+  // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
+  useEffect(() => {
+    fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
+      if (res.isAuth && res.role !== 'operator') {
+        alert('접근 권한이 없습니다.');
+        router.back();
+        return;
+      }
+      setIsLoading(false);
+    });
+  }, [updateUserInfo, router]);
+
+  if (isLoading) return <Loading />;
 
   return (
     <div className="mt-2 px-5 2lg:px-0 overflow-x-auto">

--- a/app/exams/register/page.tsx
+++ b/app/exams/register/page.tsx
@@ -1,8 +1,12 @@
 'use client';
 
+import Loading from '@/app/loading';
+import { userInfoStore } from '@/app/store/UserInfo';
+import { UserInfo } from '@/app/types/user';
+import { fetchCurrentUserInfo } from '@/app/utils/fetchCurrentUserInfo';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 const DynamicEditor = dynamic(
   () => import('@/app/components/CKEditor/CKEditor'),
@@ -12,6 +16,9 @@ const DynamicEditor = dynamic(
 );
 
 export default function RegisterExam() {
+  const updateUserInfo = userInfoStore((state: any) => state.updateUserInfo);
+
+  const [isLoading, setIsLoading] = useState(true);
   const [examName, setExamName] = useState('');
   const [courseName, setCourseName] = useState('');
   const [editorContent, setEditorContent] = useState('');
@@ -94,6 +101,20 @@ export default function RegisterExam() {
 
     alert('등록 기능 개발 예정');
   };
+
+  // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
+  useEffect(() => {
+    fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
+      if (res.isAuth && res.role !== 'operator') {
+        alert('접근 권한이 없습니다.');
+        router.back();
+        return;
+      }
+      setIsLoading(false);
+    });
+  }, [updateUserInfo, router]);
+
+  if (isLoading) return <Loading />;
 
   return (
     <div className="mt-2 px-5 2lg:px-0 overflow-x-auto">
@@ -189,7 +210,7 @@ export default function RegisterExam() {
               id="start-date"
               name="start-date"
               value={examStartDateTime.slice(0, 16)}
-              min={new Date().toISOString().slice(0, 16)}
+              min={currentDate}
               className="text-sm appearance-none border rounded shadow py-[0.375rem] px-2 text-gray-500"
               onChange={(e) => setExamStartDateTime(e.target.value)}
             />
@@ -199,7 +220,7 @@ export default function RegisterExam() {
               id="end-date"
               name="end-date"
               value={examEndDateTime.slice(0, 16)}
-              min={new Date().toISOString().slice(0, 16)}
+              min={currentDate}
               className="text-sm appearance-none border rounded shadow py-[0.375rem] px-2 text-gray-500"
               onChange={(e) => setExamEndDateTime(e.target.value)}
             />

--- a/app/notices/[nid]/edit/page.tsx
+++ b/app/notices/[nid]/edit/page.tsx
@@ -1,6 +1,9 @@
 'use client';
 
 import Loading from '@/app/loading';
+import { userInfoStore } from '@/app/store/UserInfo';
+import { UserInfo } from '@/app/types/user';
+import { fetchCurrentUserInfo } from '@/app/utils/fetchCurrentUserInfo';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
@@ -67,6 +70,8 @@ export default function EditNotice(props: DefaultProps) {
     noticePwd: 'owrejreoi12321',
   };
 
+  const updateUserInfo = userInfoStore((state: any) => state.updateUserInfo);
+
   const [isLoading, setIsLoading] = useState(true);
   const [noticeName, setNoticeName] = useState(noticeInfo.title);
   const [editorContent, setEditorContent] = useState(noticeInfo.content);
@@ -128,9 +133,17 @@ export default function EditNotice(props: DefaultProps) {
     alert('수정 기능 개발 예정');
   };
 
+  // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
-    setIsLoading(false);
-  }, []);
+    fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
+      if (res.isAuth && res.role !== 'operator') {
+        alert('접근 권한이 없습니다.');
+        router.back();
+        return;
+      }
+      setIsLoading(false);
+    });
+  }, [updateUserInfo, router]);
 
   if (isLoading) return <Loading />;
 

--- a/app/notices/register/page.tsx
+++ b/app/notices/register/page.tsx
@@ -1,8 +1,12 @@
 'use client';
 
+import Loading from '@/app/loading';
+import { userInfoStore } from '@/app/store/UserInfo';
+import { UserInfo } from '@/app/types/user';
+import { fetchCurrentUserInfo } from '@/app/utils/fetchCurrentUserInfo';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 const DynamicEditor = dynamic(
   () => import('@/app/components/CKEditor/CKEditor'),
@@ -12,6 +16,9 @@ const DynamicEditor = dynamic(
 );
 
 export default function RegisterNotice() {
+  const updateUserInfo = userInfoStore((state: any) => state.updateUserInfo);
+
+  const [isLoading, setIsLoading] = useState(true);
   const [noticeName, setNoticeName] = useState('');
   const [editorContent, setEditorContent] = useState('');
   const [isCheckedUsingPwd, setIsCheckedUsingPwd] = useState(false);
@@ -67,6 +74,20 @@ export default function RegisterNotice() {
 
     alert('등록 기능 개발 예정');
   };
+
+  // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
+  useEffect(() => {
+    fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
+      if (res.isAuth && res.role !== 'operator') {
+        alert('접근 권한이 없습니다.');
+        router.back();
+        return;
+      }
+      setIsLoading(false);
+    });
+  }, [updateUserInfo, router]);
+
+  if (isLoading) return <Loading />;
 
   return (
     <div className="mt-2 px-5 2lg:px-0 overflow-x-auto">

--- a/app/practices/[pid]/edit/page.tsx
+++ b/app/practices/[pid]/edit/page.tsx
@@ -2,6 +2,9 @@
 
 import MyDropzone from '@/app/components/MyDropzone';
 import Loading from '@/app/loading';
+import { userInfoStore } from '@/app/store/UserInfo';
+import { UserInfo } from '@/app/types/user';
+import { fetchCurrentUserInfo } from '@/app/utils/fetchCurrentUserInfo';
 import { useRouter } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 
@@ -26,6 +29,8 @@ export default function EditPractice(props: DefaultProps) {
       'http://localhost:3000/in_and_out/3.out',
     ],
   };
+
+  const updateUserInfo = userInfoStore((state: any) => state.updateUserInfo);
 
   const [isLoading, setIsLoading] = useState(true);
   const [practiceName, setPracticeName] = useState(practiceInfo.title);
@@ -122,9 +127,17 @@ export default function EditPractice(props: DefaultProps) {
     // console.log('In/Out: ', uploadedProblemInAndOutFileUrls);
   };
 
+  // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
-    setIsLoading(false);
-  }, []);
+    fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
+      if (res.isAuth && res.role !== 'operator') {
+        alert('접근 권한이 없습니다.');
+        router.back();
+        return;
+      }
+      setIsLoading(false);
+    });
+  }, [updateUserInfo, router]);
 
   if (isLoading) return <Loading />;
 

--- a/app/practices/register/page.tsx
+++ b/app/practices/register/page.tsx
@@ -1,10 +1,17 @@
 'use client';
 
 import MyDropzone from '@/app/components/MyDropzone';
+import Loading from '@/app/loading';
+import { userInfoStore } from '@/app/store/UserInfo';
+import { UserInfo } from '@/app/types/user';
+import { fetchCurrentUserInfo } from '@/app/utils/fetchCurrentUserInfo';
 import { useRouter } from 'next/navigation';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 export default function RegisterPractice() {
+  const updateUserInfo = userInfoStore((state: any) => state.updateUserInfo);
+
+  const [isLoading, setIsLoading] = useState(true);
   const [practiceName, setPracticeName] = useState('');
   const [maxExeTime, setMaxExeTime] = useState<number>();
   const [maxMemCap, setMaxMemCap] = useState<number>();
@@ -92,6 +99,20 @@ export default function RegisterPractice() {
     // console.log('PDF: ', uploadedProblemPdfFileUrl);
     // console.log('In/Out: ', uploadedProblemInAndOutFileUrls);
   };
+
+  // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
+  useEffect(() => {
+    fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
+      if (res.isAuth && res.role !== 'operator') {
+        alert('접근 권한이 없습니다.');
+        router.back();
+        return;
+      }
+      setIsLoading(false);
+    });
+  }, [updateUserInfo, router]);
+
+  if (isLoading) return <Loading />;
 
   return (
     <div className="mt-2 px-5 2lg:px-0 overflow-x-auto">


### PR DESCRIPTION
## 👀 이슈

resolve #157 

## 📌 개요

게시글 `등록/수정`과 같이 시스템 관리자의 권한이 필요한 페이지 컴포넌트 내에서
관리자 권한 확인 기능을 추가하였습니다.

## 👩‍💻 작업 사항

- 관리자 권한이 요구되는 페이지 컴포넌트 내 **관리자 권한 확인** 기능 추가

## ✅ 참고 사항

없습니다