### PR TITLE
[fix]: 컴포넌트 내 로그인한 사용자의 정보 조회 및 관리자 권한 확인 로직 일괄 수정 (#178)

### DIFF
--- a/app/contests/[cid]/edit/page.tsx
+++ b/app/contests/[cid]/edit/page.tsx
@@ -177,8 +177,8 @@ export default function EditContest(props: DefaultProps) {
 
   // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
-    fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
-      if (res.isAuth && !OPERATOR_ROLES.includes(res.role)) {
+    fetchCurrentUserInfo(updateUserInfo).then((userInfo: UserInfo) => {
+      if (userInfo.isAuth && !OPERATOR_ROLES.includes(userInfo.role)) {
         alert('접근 권한이 없습니다.');
         router.back();
         return;

--- a/app/contests/[cid]/problems/[problemId]/edit/page.tsx
+++ b/app/contests/[cid]/problems/[problemId]/edit/page.tsx
@@ -147,8 +147,8 @@ export default function EditContestProblem(props: DefaultProps) {
 
   // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
-    fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
-      if (res.isAuth && !OPERATOR_ROLES.includes(res.role)) {
+    fetchCurrentUserInfo(updateUserInfo).then((userInfo: UserInfo) => {
+      if (userInfo.isAuth && !OPERATOR_ROLES.includes(userInfo.role)) {
         alert('접근 권한이 없습니다.');
         router.back();
         return;

--- a/app/contests/[cid]/problems/register/page.tsx
+++ b/app/contests/[cid]/problems/register/page.tsx
@@ -127,8 +127,8 @@ export default function RegisterContestProblem(props: DefaultProps) {
 
   // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
-    fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
-      if (res.isAuth && !OPERATOR_ROLES.includes(res.role)) {
+    fetchCurrentUserInfo(updateUserInfo).then((userInfo: UserInfo) => {
+      if (userInfo.isAuth && !OPERATOR_ROLES.includes(userInfo.role)) {
         alert('접근 권한이 없습니다.');
         router.back();
         return;

--- a/app/contests/[cid]/submits/[submitId]/page.tsx
+++ b/app/contests/[cid]/submits/[submitId]/page.tsx
@@ -35,8 +35,8 @@ export default function UsersContestSubmit(props: DefaultProps) {
 
   // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
-    fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
-      if (res.isAuth && !OPERATOR_ROLES.includes(res.role)) {
+    fetchCurrentUserInfo(updateUserInfo).then((userInfo: UserInfo) => {
+      if (userInfo.isAuth && !OPERATOR_ROLES.includes(userInfo.role)) {
         alert('접근 권한이 없습니다.');
         router.back();
         return;

--- a/app/contests/[cid]/submits/page.tsx
+++ b/app/contests/[cid]/submits/page.tsx
@@ -29,8 +29,8 @@ export default function UsersContestSubmits(props: DefaultProps) {
 
   // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
-    fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
-      if (res.isAuth && !OPERATOR_ROLES.includes(res.role)) {
+    fetchCurrentUserInfo(updateUserInfo).then((userInfo: UserInfo) => {
+      if (userInfo.isAuth && !OPERATOR_ROLES.includes(userInfo.role)) {
         alert('접근 권한이 없습니다.');
         router.back();
         return;

--- a/app/contests/register/page.tsx
+++ b/app/contests/register/page.tsx
@@ -124,8 +124,8 @@ export default function RegisterContest() {
 
   // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
-    fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
-      if (res.isAuth && !OPERATOR_ROLES.includes(res.role)) {
+    fetchCurrentUserInfo(updateUserInfo).then((userInfo: UserInfo) => {
+      if (userInfo.isAuth && !OPERATOR_ROLES.includes(userInfo.role)) {
         alert('접근 권한이 없습니다.');
         router.back();
         return;

--- a/app/exams/[eid]/edit/page.tsx
+++ b/app/exams/[eid]/edit/page.tsx
@@ -155,8 +155,8 @@ export default function EditExam(props: DefaultProps) {
 
   // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
-    fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
-      if (res.isAuth && !OPERATOR_ROLES.includes(res.role)) {
+    fetchCurrentUserInfo(updateUserInfo).then((userInfo: UserInfo) => {
+      if (userInfo.isAuth && !OPERATOR_ROLES.includes(userInfo.role)) {
         alert('접근 권한이 없습니다.');
         router.back();
         return;

--- a/app/exams/[eid]/problems/[problemId]/edit/page.tsx
+++ b/app/exams/[eid]/problems/[problemId]/edit/page.tsx
@@ -147,8 +147,8 @@ export default function EditExamProblem(props: DefaultProps) {
 
   // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
-    fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
-      if (res.isAuth && !OPERATOR_ROLES.includes(res.role)) {
+    fetchCurrentUserInfo(updateUserInfo).then((userInfo: UserInfo) => {
+      if (userInfo.isAuth && !OPERATOR_ROLES.includes(userInfo.role)) {
         alert('접근 권한이 없습니다.');
         router.back();
         return;

--- a/app/exams/[eid]/problems/register/page.tsx
+++ b/app/exams/[eid]/problems/register/page.tsx
@@ -111,8 +111,8 @@ export default function RegisterExamProblem(props: DefaultProps) {
 
   // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
-    fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
-      if (res.isAuth && !OPERATOR_ROLES.includes(res.role)) {
+    fetchCurrentUserInfo(updateUserInfo).then((userInfo: UserInfo) => {
+      if (userInfo.isAuth && !OPERATOR_ROLES.includes(userInfo.role)) {
         alert('접근 권한이 없습니다.');
         router.back();
         return;

--- a/app/exams/[eid]/submits/[submitId]/page.tsx
+++ b/app/exams/[eid]/submits/[submitId]/page.tsx
@@ -35,8 +35,8 @@ export default function UsersExamSubmit(props: DefaultProps) {
 
   // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
-    fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
-      if (res.isAuth && !OPERATOR_ROLES.includes(res.role)) {
+    fetchCurrentUserInfo(updateUserInfo).then((userInfo: UserInfo) => {
+      if (userInfo.isAuth && !OPERATOR_ROLES.includes(userInfo.role)) {
         alert('접근 권한이 없습니다.');
         router.back();
         return;

--- a/app/exams/[eid]/submits/page.tsx
+++ b/app/exams/[eid]/submits/page.tsx
@@ -29,8 +29,8 @@ export default function UsersExamSubmits(props: DefaultProps) {
 
   // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
-    fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
-      if (res.isAuth && !OPERATOR_ROLES.includes(res.role)) {
+    fetchCurrentUserInfo(updateUserInfo).then((userInfo: UserInfo) => {
+      if (userInfo.isAuth && !OPERATOR_ROLES.includes(userInfo.role)) {
         alert('접근 권한이 없습니다.');
         router.back();
         return;

--- a/app/exams/register/page.tsx
+++ b/app/exams/register/page.tsx
@@ -102,8 +102,8 @@ export default function RegisterExam() {
 
   // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
-    fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
-      if (res.isAuth && !OPERATOR_ROLES.includes(res.role)) {
+    fetchCurrentUserInfo(updateUserInfo).then((userInfo: UserInfo) => {
+      if (userInfo.isAuth && !OPERATOR_ROLES.includes(userInfo.role)) {
         alert('접근 권한이 없습니다.');
         router.back();
         return;

--- a/app/mypage/layout.tsx
+++ b/app/mypage/layout.tsx
@@ -31,8 +31,8 @@ export default function MyPagelayout({
 
   // (로그인 한) 사용자 정보 조회
   useEffect(() => {
-    fetchCurrentUserInfo(updateUserInfo).then((res) => {
-      if (res.isAuth) setIsLoading(false);
+    fetchCurrentUserInfo(updateUserInfo).then((userInfo) => {
+      if (userInfo.isAuth) setIsLoading(false);
     });
   }, [updateUserInfo]);
 

--- a/app/notices/[nid]/edit/page.tsx
+++ b/app/notices/[nid]/edit/page.tsx
@@ -133,8 +133,8 @@ export default function EditNotice(props: DefaultProps) {
 
   // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
-    fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
-      if (res.isAuth && !OPERATOR_ROLES.includes(res.role)) {
+    fetchCurrentUserInfo(updateUserInfo).then((userInfo: UserInfo) => {
+      if (userInfo.isAuth && !OPERATOR_ROLES.includes(userInfo.role)) {
         alert('접근 권한이 없습니다.');
         router.back();
         return;

--- a/app/notices/register/page.tsx
+++ b/app/notices/register/page.tsx
@@ -75,8 +75,8 @@ export default function RegisterNotice() {
 
   // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
-    fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
-      if (res.isAuth && !OPERATOR_ROLES.includes(res.role)) {
+    fetchCurrentUserInfo(updateUserInfo).then((userInfo: UserInfo) => {
+      if (userInfo.isAuth && !OPERATOR_ROLES.includes(userInfo.role)) {
         alert('접근 권한이 없습니다.');
         router.back();
         return;

--- a/app/practices/[pid]/edit/page.tsx
+++ b/app/practices/[pid]/edit/page.tsx
@@ -130,8 +130,8 @@ export default function EditPractice(props: DefaultProps) {
 
   // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
-    fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
-      if (res.isAuth && !OPERATOR_ROLES.includes(res.role)) {
+    fetchCurrentUserInfo(updateUserInfo).then((userInfo: UserInfo) => {
+      if (userInfo.isAuth && !OPERATOR_ROLES.includes(userInfo.role)) {
         alert('접근 권한이 없습니다.');
         router.back();
         return;

--- a/app/practices/register/page.tsx
+++ b/app/practices/register/page.tsx
@@ -103,8 +103,8 @@ export default function RegisterPractice() {
 
   // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
-    fetchCurrentUserInfo(updateUserInfo).then((res: UserInfo) => {
-      if (res.isAuth && !OPERATOR_ROLES.includes(res.role)) {
+    fetchCurrentUserInfo(updateUserInfo).then((userInfo: UserInfo) => {
+      if (userInfo.isAuth && !OPERATOR_ROLES.includes(userInfo.role)) {
         alert('접근 권한이 없습니다.');
         router.back();
         return;


### PR DESCRIPTION
## 👀 이슈

resolve #178 

## 📌 개요

컴포넌트 내 로그인한 사용자의 정보 조회 및 관리자 권한을 확인하는 로직의 코드에서
로그인한 사용자의 정보를 가지고 있는 파라미터(`res`)의 식별자를 좀 더 명확한 `userInfo`로
변경하였습니다.

## 👩‍💻 작업 사항

- 로그인한 사용자의 정보 조회 및 관리자 권한 확인 로직이 사용되는 모든 컴포넌트에서 로직 파라미터 식별자를 기존 `res`에서 `userInfo`로 일괄 변경

## ✅ 참고 사항

없습니다