### PR TITLE
[design]: {CKEditor/uiw/react-markdown-preview} 디자인 변경(#162)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -64,6 +64,10 @@
   letter-spacing: 0.005rem;
 }
 
+.ck strong {
+  color: inherit;
+}
+
 .ck h2,
 h3,
 h4 {
@@ -85,6 +89,13 @@ h4 {
   font-size: 1.25em;
 }
 
+.markdown-preview strong,
+s,
+u,
+i {
+  color: inherit;
+}
+
 .ck ul,
 ol {
   margin-left: 1.75rem;
@@ -98,7 +109,14 @@ ol {
 }
 
 .ck p {
-  margin: 0 !important;
+  margin-bottom: 0 !important;
+}
+
+.ck .text-huge,
+.text-big,
+.text-small,
+.text-tiny {
+  line-height: 1.5;
 }
 
 /* uiw markdown(Editor) CSS */
@@ -117,13 +135,46 @@ ol {
   letter-spacing: 0.04rem;
 }
 
+.markdown-preview p {
+  margin-bottom: 0 !important;
+}
+
+.markdown-preview strong,
+s,
+u,
+i {
+  color: inherit;
+}
+
+.markdown-preview .text-huge {
+  font-size: 1.8em;
+}
+
+.markdown-preview .text-big {
+  font-size: 1.4em;
+}
+
+.markdown-preview .text-small {
+  font-size: 0.85em;
+}
+
+.markdown-preview .text-tiny {
+  font-size: 0.7em;
+}
+
 .markdown-preview ul {
   list-style-type: disc;
 }
 
+.markdown-preview ol {
+  list-style-type: disc;
+}
+
 .markdown-preview blockquote {
+  font-style: normal !important;
   padding: 1rem 1.75rem !important;
   border-left: 0.25rem solid #2fc27b !important;
+  background-color: #fafcfe;
 }
 
 .markdown-preview img {


### PR DESCRIPTION
## 👀 이슈

resolve #162 

## 📌 개요

**`CKEditor`** 내에서 글자색을 붉은색으로 변경 후 **Bold**체로 변경하거나,
글자 크기를 변경했는데, 스타일이 적용되지 않는 문제,  행간이 게시글 작성 때와 다른
상태로 적용되는 등의 CSS 스타일 미적용 이슈가 발생하여, 이를 해결하고자 **`globals.css`**
코드를 수정하였습니다.

## 👩‍💻 작업 사항

- **`globals.css`** 파일 내 `CKEditor/uiw/react-markdown-preview` 부분 CSS 스타일 수정

## ✅ 참고 사항

- 디자인 변경 이전의 **CKEditor UI**
> <img width="1247" alt="Screenshot 2024-02-02 at 7 11 20 AM" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/848be7e3-6801-4913-86bd-117377cbe892">

<br />

- 디자인 변경 이후의 **CKEditor UI** (글자색과 행간이 올바른 상태의 디자인으로 변경됨)
> <img width="1247" alt="Screenshot 2024-02-02 at 7 10 53 AM" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/e90ef5b2-76ef-413b-a7b2-f990f654d385">

---

- 디자인 변경 이전의 **uiw/react-markdown-preview UI**
> <img width="1247" alt="Screenshot 2024-02-02 at 7 06 33 AM" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/8b788345-5c31-4efb-b01f-b3fdba8982fb">

<br />

- 디자인 변경 이후의 **uiw/react-markdown-preview UI** (글자색, 글자 크기, 행간이 올바른 상태의 디자인으로 변경됨)
> <img width="1247" alt="Screenshot 2024-02-02 at 7 05 55 AM" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/4c0f6d47-f8f8-406f-b881-a2c2173aff45">