### PR TITLE
[fix]: 메인페이지 `추가된 시험` 요소 fetching Pending 상태의 표시에 대한 UI 요소 추가 (#166)

### DIFF
--- a/app/components/exams/DummyExamListItem.tsx
+++ b/app/components/exams/DummyExamListItem.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function DummyExamListItem() {
+  return (
+    <div className="relative flex flex-col gap-4 bg-[#f7f7f7] text-gray-500 px-3 py-[3.15rem] group">
+      {''}
+      <div className="absolute right-0 bottom-0 border-l-[0.6rem] border-l-[#eee] border-t-[0.6rem] border-t-[#eee] border-b-[0.6rem] border-b-white border-r-[0.6rem] border-r-white group-hover:border-l-[#3274ba] group-hover:border-t-[#3274ba] ease-in duration-100"></div>
+    </div>
+  );
+}

--- a/app/components/exams/ExamList.tsx
+++ b/app/components/exams/ExamList.tsx
@@ -5,6 +5,7 @@ import axiosInstance from '../../utils/axiosInstance';
 import { useQuery } from '@tanstack/react-query';
 import NoneExamListItem from './NoneExamListItem';
 import ExamListItem from './ExamListItem';
+import DummyExamListItem from './DummyExamListItem'; // DummyExamListItem 컴포넌트를 import 해야 합니다.
 import { ExamInfo } from '@/app/types/exam';
 
 // 시험 목록 반환 API (최근 데이터 3개까지)
@@ -15,20 +16,37 @@ const fetchExams = () => {
 };
 
 export default function ExamList() {
-  const { data } = useQuery({
+  const { isPending, data } = useQuery({
     queryKey: ['examList'],
     queryFn: fetchExams,
   });
 
   const resData = data?.data.data;
+  const examCnt = resData?.documents.length || 0;
 
-  if (resData?.documents.length === 0) return <NoneExamListItem />;
+  // DummyExamListItem 컴포넌트를 필요한 만큼 렌더링하기 위한 배열을 생성합니다.
+  const dummyItemsCount = 3 - examCnt;
+  const dummyItems = Array.from({ length: dummyItemsCount }, (_, index) => (
+    <DummyExamListItem key={`dummy-${index}`} />
+  ));
+
+  if (isPending) {
+    const loadingItems = Array.from({ length: 3 }, (_, index) => (
+      <DummyExamListItem key={`loading-${index}`} />
+    ));
+    return <>{loadingItems}</>;
+  }
+
+  if (examCnt === 0) {
+    return <NoneExamListItem />;
+  }
 
   return (
     <>
       {resData?.documents.map((examInfo: ExamInfo) => (
         <ExamListItem examInfo={examInfo} key={examInfo._id} />
       ))}
+      {dummyItems}
     </>
   );
 }

--- a/app/components/exams/NoneExamListItem.tsx
+++ b/app/components/exams/NoneExamListItem.tsx
@@ -1,7 +1,16 @@
 import React from 'react';
+import DummyExamListemItem from './DummyExamListItem';
 
 export default function NoneExamListItem() {
   return (
-    <div className="text-gray-500 border p-2">조회된 시험 정보가 없습니다</div>
+    <>
+      <div className="relative flex flex-col gap-4 bg-[#f7f7f7] text-gray-500 px-3 py-[2.5rem] group">
+        조회된 시험 정보가 없습니다
+        <div className="absolute right-0 bottom-0 border-l-[0.6rem] border-l-[#eee] border-t-[0.6rem] border-t-[#eee] border-b-[0.6rem] border-b-white border-r-[0.6rem] border-r-white group-hover:border-l-[#3274ba] group-hover:border-t-[#3274ba] ease-in duration-100"></div>
+      </div>
+      {Array.from({ length: 2 }, (_, index) => (
+        <DummyExamListemItem key={index} />
+      ))}
+    </>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -13,13 +13,6 @@
   -o-animation: fadeIn 3s; /* Opera */
 }
 
-.fade-in-fast {
-  animation: fadeIn 0.75s;
-  -moz-animation: fadeIn 0.75s; /* Firefox */
-  -webkit-animation: fadeIn 0.75s; /* Safari and Chrome */
-  -o-animation: fadeIn 0.75s; /* Opera */
-}
-
 .bright-in {
   animation: brightIn 3s;
   -moz-animation: brightIn 3s; /* Firefox */


### PR DESCRIPTION
## 👀 이슈

resolve #166 

## 📌 개요

메인페이지 내 **추가된 시험** 요소에서 서버로부터 데이터를 받아오기 전까지
Pending 상태에 대한 표시를 하기 위해 UI 렌더링 요소를 추가하였습니다.

## 👩‍💻 작업 사항

- 메인페이지 컴포넌트 내 `추가된 시험` 요소 fetching Pending 상태의 표시에 대한 UI 렌더링 코드  추가

## ✅ 참고 사항

- 기능 수정 전 UI (Pending 상태일 떄)
> 빈 박스가 보이지 않음.
> <img width="1310" alt="Screenshot 2024-02-04 at 11 39 27 AM" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/046aa60e-d14c-412d-ae37-f4e38cf0cdb7">

- 기능 수정 후 UI (Pending 상태일 때)
> 빈 박스가 표시됨.
> <img width="1310" alt="Screenshot 2024-02-04 at 11 39 33 AM" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/c3672c15-0fef-460e-b17f-57940dd43cd1">