### PR TITLE
[fix]: 페이지 별 접근 권한 확인 로직 수정 (#170)

### DIFF
--- a/app/contests/[cid]/edit/page.tsx
+++ b/app/contests/[cid]/edit/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { OPERATOR_ROLES } from '@/app/constants/role';
 import Loading from '@/app/loading';
 import { userInfoStore } from '@/app/store/UserInfo';
 import { UserInfo } from '@/app/types/user';
@@ -177,7 +178,7 @@ export default function EditContest(props: DefaultProps) {
   // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
     fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
-      if (res.isAuth && res.role !== 'operator') {
+      if (res.isAuth && !OPERATOR_ROLES.includes(res.role)) {
         alert('접근 권한이 없습니다.');
         router.back();
         return;

--- a/app/contests/[cid]/problems/[problemId]/edit/page.tsx
+++ b/app/contests/[cid]/problems/[problemId]/edit/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import MyDropzone from '@/app/components/MyDropzone';
+import { OPERATOR_ROLES } from '@/app/constants/role';
 import Loading from '@/app/loading';
 import { userInfoStore } from '@/app/store/UserInfo';
 import { UserInfo } from '@/app/types/user';
@@ -147,7 +148,7 @@ export default function EditContestProblem(props: DefaultProps) {
   // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
     fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
-      if (res.isAuth && res.role !== 'operator') {
+      if (res.isAuth && !OPERATOR_ROLES.includes(res.role)) {
         alert('접근 권한이 없습니다.');
         router.back();
         return;

--- a/app/contests/[cid]/problems/register/page.tsx
+++ b/app/contests/[cid]/problems/register/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import MyDropzone from '@/app/components/MyDropzone';
+import { OPERATOR_ROLES } from '@/app/constants/role';
 import Loading from '@/app/loading';
 import { userInfoStore } from '@/app/store/UserInfo';
 import { UserInfo } from '@/app/types/user';
@@ -127,7 +128,7 @@ export default function RegisterContestProblem(props: DefaultProps) {
   // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
     fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
-      if (res.isAuth && res.role !== 'operator') {
+      if (res.isAuth && !OPERATOR_ROLES.includes(res.role)) {
         alert('접근 권한이 없습니다.');
         router.back();
         return;

--- a/app/contests/[cid]/submits/[submitId]/page.tsx
+++ b/app/contests/[cid]/submits/[submitId]/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { OPERATOR_ROLES } from '@/app/constants/role';
 import Loading from '@/app/loading';
 import { userInfoStore } from '@/app/store/UserInfo';
 import { UserInfo } from '@/app/types/user';
@@ -35,7 +36,7 @@ export default function UsersContestSubmit(props: DefaultProps) {
   // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
     fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
-      if (res.isAuth && res.role !== 'operator') {
+      if (res.isAuth && !OPERATOR_ROLES.includes(res.role)) {
         alert('접근 권한이 없습니다.');
         router.back();
         return;

--- a/app/contests/[cid]/submits/page.tsx
+++ b/app/contests/[cid]/submits/page.tsx
@@ -10,6 +10,7 @@ import { userInfoStore } from '@/app/store/UserInfo';
 import { fetchCurrentUserInfo } from '@/app/utils/fetchCurrentUserInfo';
 import { UserInfo } from '@/app/types/user';
 import { useRouter } from 'next/navigation';
+import { OPERATOR_ROLES } from '@/app/constants/role';
 
 interface DefaultProps {
   params: {
@@ -29,7 +30,7 @@ export default function UsersContestSubmits(props: DefaultProps) {
   // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
     fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
-      if (res.isAuth && res.role !== 'operator') {
+      if (res.isAuth && !OPERATOR_ROLES.includes(res.role)) {
         alert('접근 권한이 없습니다.');
         router.back();
         return;

--- a/app/contests/page.tsx
+++ b/app/contests/page.tsx
@@ -6,6 +6,7 @@ import Image from 'next/image';
 import trophyImg from '@/public/images/trophy.png';
 import { useState } from 'react';
 import { userInfoStore } from '../store/UserInfo';
+import { OPERATOR_ROLES } from '../constants/role';
 
 export default function Contests() {
   const [searchQuery, setSearchQuery] = useState('');
@@ -59,7 +60,7 @@ export default function Contests() {
                 대회명으로 검색
               </p>
             </div>
-            {userInfo.role === 'operator' && (
+            {OPERATOR_ROLES.includes(userInfo.role) && (
               <div className="relative ml-auto mt-auto bottom-[-0.75rem]">
                 <div className="flex justify-end mb-2">
                   <div className="flex">

--- a/app/contests/register/page.tsx
+++ b/app/contests/register/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { OPERATOR_ROLES } from '@/app/constants/role';
 import Loading from '@/app/loading';
 import { userInfoStore } from '@/app/store/UserInfo';
 import { UserInfo } from '@/app/types/user';
@@ -124,7 +125,7 @@ export default function RegisterContest() {
   // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
     fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
-      if (res.isAuth && res.role !== 'operator') {
+      if (res.isAuth && !OPERATOR_ROLES.includes(res.role)) {
         alert('접근 권한이 없습니다.');
         router.back();
         return;

--- a/app/exams/[eid]/edit/page.tsx
+++ b/app/exams/[eid]/edit/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { OPERATOR_ROLES } from '@/app/constants/role';
 import Loading from '@/app/loading';
 import { userInfoStore } from '@/app/store/UserInfo';
 import { UserInfo } from '@/app/types/user';
@@ -155,7 +156,7 @@ export default function EditExam(props: DefaultProps) {
   // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
     fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
-      if (res.isAuth && res.role !== 'operator') {
+      if (res.isAuth && !OPERATOR_ROLES.includes(res.role)) {
         alert('접근 권한이 없습니다.');
         router.back();
         return;

--- a/app/exams/[eid]/problems/[problemId]/edit/page.tsx
+++ b/app/exams/[eid]/problems/[problemId]/edit/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import MyDropzone from '@/app/components/MyDropzone';
+import { OPERATOR_ROLES } from '@/app/constants/role';
 import Loading from '@/app/loading';
 import { userInfoStore } from '@/app/store/UserInfo';
 import { UserInfo } from '@/app/types/user';
@@ -147,7 +148,7 @@ export default function EditExamProblem(props: DefaultProps) {
   // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
     fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
-      if (res.isAuth && res.role !== 'operator') {
+      if (res.isAuth && !OPERATOR_ROLES.includes(res.role)) {
         alert('접근 권한이 없습니다.');
         router.back();
         return;

--- a/app/exams/[eid]/problems/register/page.tsx
+++ b/app/exams/[eid]/problems/register/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import MyDropzone from '@/app/components/MyDropzone';
+import { OPERATOR_ROLES } from '@/app/constants/role';
 import Loading from '@/app/loading';
 import { userInfoStore } from '@/app/store/UserInfo';
 import { UserInfo } from '@/app/types/user';
@@ -111,7 +112,7 @@ export default function RegisterExamProblem(props: DefaultProps) {
   // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
     fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
-      if (res.isAuth && res.role !== 'operator') {
+      if (res.isAuth && !OPERATOR_ROLES.includes(res.role)) {
         alert('접근 권한이 없습니다.');
         router.back();
         return;

--- a/app/exams/[eid]/submits/[submitId]/page.tsx
+++ b/app/exams/[eid]/submits/[submitId]/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { OPERATOR_ROLES } from '@/app/constants/role';
 import Loading from '@/app/loading';
 import { userInfoStore } from '@/app/store/UserInfo';
 import { UserInfo } from '@/app/types/user';
@@ -35,7 +36,7 @@ export default function UsersExamSubmit(props: DefaultProps) {
   // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
     fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
-      if (res.isAuth && res.role !== 'operator') {
+      if (res.isAuth && !OPERATOR_ROLES.includes(res.role)) {
         alert('접근 권한이 없습니다.');
         router.back();
         return;

--- a/app/exams/[eid]/submits/page.tsx
+++ b/app/exams/[eid]/submits/page.tsx
@@ -10,6 +10,7 @@ import { fetchCurrentUserInfo } from '@/app/utils/fetchCurrentUserInfo';
 import { UserInfo } from '@/app/types/user';
 import { userInfoStore } from '@/app/store/UserInfo';
 import { useRouter } from 'next/navigation';
+import { OPERATOR_ROLES } from '@/app/constants/role';
 
 interface DefaultProps {
   params: {
@@ -29,7 +30,7 @@ export default function UsersExamSubmits(props: DefaultProps) {
   // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
     fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
-      if (res.isAuth && res.role !== 'operator') {
+      if (res.isAuth && !OPERATOR_ROLES.includes(res.role)) {
         alert('접근 권한이 없습니다.');
         router.back();
         return;

--- a/app/exams/page.tsx
+++ b/app/exams/page.tsx
@@ -6,6 +6,7 @@ import ExamList from './components/ExamList';
 import Image from 'next/image';
 import examImg from '@/public/images/exam.png';
 import { userInfoStore } from '../store/UserInfo';
+import { OPERATOR_ROLES } from '../constants/role';
 
 export default function Exams() {
   const [searchQuery, setSearchQuery] = useState('');
@@ -59,7 +60,7 @@ export default function Exams() {
                 시험명, 수업명, 작성자명으로 검색
               </p>
             </div>
-            {userInfo.role === 'operator' && (
+            {OPERATOR_ROLES.includes(userInfo.role) && (
               <div className="relative ml-auto mt-auto bottom-[-0.75rem]">
                 <div className="flex justify-end mb-2">
                   <div className="flex">

--- a/app/exams/register/page.tsx
+++ b/app/exams/register/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { OPERATOR_ROLES } from '@/app/constants/role';
 import Loading from '@/app/loading';
 import { userInfoStore } from '@/app/store/UserInfo';
 import { UserInfo } from '@/app/types/user';
@@ -102,7 +103,7 @@ export default function RegisterExam() {
   // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
     fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
-      if (res.isAuth && res.role !== 'operator') {
+      if (res.isAuth && !OPERATOR_ROLES.includes(res.role)) {
         alert('접근 권한이 없습니다.');
         router.back();
         return;

--- a/app/mypage/layout.tsx
+++ b/app/mypage/layout.tsx
@@ -6,6 +6,7 @@ import { userInfoStore } from '../store/UserInfo';
 import { useEffect, useState } from 'react';
 import { fetchCurrentUserInfo } from '../utils/fetchCurrentUserInfo';
 import Loading from '../loading';
+import { OPERATOR_ROLES } from '../constants/role';
 
 export default function MyPagelayout({
   children,
@@ -66,7 +67,7 @@ export default function MyPagelayout({
               >
                 참가 내역
               </button>
-              {userInfo.role === 'operator' && (
+              {OPERATOR_ROLES.includes(userInfo.role) && (
                 <button
                   onClick={() => handleChangeTab(tabNames[2])}
                   className={`${

--- a/app/mypage/managing-my-post/page.tsx
+++ b/app/mypage/managing-my-post/page.tsx
@@ -8,6 +8,7 @@ import MyNoticePostList from './components/noticePost/MyNoticePostList';
 import { mypageTabNameStore } from '@/app/store/MypageTabName';
 import { userInfoStore } from '@/app/store/UserInfo';
 import { useRouter } from 'next/navigation';
+import { OPERATOR_ROLES } from '@/app/constants/role';
 
 export default function ManagingMyPost() {
   const [category, setCategory] = useState('contest');
@@ -29,7 +30,7 @@ export default function ManagingMyPost() {
   }, [updateTabName]);
 
   // 비관리자 회원의 접근 시 로그인 페이지로 리다이렉트 수행
-  if (userInfo.role !== 'operator') {
+  if (!OPERATOR_ROLES.includes(userInfo.role)) {
     alert('접근 권한이 없습니다.');
     router.back();
     return;

--- a/app/notices/[nid]/edit/page.tsx
+++ b/app/notices/[nid]/edit/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { OPERATOR_ROLES } from '@/app/constants/role';
 import Loading from '@/app/loading';
 import { userInfoStore } from '@/app/store/UserInfo';
 import { UserInfo } from '@/app/types/user';
@@ -133,7 +134,7 @@ export default function EditNotice(props: DefaultProps) {
   // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
     fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
-      if (res.isAuth && res.role !== 'operator') {
+      if (res.isAuth && !OPERATOR_ROLES.includes(res.role)) {
         alert('접근 권한이 없습니다.');
         router.back();
         return;

--- a/app/notices/register/page.tsx
+++ b/app/notices/register/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { OPERATOR_ROLES } from '@/app/constants/role';
 import Loading from '@/app/loading';
 import { userInfoStore } from '@/app/store/UserInfo';
 import { UserInfo } from '@/app/types/user';
@@ -75,7 +76,7 @@ export default function RegisterNotice() {
   // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
     fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
-      if (res.isAuth && res.role !== 'operator') {
+      if (res.isAuth && !OPERATOR_ROLES.includes(res.role)) {
         alert('접근 권한이 없습니다.');
         router.back();
         return;

--- a/app/practices/[pid]/edit/page.tsx
+++ b/app/practices/[pid]/edit/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import MyDropzone from '@/app/components/MyDropzone';
+import { OPERATOR_ROLES } from '@/app/constants/role';
 import Loading from '@/app/loading';
 import { userInfoStore } from '@/app/store/UserInfo';
 import { UserInfo } from '@/app/types/user';
@@ -130,7 +131,7 @@ export default function EditPractice(props: DefaultProps) {
   // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
     fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
-      if (res.isAuth && res.role !== 'operator') {
+      if (res.isAuth && !OPERATOR_ROLES.includes(res.role)) {
         alert('접근 권한이 없습니다.');
         router.back();
         return;

--- a/app/practices/page.tsx
+++ b/app/practices/page.tsx
@@ -6,6 +6,7 @@ import PracticeList from './components/PracticeList';
 import Image from 'next/image';
 import pencilImg from '@/public/images/pencil.png';
 import { userInfoStore } from '../store/UserInfo';
+import { OPERATOR_ROLES } from '../constants/role';
 
 export default function Practices() {
   const [searchQuery, setSearchQuery] = useState('');
@@ -59,7 +60,7 @@ export default function Practices() {
                 문제명, 작성자명으로 검색
               </p>
             </div>
-            {userInfo.role === 'operator' && (
+            {OPERATOR_ROLES.includes(userInfo.role) && (
               <div className="relative ml-auto mt-auto bottom-[-0.75rem]">
                 <div className="flex justify-end mb-2">
                   <div className="flex">

--- a/app/practices/register/page.tsx
+++ b/app/practices/register/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import MyDropzone from '@/app/components/MyDropzone';
+import { OPERATOR_ROLES } from '@/app/constants/role';
 import Loading from '@/app/loading';
 import { userInfoStore } from '@/app/store/UserInfo';
 import { UserInfo } from '@/app/types/user';
@@ -103,7 +104,7 @@ export default function RegisterPractice() {
   // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
     fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
-      if (res.isAuth && res.role !== 'operator') {
+      if (res.isAuth && !OPERATOR_ROLES.includes(res.role)) {
         alert('접근 권한이 없습니다.');
         router.back();
         return;


### PR DESCRIPTION
## 👀 이슈

resolve #170 

## 📌 개요

현재 관리자의 접근 권한이 필요한 페이지 컴포넌트에서는 사용자의 role 값이
`operator`인지 아닌지만을 확인하기 때문에 코드의 유지보수성이 저하되어
여러 권한에 대해서도 손쉽게 확인이 가능하게끔 권한 배열의 상수를 추가하여
확인 작업이 용이하도록 코드를 수정하였습니다.

## 👩‍💻 작업 사항

- 컴포넌트 내 관리자 권한 확인 로직 일괄 수정

## ✅ 참고 사항

- 관리자 권한 확인 로직 작동 화면

https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/7970a26e-54fc-4384-8ad4-08a30531b01d