### PR TITLE
[fix]: axiosInstance response interceptor 내에 500 에러 처리 로직 추가 (#162)

### DIFF
--- a/app/utils/axiosInstance.ts
+++ b/app/utils/axiosInstance.ts
@@ -23,11 +23,22 @@ axiosInstance.interceptors.response.use(
   },
   (error) => {
     // 응답 에러 처리
-    if (error.response && error.response.status === 401) {
-      localStorage.removeItem('access-token');
-      localStorage.removeItem('refresh-token');
-      localStorage.removeItem('activeAuthorization');
-      if (typeof window !== 'undefined') window.location.href = '/login';
+    if (error.response) {
+      switch (error.response.status) {
+        case 401:
+          // 401 Unauthorized 에러 처리
+          localStorage.removeItem('access-token');
+          localStorage.removeItem('refresh-token');
+          localStorage.removeItem('activeAuthorization');
+          if (typeof window !== 'undefined') window.location.href = '/login';
+          break;
+        case 500:
+          // 500 Internal Server Error 에러 처리
+          alert('서버에 오류가 발생하였습니다. 잠시 후 다시 시도해주세요.');
+          break;
+        default:
+          break;
+      }
     }
     return Promise.reject(error);
   },


### PR DESCRIPTION
## 👀 이슈

resolve #164 

## 📌 개요

서버의 문제로 http 응답의 `status code`가 `500(Internal Server Error)`일 경우
홈페이지 내에서 해당 에러가 발생하였음을 안내할 수 있도록 axiosInstance response
내에 관련 로직을 추가하였습니다.

## 👩‍💻 작업 사항

- axiosInstance response interceptor 내에 `500(Internal Server Error)` 에러에 대한 안내 메시지 표시 로직 추가

## ✅ 참고 사항

https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/97867b72-7211-45e9-88ca-e3680af9efeb