### PR TITLE
[feat]: 대회 순위 표시 기능 추가 (#184)

### DIFF
--- a/app/contests/[cid]/ranklist/components/UserScoreInfoList.tsx
+++ b/app/contests/[cid]/ranklist/components/UserScoreInfoList.tsx
@@ -1,17 +1,60 @@
 import React from 'react';
 import UserScoreInfoListItem from './UserScoreInfoListItem';
+import { ContestRankInfo } from '@/app/types/contest';
 
 interface UserScoreInfoListProps {
   cid: string;
+  contestRankListInfo: ContestRankInfo[];
 }
 
-export default function UserScoreInfoList({ cid }: UserScoreInfoListProps) {
-  const numberOfItems = 5;
+export default function UserScoreInfoList({
+  cid,
+  contestRankListInfo,
+}: UserScoreInfoListProps) {
+  // 함수: ContestRankInfo 객체를 받아 totalScore와 totalPenalty를 계산
+  function calculateTotalScoreAndPenalty(contestRankInfo: ContestRankInfo): {
+    totalScore: number;
+    totalPenalty: number;
+  } {
+    let totalScore = 0;
+    let totalPenalty = 0;
+
+    contestRankInfo.scores.forEach((score) => {
+      if (score.right) {
+        totalScore += score.score;
+        // 정답을 맞힌 경우에만 시도 횟수에 따른 패널티를 추가합니다.
+        totalPenalty += (score.tries - 1) * 20 + score.time;
+      }
+    });
+
+    return { totalScore, totalPenalty };
+  }
+
+  const rankedContestRankListInfo = contestRankListInfo
+    .map((contestRankInfo) => {
+      const { totalScore, totalPenalty } =
+        calculateTotalScoreAndPenalty(contestRankInfo);
+      return { ...contestRankInfo, totalScore, totalPenalty };
+    })
+    // 그 다음, 총 점수가 높은 순으로 정렬하고, 점수가 같다면 패널티가 낮은 순으로 정렬합니다.
+    .sort((a, b) => {
+      if (a.totalScore === b.totalScore) {
+        return a.totalPenalty - b.totalPenalty; // 패널티가 낮은 순
+      }
+      return b.totalScore - a.totalScore; // 점수가 높은 순
+    });
 
   return (
     <div className="flex flex-col gap-5">
-      {Array.from({ length: numberOfItems }, (_, idx) => (
-        <UserScoreInfoListItem key={idx} cid={cid} ranking={idx + 1} />
+      {rankedContestRankListInfo.map((contestRankInfo, index) => (
+        <UserScoreInfoListItem
+          key={index}
+          cid={cid}
+          ranking={index + 1}
+          contestRankInfo={contestRankInfo}
+          totalScore={contestRankInfo.totalScore}
+          totalPenalty={contestRankInfo.totalPenalty}
+        />
       ))}
     </div>
   );

--- a/app/contests/[cid]/ranklist/components/UserScoreInfoListItem.tsx
+++ b/app/contests/[cid]/ranklist/components/UserScoreInfoListItem.tsx
@@ -1,17 +1,22 @@
 'use client';
 
-import Link from 'next/link';
+import { ContestRankInfo } from '@/app/types/contest';
 import { useRouter } from 'next/navigation';
-import React, { useEffect, useState } from 'react';
 
 interface UserScoreInfoListItemProps {
   cid: string;
   ranking: number;
+  contestRankInfo: ContestRankInfo;
+  totalScore: number;
+  totalPenalty: number;
 }
 
 export default function UserScoreInfoListItem({
   cid,
   ranking,
+  contestRankInfo,
+  totalScore,
+  totalPenalty,
 }: UserScoreInfoListItemProps) {
   const router = useRouter();
 
@@ -29,188 +34,57 @@ export default function UserScoreInfoListItem({
             </span>
           </div>
           <div className="ml-2">
-            <span className="text-base">홍길동</span>{' '}
+            <span className="text-base">{contestRankInfo.user.name}</span>
             <span className="text-xs text-gray-600">
-              (충북대학교 소프트웨어학과)
+              ({contestRankInfo.user.department})
             </span>
           </div>
         </div>
         <div className="flex flex-wrap mt-5 gap-3">
-          <div className="relative flex flex-col justify-center items-center w-[5.5rem] h-[4.5rem] bg-[#3870e0] border border-[#3565c4] hover:brightness-90 duration-150">
-            <div className="absolute top-[0.175rem] left-[0.175rem]">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                height="5"
-                viewBox="0 -960 960 960"
-                width="5"
-                fill="white"
-              >
-                <path d="M480.238-137q-71.145 0-133.868-27.023t-109.12-73.348q-46.398-46.325-73.324-108.826Q137-408.699 137-479.762q0-71.145 27.023-133.868t73.348-109.12q46.325-46.398 108.826-73.324Q408.699-823 479.762-823q71.145 0 133.868 27.023t109.12 73.348q46.398 46.325 73.324 108.826Q823-551.301 823-480.238q0 71.145-27.023 133.868t-73.348 109.12q-46.325 46.398-108.826 73.324Q551.301-137 480.238-137Z" />
-              </svg>
-            </div>
-            <button
-              className="text-white text-[0.825rem] underline font-medium hover:text-[#eee] focus:text-[#eee]"
-              onClick={() => handleGoToTheProblem('6544673bc4fc3d9d4396aed7')}
+          {contestRankInfo.scores.map((score, index) => (
+            <div
+              key={index}
+              className={`relative flex flex-col justify-center items-center w-[5.5rem] h-[4.5rem] ${
+                score.right ? 'bg-[#3870e0]' : 'bg-[#e0e0e0]'
+              } border ${
+                score.right ? 'border-[#3565c4]' : 'border-[#d3d3d3]'
+              } hover:brightness-90 duration-150`}
             >
-              문제 1번
-            </button>
-            <span className="text-white text-[0.825rem]">시도: 1회</span>
-            <span className="text-white text-[0.825rem]">시간: 3분</span>
-          </div>
-
-          <div className="relative flex flex-col justify-center items-center w-[5.5rem] h-[4.5rem] bg-[#3870e0] border border-[#3565c4] hover:brightness-90 duration-150">
-            <div className="absolute top-[0.175rem] left-[0.175rem]">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                height="5"
-                viewBox="0 -960 960 960"
-                width="5"
-                fill="white"
+              <div className="absolute top-[0.175rem] left-[0.175rem]">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  height="5"
+                  viewBox="0 -960 960 960"
+                  width="5"
+                  fill="white"
+                >
+                  <path d="M480.238-137q-71.145 0-133.868-27.023t-109.12-73.348q-46.398-46.325-73.324-108.826Q137-408.699 137-479.762q0-71.145 27.023-133.868t73.348-109.12q46.325-46.398 108.826-73.324Q408.699-823 479.762-823q71.145 0 133.868 27.023t109.12 73.348q46.398 46.325 73.324 108.826Q823-551.301 823-480.238q0 71.145-27.023 133.868t-73.348 109.12q-46.325 46.398-108.826 73.324Q551.301-137 480.238-137Z" />
+                </svg>
+              </div>
+              <button
+                className={`${
+                  score.right ? 'text-white' : 'text-[#3f3f3f]'
+                } text-[0.825rem] underline font-medium hover:text-[#eee] focus:text-[#eee]`}
+                onClick={() => handleGoToTheProblem(score.problem)}
               >
-                <path d="M480.238-137q-71.145 0-133.868-27.023t-109.12-73.348q-46.398-46.325-73.324-108.826Q137-408.699 137-479.762q0-71.145 27.023-133.868t73.348-109.12q46.325-46.398 108.826-73.324Q408.699-823 479.762-823q71.145 0 133.868 27.023t109.12 73.348q46.398 46.325 73.324 108.826Q823-551.301 823-480.238q0 71.145-27.023 133.868t-73.348 109.12q-46.325 46.398-108.826 73.324Q551.301-137 480.238-137Z" />
-              </svg>
-            </div>
-            <button
-              className="text-white text-[0.825rem] underline font-medium hover:text-[#eee] focus:text-[#eee]"
-              onClick={() => handleGoToTheProblem('6544673bc4fc3d9d4396aed7')}
-            >
-              문제 2번
-            </button>
-            <span className="text-white text-[0.825rem]">시도: 1회</span>
-            <span className="text-white text-[0.825rem]">시간: 3분</span>
-          </div>
-
-          <div className="relative flex flex-col justify-center items-center w-[5.5rem] h-[4.5rem] bg-[#e0e0e0] border border-[#d3d3d3] hover:brightness-90 duration-150">
-            <div className="absolute top-[0.175rem] left-[0.175rem]">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                height="5"
-                viewBox="0 -960 960 960"
-                width="5"
-                fill="white"
+                문제 {index + 1}번
+              </button>
+              <span
+                className={`${
+                  score.right ? 'text-white' : 'text-[#3f3f3f]'
+                } text-[0.825rem]`}
               >
-                <path d="M480.238-137q-71.145 0-133.868-27.023t-109.12-73.348q-46.398-46.325-73.324-108.826Q137-408.699 137-479.762q0-71.145 27.023-133.868t73.348-109.12q46.325-46.398 108.826-73.324Q408.699-823 479.762-823q71.145 0 133.868 27.023t109.12 73.348q46.398 46.325 73.324 108.826Q823-551.301 823-480.238q0 71.145-27.023 133.868t-73.348 109.12q-46.325 46.398-108.826 73.324Q551.301-137 480.238-137Z" />
-              </svg>
-            </div>
-            <button
-              className="text-[#3f3f3f] text-[0.825rem] underline font-medium hover:text-black focus:text-black"
-              onClick={() => handleGoToTheProblem('6544673bc4fc3d9d4396aed7')}
-            >
-              문제 3번
-            </button>
-            <span className="text-[#3f3f3f] text-[0.825rem]">시도: 1회</span>
-            <span className="text-[#3f3f3f] text-[0.825rem]">시간: 3분</span>
-          </div>
-
-          <div className="relative flex flex-col justify-center items-center w-[5.5rem] h-[4.5rem] bg-[#3870e0] border border-[#3565c4] hover:brightness-90 duration-150">
-            <div className="absolute top-[0.175rem] left-[0.175rem]">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                height="5"
-                viewBox="0 -960 960 960"
-                width="5"
-                fill="white"
+                시도: {score.tries}회
+              </span>
+              <span
+                className={`${
+                  score.right ? 'text-white' : 'text-[#3f3f3f]'
+                } text-[0.825rem]`}
               >
-                <path d="M480.238-137q-71.145 0-133.868-27.023t-109.12-73.348q-46.398-46.325-73.324-108.826Q137-408.699 137-479.762q0-71.145 27.023-133.868t73.348-109.12q46.325-46.398 108.826-73.324Q408.699-823 479.762-823q71.145 0 133.868 27.023t109.12 73.348q46.398 46.325 73.324 108.826Q823-551.301 823-480.238q0 71.145-27.023 133.868t-73.348 109.12q-46.325 46.398-108.826 73.324Q551.301-137 480.238-137Z" />
-              </svg>
+                시간: {score.time}분
+              </span>
             </div>
-            <button
-              className="text-white text-[0.825rem] underline font-medium hover:text-[#eee] focus:text-[#eee]"
-              onClick={() => handleGoToTheProblem('6544673bc4fc3d9d4396aed7')}
-            >
-              문제 4번
-            </button>
-            <span className="text-white text-[0.825rem]">시도: 1회</span>
-            <span className="text-white text-[0.825rem]">시간: 3분</span>
-          </div>
-
-          <div className="relative flex flex-col justify-center items-center w-[5.5rem] h-[4.5rem] bg-[#e0e0e0] border border-[#d3d3d3] hover:brightness-90 duration-150">
-            <div className="absolute top-[0.175rem] left-[0.175rem]">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                height="5"
-                viewBox="0 -960 960 960"
-                width="5"
-                fill="white"
-              >
-                <path d="M480.238-137q-71.145 0-133.868-27.023t-109.12-73.348q-46.398-46.325-73.324-108.826Q137-408.699 137-479.762q0-71.145 27.023-133.868t73.348-109.12q46.325-46.398 108.826-73.324Q408.699-823 479.762-823q71.145 0 133.868 27.023t109.12 73.348q46.398 46.325 73.324 108.826Q823-551.301 823-480.238q0 71.145-27.023 133.868t-73.348 109.12q-46.325 46.398-108.826 73.324Q551.301-137 480.238-137Z" />
-              </svg>
-            </div>
-            <button
-              className="text-[#3f3f3f] text-[0.825rem] underline font-medium hover:text-black focus:text-black"
-              onClick={() => handleGoToTheProblem('6544673bc4fc3d9d4396aed7')}
-            >
-              문제 5번
-            </button>
-            <span className="text-[#3f3f3f] text-[0.825rem]">시도: 1회</span>
-            <span className="text-[#3f3f3f] text-[0.825rem]">시간: 3분</span>
-          </div>
-
-          <div className="relative flex flex-col justify-center items-center w-[5.5rem] h-[4.5rem] bg-[#e0e0e0] border border-[#d3d3d3] hover:brightness-90 duration-150">
-            <div className="absolute top-[0.175rem] left-[0.175rem]">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                height="5"
-                viewBox="0 -960 960 960"
-                width="5"
-                fill="white"
-              >
-                <path d="M480.238-137q-71.145 0-133.868-27.023t-109.12-73.348q-46.398-46.325-73.324-108.826Q137-408.699 137-479.762q0-71.145 27.023-133.868t73.348-109.12q46.325-46.398 108.826-73.324Q408.699-823 479.762-823q71.145 0 133.868 27.023t109.12 73.348q46.398 46.325 73.324 108.826Q823-551.301 823-480.238q0 71.145-27.023 133.868t-73.348 109.12q-46.325 46.398-108.826 73.324Q551.301-137 480.238-137Z" />
-              </svg>
-            </div>
-            <button
-              className="text-[#3f3f3f] text-[0.825rem] underline font-medium hover:text-black focus:text-black"
-              onClick={() => handleGoToTheProblem('6544673bc4fc3d9d4396aed7')}
-            >
-              문제 6번
-            </button>
-            <span className="text-[#3f3f3f] text-[0.825rem]">시도: 1회</span>
-            <span className="text-[#3f3f3f] text-[0.825rem]">시간: 3분</span>
-          </div>
-
-          <div className="relative flex flex-col justify-center items-center w-[5.5rem] h-[4.5rem] bg-[#e0e0e0] border border-[#d3d3d3] hover:brightness-90 duration-150">
-            <div className="absolute top-[0.175rem] left-[0.175rem]">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                height="5"
-                viewBox="0 -960 960 960"
-                width="5"
-                fill="white"
-              >
-                <path d="M480.238-137q-71.145 0-133.868-27.023t-109.12-73.348q-46.398-46.325-73.324-108.826Q137-408.699 137-479.762q0-71.145 27.023-133.868t73.348-109.12q46.325-46.398 108.826-73.324Q408.699-823 479.762-823q71.145 0 133.868 27.023t109.12 73.348q46.398 46.325 73.324 108.826Q823-551.301 823-480.238q0 71.145-27.023 133.868t-73.348 109.12q-46.325 46.398-108.826 73.324Q551.301-137 480.238-137Z" />
-              </svg>
-            </div>
-            <button
-              className="text-[#3f3f3f] text-[0.825rem] underline font-medium hover:text-black focus:text-black"
-              onClick={() => handleGoToTheProblem('6544673bc4fc3d9d4396aed7')}
-            >
-              문제 7번
-            </button>
-            <span className="text-[#3f3f3f] text-[0.825rem]">시도: 1회</span>
-            <span className="text-[#3f3f3f] text-[0.825rem]">시간: 3분</span>
-          </div>
-
-          <div className="relative flex flex-col justify-center items-center w-[5.5rem] h-[4.5rem] bg-[#e0e0e0] border border-[#d3d3d3] hover:brightness-90 duration-150">
-            <div className="absolute top-[0.175rem] left-[0.175rem]">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                height="5"
-                viewBox="0 -960 960 960"
-                width="5"
-                fill="white"
-              >
-                <path d="M480.238-137q-71.145 0-133.868-27.023t-109.12-73.348q-46.398-46.325-73.324-108.826Q137-408.699 137-479.762q0-71.145 27.023-133.868t73.348-109.12q46.325-46.398 108.826-73.324Q408.699-823 479.762-823q71.145 0 133.868 27.023t109.12 73.348q46.398 46.325 73.324 108.826Q823-551.301 823-480.238q0 71.145-27.023 133.868t-73.348 109.12q-46.325 46.398-108.826 73.324Q551.301-137 480.238-137Z" />
-              </svg>
-            </div>
-            <button
-              className="text-[#3f3f3f] text-[0.825rem] underline font-medium hover:text-black focus:text-black"
-              onClick={() => handleGoToTheProblem('6544673bc4fc3d9d4396aed7')}
-            >
-              문제 8번
-            </button>
-            <span className="text-[#3f3f3f] text-[0.825rem]">시도: 1회</span>
-            <span className="text-[#3f3f3f] text-[0.825rem]">시간: 3분</span>
-          </div>
+          ))}
         </div>
       </div>
 
@@ -220,7 +94,7 @@ export default function UserScoreInfoListItem({
             점수
           </div>
           <div className="flex justify-center items-center bg-white h-full">
-            10
+            {totalScore}
           </div>
         </div>
         <div className="flex flex-col w-full text-center bg-[#f7f7f7]">
@@ -228,7 +102,7 @@ export default function UserScoreInfoListItem({
             패널티
           </div>
           <div className="flex justify-center items-center bg-white h-full border-l text-red-600">
-            194
+            {totalPenalty}
           </div>
         </div>
       </div>

--- a/app/contests/[cid]/ranklist/page.tsx
+++ b/app/contests/[cid]/ranklist/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import Loading from '@/app/loading';
 import UserScoreInfoList from './components/UserScoreInfoList';
 import NoneUserScoreInfoList from './components/NoneUserScoreInfoListItem';
@@ -8,6 +7,29 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import trophyImg from '@/public/images/trophy.png';
+import axiosInstance from '@/app/utils/axiosInstance';
+import { useQueries } from '@tanstack/react-query';
+import { ContestInfo, ContestRankInfo } from '@/app/types/contest';
+import { formatDateToYYMMDDHHMM } from '@/app/utils/formatDate';
+import { useCountdownTimer } from '@/app/hooks/useCountdownTimer';
+import { useCallback, useEffect, useState } from 'react';
+import { userInfoStore } from '@/app/store/UserInfo';
+
+// 대회 게시글 정보 조회 API
+const fetchContestDetailInfo = ({ queryKey }: any) => {
+  const cid = queryKey[1];
+  return axiosInstance.get(
+    `${process.env.NEXT_PUBLIC_API_VERSION}/contest/${cid}`,
+  );
+};
+
+// 대회 순위 조회 API
+const fetchContestRankListInfo = ({ queryKey }: any) => {
+  const cid = queryKey[1];
+  return axiosInstance.get(
+    `${process.env.NEXT_PUBLIC_API_VERSION}/score/contest/${cid}`,
+  );
+};
 
 interface DefaultProps {
   params: {
@@ -16,24 +38,130 @@ interface DefaultProps {
 }
 
 export default function ContestRankList(props: DefaultProps) {
-  const [isLoading, setIsLoading] = useState(true);
-  const [isUserScoreInfoListEmpty, setIsUserScoreInfoListEmpty] =
-    useState(true);
-
   const cid = props.params.cid;
 
+  const results = useQueries({
+    queries: [
+      { queryKey: ['contestDetailInfo', cid], queryFn: fetchContestDetailInfo },
+      {
+        queryKey: ['contestRankListInfo', cid],
+        queryFn: fetchContestRankListInfo,
+      },
+    ],
+  });
+
+  const userInfo = userInfoStore((state: any) => state.userInfo);
+
+  const contestInfo: ContestInfo = results[0].data?.data.data;
+  const contestRankListInfo: ContestRankInfo[] = results[1].data?.data.data;
+
+  const timeUntilStart = useCountdownTimer(contestInfo?.testPeriod.start);
+  const timeUntilEnd = useCountdownTimer(contestInfo?.testPeriod.end);
+  const currentTime = new Date();
+  const contestStartTime = new Date(contestInfo?.testPeriod.start);
+  const contestEndTime = new Date(contestInfo?.testPeriod.end);
+
+  const [isEnrollContest, setIsEnrollContest] = useState(false);
+
   const router = useRouter();
+
+  // 대회 신청 여부 확인
+  const isUserContestant = useCallback(() => {
+    return contestInfo.contestants.some(
+      (contestant) => contestant._id === userInfo._id,
+    );
+  }, [contestInfo, userInfo]);
+
+  useEffect(() => {
+    if (contestInfo && contestInfo.contestants && userInfo)
+      setIsEnrollContest(isUserContestant());
+  }, [contestInfo, userInfo, isUserContestant]);
+
+  // "문제 목록" 버튼의 렌더링 조건을 설정
+  const shouldShowProblemsButton = () => {
+    // 대회 게시글 작성자인 경우, 언제든지 버튼 보임
+    if (userInfo._id === contestInfo.writer._id) {
+      return true;
+    }
+
+    // 대회 신청자인 경우, 대회 시간 중에만 버튼 보임
+    if (
+      isEnrollContest &&
+      currentTime >= contestStartTime &&
+      currentTime <= contestEndTime
+    ) {
+      return true;
+    }
+
+    return false;
+  };
+
+  // 대회 시간 표시에 사용할 클래스를 결정하는 함수
+  const getTimeDisplayClass = () => {
+    if (currentTime < contestStartTime) {
+      // 대회 시작 전
+      return 'text-blue-500';
+    } else if (
+      currentTime >= contestStartTime &&
+      currentTime <= contestEndTime
+    ) {
+      // 대회 진행 중
+      return 'text-red-500';
+    }
+  };
+
+  // 대회 시작까지 남은 시간 또는 대회 종료까지 남은 시간을 표시하는 함수
+  const renderRemainingTime = () => {
+    if (currentTime < contestStartTime) {
+      // 대회 시작 전: 대회 시작까지 남은 시간 표시
+      return (
+        <span className={`font-semibold ${getTimeDisplayClass()}`}>
+          {timeUntilStart.days > 0 &&
+            `(${timeUntilStart.days}일 ${timeUntilStart.hours}시간 남음)`}
+          {timeUntilStart.days === 0 &&
+            timeUntilStart.hours > 0 &&
+            `(${timeUntilStart.hours}시간 ${timeUntilStart.minutes}분 남음)`}
+          {timeUntilStart.days === 0 &&
+            timeUntilStart.hours === 0 &&
+            timeUntilStart.minutes > 0 &&
+            `(${timeUntilStart.minutes}분 ${timeUntilStart.seconds}초 남음)`}
+          {timeUntilStart.days === 0 &&
+            timeUntilStart.hours === 0 &&
+            timeUntilStart.minutes === 0 &&
+            `(${timeUntilStart.seconds}초 남음)`}
+        </span>
+      );
+    } else if (
+      currentTime >= contestStartTime &&
+      currentTime <= contestEndTime
+    ) {
+      // 대회 진행 중: 대회 종료까지 남은 시간 표시
+      return (
+        <span className={`font-semibold ${getTimeDisplayClass()}`}>
+          {timeUntilEnd.days > 0 &&
+            `(${timeUntilEnd.days}일 ${timeUntilEnd.hours}시간 남음)`}
+          {timeUntilEnd.days === 0 &&
+            timeUntilEnd.hours > 0 &&
+            `(${timeUntilEnd.hours}시간 ${timeUntilEnd.minutes}분 남음)`}
+          {timeUntilEnd.days === 0 &&
+            timeUntilEnd.hours === 0 &&
+            timeUntilEnd.minutes > 0 &&
+            `(${timeUntilEnd.minutes}분 ${timeUntilEnd.seconds}초 남음)`}
+          {timeUntilEnd.days === 0 &&
+            timeUntilEnd.hours === 0 &&
+            timeUntilEnd.minutes === 0 &&
+            `(${timeUntilEnd.seconds}초 남음)`}
+        </span>
+      );
+    }
+  };
 
   const handleGoToContestProblems = () => {
     router.push(`/contests/${cid}/problems`);
   };
 
-  useEffect(() => {
-    setIsLoading(false);
-    setIsUserScoreInfoListEmpty(false);
-  }, []);
-
-  if (isLoading) return <Loading />;
+  const isAnyQueryPending = results.some((result) => result.isFetching);
+  if (isAnyQueryPending) return <Loading />;
 
   return (
     <div className="mt-2 mb-24 px-5 2lg:px-0 overflow-x-auto">
@@ -56,38 +184,48 @@ export default function ContestRankList(props: DefaultProps) {
                 href={`/contests/${cid}`}
                 className="mt-1 ml-1 text-xl font-medium cursor-pointer hover:underline hover:text-[#0038a8] focus:underline focus:text-[#0038a8] text-[#1048b8]"
               >
-                (2023년 제2회 충청북도 대학생 프로그래밍 경진대회 본선)
+                ({contestInfo.title})
               </Link>
             </div>
           </p>
           <div className="flex justify-between items-center pb-3 border-b border-gray-300">
             <div className="flex gap-2">
-              <button
-                onClick={handleGoToContestProblems}
-                className="flex justify-center items-center gap-[0.375rem] text-[#f9fafb] bg-green-500 px-2 py-[0.45rem] rounded-[6px] focus:bg-[#3e9368] hover:bg-[#3e9368]"
-              >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  height="20"
-                  viewBox="0 -960 960 960"
-                  width="20"
-                  fill="white"
+              {shouldShowProblemsButton() && (
+                <button
+                  onClick={handleGoToContestProblems}
+                  className="flex justify-center items-center gap-[0.375rem] text-[#f9fafb] bg-green-500 px-2 py-[0.45rem] rounded-[6px] focus:bg-[#3e9368] hover:bg-[#3e9368]"
                 >
-                  <path d="M320-240h320v-80H320v80Zm0-160h320v-80H320v80ZM240-80q-33 0-56.5-23.5T160-160v-640q0-33 23.5-56.5T240-880h320l240 240v480q0 33-23.5 56.5T720-80H240Zm280-520h200L520-800v200Z" />
-                </svg>
-                문제 목록
-              </button>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    height="20"
+                    viewBox="0 -960 960 960"
+                    width="20"
+                    fill="white"
+                  >
+                    <path d="M320-240h320v-80H320v80Zm0-160h320v-80H320v80ZM240-80q-33 0-56.5-23.5T160-160v-640q0-33 23.5-56.5T240-880h320l240 240v480q0 33-23.5 56.5T720-80H240Zm280-520h200L520-800v200Z" />
+                  </svg>
+                  문제 목록
+                </button>
+              )}
             </div>
             <div className="mt-3">
               <span className="font-semibold">
                 대회 시간:{' '}
-                <span className="text-red-500 font-bold">41분 3초 후 종료</span>
+                <span className="font-light">
+                  {formatDateToYYMMDDHHMM(contestInfo.testPeriod.start)} ~{' '}
+                  {formatDateToYYMMDDHHMM(contestInfo.testPeriod.end)}{' '}
+                  {timeUntilEnd?.isPast ? (
+                    <span className="text-red-500 font-bold">(종료)</span>
+                  ) : (
+                    renderRemainingTime()
+                  )}
+                </span>
               </span>
             </div>
           </div>
         </div>
 
-        {isUserScoreInfoListEmpty ? (
+        {contestRankListInfo.length === 0 ? (
           <NoneUserScoreInfoList />
         ) : (
           <>
@@ -95,13 +233,19 @@ export default function ContestRankList(props: DefaultProps) {
               <span>
                 총:{' '}
                 <span>
-                  <span className="text-red-500">8</span>명
+                  <span className="text-red-500">
+                    {contestRankListInfo.length}
+                  </span>
+                  명
                 </span>
               </span>
             </div>
 
             <div className="mt-4 mb-4 pb-5">
-              <UserScoreInfoList cid={cid} />
+              <UserScoreInfoList
+                cid={cid}
+                contestRankListInfo={contestRankListInfo}
+              />
             </div>
           </>
         )}

--- a/app/types/contest.ts
+++ b/app/types/contest.ts
@@ -54,3 +54,34 @@ export interface ContestEnrolledInfo {
   _id: string;
   title: string;
 }
+
+export interface ContestRankInfo {
+  _id: string;
+  contest: string;
+  user: {
+    center: null | string;
+    permissions: string[];
+    _id: string;
+    no: string;
+    name: string;
+    email: string;
+    phone: string;
+    department: string;
+    university: string;
+    position: null | string;
+    role: string;
+    joinedAt: string;
+    updatedAt: string;
+    __v: number;
+  };
+  scores: {
+    right: boolean;
+    tries: number;
+    time: number;
+    score: number;
+    problem: string;
+  }[];
+  createdAt: string;
+  updatedAt: string;
+  __v: number;
+}


### PR DESCRIPTION
## 👀 이슈

resolve #184 

## 📌 개요

대회 게시글 내에서 `대회 순위` 버튼 클릭 시 참가자의 실제 순위가 표시되도록
해당 기능을 추가하였습니다.

## 👩‍💻 작업 사항

- `대회 순위` 표시 기능 추가

## ✅ 참고 사항

- 기능 추가 후 **대회 순위** 페이지 UI

https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/3665fa4f-bdb5-4a75-801c-ab2cf4fedea6