### PR TITLE
[feat]: 시험 게시글 페이지 컴포넌트 내 기능 추가 (#174)

### DIFF
--- a/app/contests/[cid]/page.tsx
+++ b/app/contests/[cid]/page.tsx
@@ -15,7 +15,7 @@ import { AxiosError } from 'axios';
 import { OPERATOR_ROLES } from '@/app/constants/role';
 import { deleteCookie, getCookie, setCookie } from 'cookies-next';
 
-// 참가했던 대회 목록 반환 API
+// 대회 게시글 정보 조회 API
 const fetchContestDetailInfo = (cid: string) => {
   return axiosInstance.get(
     `${process.env.NEXT_PUBLIC_API_VERSION}/contest/${cid}`,
@@ -213,7 +213,7 @@ export default function ContestDetail(props: DefaultProps) {
 
     // 대회 신청자인 경우, 대회 시간 중에만 버튼 보임
     if (
-      isUserContestant() &&
+      isEnrollContest &&
       currentTime >= contestStartTime &&
       currentTime <= contestEndTime
     ) {
@@ -268,12 +268,11 @@ export default function ContestDetail(props: DefaultProps) {
     return contestInfo.contestants.some(
       (contestant) => contestant._id === userInfo._id,
     );
-  }, [contestInfo?.contestants, userInfo._id]);
+  }, [contestInfo, userInfo]);
 
   useEffect(() => {
-    if (contestInfo && contestInfo.contestants && userInfo) {
+    if (contestInfo && contestInfo.contestants && userInfo)
       setIsEnrollContest(isUserContestant());
-    }
   }, [contestInfo, userInfo, isUserContestant]);
 
   const handleEnrollContest = () => {
@@ -364,8 +363,6 @@ export default function ContestDetail(props: DefaultProps) {
     return () => clearInterval(interval);
   }, []);
 
-  if (isPending) return <Loading />;
-
   // 에러가 발생했을 때의 처리
   if (isError) {
     const axiosError = error as AxiosError;
@@ -374,9 +371,8 @@ export default function ContestDetail(props: DefaultProps) {
       case 500:
         switch (axiosError.code) {
           case 'CONTEST_NOT_FOUND':
-          case 'ERR_BAD_RESPONSE':
+          case 'ERR_BAD_REQUEST':
             alert('존재하지 않는 대회입니다.');
-            router.push('/');
             break;
           default:
             alert('정의되지 않은 http code입니다.');
@@ -385,8 +381,11 @@ export default function ContestDetail(props: DefaultProps) {
       default:
         alert('정의되지 않은 http status code입니다');
     }
+    router.push('/');
     return;
   }
+
+  if (isPending) return <Loading />;
 
   return (
     <div className="mt-6 mb-24 px-5 2lg:px-0 overflow-x-auto">

--- a/app/contests/components/ContestListItem.tsx
+++ b/app/contests/components/ContestListItem.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { ContestInfo } from '@/app/types/contest';
 import {
   formatDateToYYMMDDHHMM,

--- a/app/exams/components/ExamListItem.tsx
+++ b/app/exams/components/ExamListItem.tsx
@@ -1,9 +1,6 @@
-'use client';
-
 import { ExamInfo } from '@/app/types/exam';
 import { formatDateToYYMMDDHHMM } from '@/app/utils/formatDate';
 import { useRouter } from 'next/navigation';
-import React from 'react';
 
 interface ExamListItemProps {
   examInfo: ExamInfo;
@@ -20,9 +17,7 @@ export default function ExamListItem(props: ExamListItemProps) {
   return (
     <tr
       className="border-b dark:border-gray-700 text-xs text-center cursor-pointer hover:bg-gray-50 focus:bg-gray-50"
-      onClick={() => {
-        router.push('exams/645f82d1dfc11e0020d07253');
-      }}
+      onClick={() => router.push(`exams/${examInfo._id}`)}
     >
       <th
         scope="row"

--- a/app/types/exam.ts
+++ b/app/types/exam.ts
@@ -1,6 +1,21 @@
 export interface ExamInfo {
   problems: string[];
-  students: string[];
+  students: {
+    center: null;
+    _id: string;
+    no: string;
+    name: string;
+    email: string;
+    phone: string;
+    department: string;
+    university: string;
+    position: null;
+    role: string;
+    joinedAt: string;
+    updatedAt: string;
+    __v: number;
+    image?: null; // 옵셔널 필드 (일부 객체에만 존재)
+  }[];
   _id: string;
   title: string;
   course: string;


### PR DESCRIPTION
## 👀 이슈

resolve #174 

## 📌 개요

시험 게시글을 클릭하여 해당 페이지로 접속하였을 때 하드코딩된 데이터가 아니라
실제 서버에 저장되어 있는 데이터를 기반으로 게시글 정보가 구성되게끔 관련된
기능들을 일괄적으로 추가하였습니다.

## 👩‍💻 작업 사항

- `시험 게시글` 페이지 컴포넌트 내 정보 표시 기능 추가

## ✅ 참고 사항

- 기능 추가 후 **시험 게시글** UI

https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/13655436-483f-4780-99e7-55eca17239fc