### PR TITLE
[feat]: 메인페이지 내 신청 가능한 대회 요소에 대한 라우팅 기능 추가 (#172)

### DIFF
--- a/app/components/Contests/ContestList.tsx
+++ b/app/components/Contests/ContestList.tsx
@@ -15,46 +15,56 @@ const fetchProgressingContests = () => {
 };
 
 export default function ContestList() {
-  const { data } = useQuery({
+  const { isPending, data } = useQuery({
     queryKey: ['progressingContests'],
     queryFn: fetchProgressingContests,
   });
 
-  // 실제 대회 정보를 렌더링한 횟수를 추적
-  let renderedContestsCount = 0;
-
   const resData = data?.data.data;
 
-  if (resData?.documents.length === 0) return <NoneContestListItem />;
+  // Filter contests that are applicable
+  const applicableContests = resData?.documents.filter(
+    (contestInfo: ContestInfo) => {
+      const now = new Date();
+      let isContestApplicable = false;
+
+      if (contestInfo.applyingPeriod) {
+        const applyingPeriodEnd = new Date(contestInfo.applyingPeriod.end);
+        isContestApplicable = applyingPeriodEnd > now;
+      } else {
+        const testPeriodStart = new Date(contestInfo.testPeriod.start);
+        isContestApplicable = testPeriodStart > now;
+      }
+
+      return isContestApplicable;
+    },
+  );
+
+  if (resData?.documents.length === 0 || applicableContests?.length === 0)
+    return <NoneContestListItem />;
 
   return (
     <>
-      {resData?.documents.map((contestInfo: ContestInfo) => {
-        const now = new Date();
-        let isContestApplicable = false;
+      {isPending ? (
+        <>
+          {Array.from({ length: 4 }, (_, index) => (
+            <DummyContestListemItem key={index} />
+          ))}
+        </>
+      ) : (
+        <>
+          {applicableContests.map((contestInfo: ContestInfo) => (
+            <ContestListItem contestInfo={contestInfo} key={contestInfo._id} />
+          ))}
 
-        if (contestInfo.applyingPeriod) {
-          // applyingPeriod이 존재하는 경우, applyingPeriod.end를 Date 객체로 변환
-          const applyingPeriodEnd = new Date(contestInfo.applyingPeriod.end);
-          // 현재 시간이 applyingPeriod.end 이전인지 확인
-          isContestApplicable = applyingPeriodEnd > now;
-        } else {
-          // applyingPeriod이 null인 경우, testPeriod.start를 Date 객체로 변환
-          const testPeriodStart = new Date(contestInfo.testPeriod.start);
-          // 현재 시간이 testPeriod.start 이전인지 확인
-          isContestApplicable = testPeriodStart > now;
-        }
-
-        if (!isContestApplicable) return;
-        renderedContestsCount++;
-        return (
-          <ContestListItem contestInfo={contestInfo} key={contestInfo._id} />
-        );
-      })}
-
-      {Array.from({ length: 4 - renderedContestsCount }, (_, index) => (
-        <DummyContestListemItem key={index} />
-      ))}
+          {Array.from(
+            { length: 4 - applicableContests?.length },
+            (_, index) => (
+              <DummyContestListemItem key={index} />
+            ),
+          )}
+        </>
+      )}
     </>
   );
 }

--- a/app/components/Contests/ContestListItem.tsx
+++ b/app/components/Contests/ContestListItem.tsx
@@ -14,7 +14,7 @@ export default function ContestListItem(props: ContestProps) {
   return (
     <div className="relative flex flex-col gap-4 bg-[#f7f7f7] p-3 group">
       <p className="font-bold">
-        <Link href="/" className="hover:underline">
+        <Link href={`/contests/${contestInfo._id}`} className="hover:underline">
           {contestInfo.title}
         </Link>
       </p>


### PR DESCRIPTION
## 👀 이슈

resolve #172 

## 📌 개요

메인페이지 내에 존재하는 `신청 가능한 대회` 요소에 대하여 실제 해당 대회 게시물로
이동할 수 있도록 라우팅 기능을 추가하였습니다.

## 👩‍💻 작업 사항

- `신청 가능한 대회` 요소에 대한 라우팅 기능 추가

## ✅ 참고 사항

- 기능 추가 후 라우팅 기능 작동 화면

https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/1d98c201-cfdf-488a-b262-1f4f7f640683