### PR TITLE
[feat]: 대회 코드 제출 목록 및 제출 코드 표시 기능 추가 (#186)

### DIFF
--- a/app/components/RenderPaginationButtons.tsx
+++ b/app/components/RenderPaginationButtons.tsx
@@ -6,6 +6,11 @@ export const RenderPaginationButtons = (
   let buttons: JSX.Element[] = [];
   let startPage, endPage;
 
+  // totalPages가 0인 경우에도 최소한 1 페이지를 가정
+  if (totalPages <= 1) {
+    totalPages = 1;
+  }
+
   if (totalPages <= 3) {
     startPage = 1;
     endPage = totalPages;

--- a/app/contests/[cid]/components/ContestContestContestantList.tsx
+++ b/app/contests/[cid]/components/ContestContestContestantList.tsx
@@ -26,10 +26,10 @@ export default function ContestContestContestantList(
                 이름
               </th>
               <th scope="col" className="px-4 py-2">
-                소속 대학
+                대학교
               </th>
               <th scope="col" className="px-4 py-2">
-                소속 학과
+                학부(과)
               </th>
               <th scope="col" className="px-4 py-2">
                 이메일

--- a/app/contests/[cid]/submits/[submitId]/page.tsx
+++ b/app/contests/[cid]/submits/[submitId]/page.tsx
@@ -3,15 +3,31 @@
 import { OPERATOR_ROLES } from '@/app/constants/role';
 import Loading from '@/app/loading';
 import { userInfoStore } from '@/app/store/UserInfo';
+import { ContestSubmitInfo } from '@/app/types/contest';
+import { SubmitInfo } from '@/app/types/submit';
 import { UserInfo } from '@/app/types/user';
+import axiosInstance from '@/app/utils/axiosInstance';
 import { fetchCurrentUserInfo } from '@/app/utils/fetchCurrentUserInfo';
+import { formatDateToYYMMDDHHMMSS } from '@/app/utils/formatDate';
+import { getCodeSubmitResultTypeDescription } from '@/app/utils/getCodeSubmitResultTypeDescription';
+import { getLanguageCode } from '@/app/utils/getLanguageCode';
+import { useQuery } from '@tanstack/react-query';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
 import React, { useEffect, useState } from 'react';
 
+// 코드 제출 정보 조회 API
+const fetchSubmitInfo = ({ queryKey }: any) => {
+  const submitId = queryKey[1];
+  return axiosInstance.get(
+    `${process.env.NEXT_PUBLIC_API_VERSION}/submit/${submitId}`,
+  );
+};
+
 interface DefaultProps {
   params: {
     cid: string;
+    submitId: string;
   };
 }
 
@@ -21,11 +37,20 @@ const MarkdownPreview = dynamic(
 );
 
 export default function UsersContestSubmit(props: DefaultProps) {
+  const cid = props.params.cid;
+  const submitId = props.params.submitId;
+
+  const { isPending, data } = useQuery({
+    queryKey: ['submitInfo', submitId],
+    queryFn: fetchSubmitInfo,
+  });
+
   const updateUserInfo = userInfoStore((state: any) => state.updateUserInfo);
 
-  const [isLoading, setIsLoading] = useState(true);
+  const resData = data?.data.data;
+  const submitInfo: SubmitInfo = resData;
 
-  const cid = props.params.cid;
+  const [isLoading, setIsLoading] = useState(true);
 
   const router = useRouter();
 
@@ -33,17 +58,25 @@ export default function UsersContestSubmit(props: DefaultProps) {
     router.push(`/contests/${cid}/submits`);
   };
 
-  // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
+  // 페이지 접근 권한 설정
   useEffect(() => {
     fetchCurrentUserInfo(updateUserInfo).then((userInfo: UserInfo) => {
-      if (userInfo.isAuth && !OPERATOR_ROLES.includes(userInfo.role)) {
+      if (submitInfo) {
+        if (
+          userInfo.isAuth &&
+          ((OPERATOR_ROLES.includes(userInfo.role) &&
+            userInfo._id === submitInfo.parentId.writer._id) ||
+            submitInfo.parentId.contestants[0] === userInfo._id)
+        ) {
+          setIsLoading(false);
+          return;
+        }
+
         alert('접근 권한이 없습니다.');
         router.back();
-        return;
       }
-      setIsLoading(false);
     });
-  }, [updateUserInfo, router]);
+  }, [updateUserInfo, submitInfo, router]);
 
   if (isLoading) return <Loading />;
 
@@ -71,23 +104,8 @@ export default function UsersContestSubmit(props: DefaultProps) {
           <MarkdownPreview
             className="markdown-preview"
             source={`
-\`\`\`cpp
-#include <iostream>
-
-using namespace std;
-
-int main(int argc, const char* argv[]) {
-  ios_base::sync_with_stdio(false);
-  cin.tie(0);
-
-  int a, b;
-  cin >> a >> b;
-  cout << a + b;
-
-  return 0;
-}
-\`\`\`
-`}
+\`\`\`${getLanguageCode(submitInfo.language)}
+${submitInfo.code}`}
           />
         </div>
 
@@ -128,21 +146,33 @@ int main(int argc, const char* argv[]) {
                     scope="row"
                     className="py-3 font-medium text-gray-900 whitespace-nowrap dark:text-white"
                   >
-                    2023년 제2회 충청북도 대학생 프로그래밍 경진대회 본선
+                    {submitInfo.parentId.title}
                   </th>
-                  <td className="">A+B</td>
-                  <td className="">홍길동</td>
-                  <td className="text-[#0076C0] font-semibold">정답</td>
+                  <td className="">{submitInfo.problem.title}</td>
+                  <td className="">{submitInfo.user.name}</td>
+                  <td
+                    className={`${
+                      submitInfo.result.type === 'done'
+                        ? 'text-[#0076C0]'
+                        : 'text-red-500'
+                    } font-semibold`}
+                  >
+                    {getCodeSubmitResultTypeDescription(submitInfo.result.type)}
+                  </td>
                   <td>
-                    <span>1527 </span>
+                    <span>
+                      {(submitInfo.result.memory / 1048576).toFixed(2)}{' '}
+                    </span>
                     <span className="ml-[-1px] text-red-500">KB</span>
                   </td>
                   <td className="">
-                    <span>64 </span>{' '}
+                    <span>{submitInfo.result.time} </span>{' '}
                     <span className="ml-[-1px] text-red-500">ms</span>
                   </td>
-                  <td className="">C++17</td>
-                  <td className="">2023.09.26 07:00:00</td>
+                  <td className="">{submitInfo.language}</td>
+                  <td className="">
+                    {formatDateToYYMMDDHHMMSS(submitInfo.createdAt)}
+                  </td>
                 </tr>
               </tbody>
             </table>

--- a/app/contests/[cid]/submits/components/UsersContestSubmitList.tsx
+++ b/app/contests/[cid]/submits/components/UsersContestSubmitList.tsx
@@ -13,8 +13,9 @@ import { RenderPaginationButtons } from '@/app/components/RenderPaginationButton
 // 대회 코드 제출 목록 조회 API
 const fetchContestSubmitsInfo = ({ queryKey }: any) => {
   const cid = queryKey[1];
+  const page = queryKey[2];
   return axiosInstance.get(
-    `${process.env.NEXT_PUBLIC_API_VERSION}/submit/contest/${cid}`,
+    `${process.env.NEXT_PUBLIC_API_VERSION}/submit/contest/${cid}?page=${page}&limit=10&sort=-createdAt`,
   );
 };
 
@@ -30,7 +31,7 @@ export default function UsersContestSubmitList({
   const page = Number(params?.get('page')) || 1;
 
   const { isPending, data } = useQuery({
-    queryKey: ['contestSubmitsInfo', cid],
+    queryKey: ['contestSubmitsInfo', cid, page],
     queryFn: fetchContestSubmitsInfo,
     retry: 0,
   });

--- a/app/contests/[cid]/submits/components/UsersContestSubmitList.tsx
+++ b/app/contests/[cid]/submits/components/UsersContestSubmitList.tsx
@@ -1,9 +1,22 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import UsersContestSubmitListItem from './UsersContestSubmitListItem';
 import NoneUsersContestSubmitListItem from './NoneUsersContestSubmitListItem';
 import Loading from '@/app/loading';
+import { useQuery } from '@tanstack/react-query';
+import { ContestSubmitInfo } from '@/app/types/contest';
+import axiosInstance from '@/app/utils/axiosInstance';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { RenderPaginationButtons } from '@/app/components/RenderPaginationButtons';
+
+// 대회 코드 제출 목록 조회 API
+const fetchContestSubmitsInfo = ({ queryKey }: any) => {
+  const cid = queryKey[1];
+  return axiosInstance.get(
+    `${process.env.NEXT_PUBLIC_API_VERSION}/submit/contest/${cid}`,
+  );
+};
 
 interface UsersContestSubmitListProps {
   cid: string;
@@ -12,24 +25,155 @@ interface UsersContestSubmitListProps {
 export default function UsersContestSubmitList({
   cid,
 }: UsersContestSubmitListProps) {
-  const [isLoading, setIsLoading] = useState(true);
-  const [isSubmitListEmpty, setIsSumbitListEmpty] = useState(true);
+  const params = useSearchParams();
 
-  const numberOfItems = 10;
+  const page = Number(params?.get('page')) || 1;
+
+  const { isPending, data } = useQuery({
+    queryKey: ['contestSubmitsInfo', cid],
+    queryFn: fetchContestSubmitsInfo,
+    retry: 0,
+  });
+
+  const router = useRouter();
+
+  const resData = data?.data.data;
+  const contestSubmitsInfo: ContestSubmitInfo[] = resData?.documents;
+  const startItemNum = (resData?.page - 1) * 10 + 1;
+  const endItemNum = startItemNum - 1 + resData?.documents.length;
+  const totalPages = Math.ceil(resData?.total / 10);
+
+  const handlePagination = (newPage: number) => {
+    if (newPage < 1 || newPage > totalPages) return;
+    router.push(`/contests/${cid}/submits?page=${newPage}`);
+  };
 
   useEffect(() => {
-    setIsLoading(false);
-    setIsSumbitListEmpty(false);
-  }, []);
+    // page가 유효한 양의 정수가 아닌 경우, ?page=1로 리다이렉트
+    if (!params?.has('page') || !Number.isInteger(page) || page < 1) {
+      router.replace(`contests/${cid}/submits?page=1`);
+    }
+  }, [page, params, router, cid]);
 
-  if (isLoading) return <Loading />;
-  if (isSubmitListEmpty) return <NoneUsersContestSubmitListItem />;
+  if (isPending) return <Loading />;
 
   return (
-    <tbody>
-      {Array.from({ length: numberOfItems }, (_, idx) => (
-        <UsersContestSubmitListItem key={idx} cid={cid} />
-      ))}
-    </tbody>
+    <div className="mx-auto w-full">
+      <div className="border dark:bg-gray-800 relative overflow-hidden rounded-sm">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm text-left text-gray-500 dark:text-gray-400">
+            <thead className="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-gray-700 dark:text-gray-400 text-center">
+              <tr>
+                <th scope="col" className="w-16 px-4 py-2">
+                  번호
+                </th>
+                <th scope="col" className="px-4 py-2">
+                  대학
+                </th>
+                <th scope="col" className="px-4 py-2">
+                  학과(부)
+                </th>
+                <th scope="col" className="px-4 py-2">
+                  학번
+                </th>
+                <th scope="col" className="px-4 py-2">
+                  이름
+                </th>
+                <th scope="col" className="px-4 py-2">
+                  문제명
+                </th>
+                <th scope="col" className="px-4 py-2">
+                  결과
+                </th>
+                <th scope="col" className="px-4 py-2">
+                  메모리
+                </th>
+                <th scope="col" className="px-4 py-2">
+                  시간
+                </th>
+                <th scope="col" className="px-4 py-2">
+                  언어
+                </th>
+                <th scope="col" className="px-4 py-2">
+                  제출 시간
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {contestSubmitsInfo?.length === 0 && (
+                <NoneUsersContestSubmitListItem />
+              )}
+              {contestSubmitsInfo.map((contestSubmitInfo, idx) => (
+                <UsersContestSubmitListItem
+                  key={idx}
+                  contestSubmitInfo={contestSubmitInfo}
+                  total={resData.total}
+                  page={page}
+                  cid={cid}
+                  index={idx}
+                />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <nav
+        className="flex flex-col md:flex-row text-xs justify-between items-start md:items-center space-y-3 md:space-y-0 pl-1 mt-3"
+        aria-label="Table navigation"
+      >
+        <span className="text-gray-500 dark:text-gray-400">
+          <span className="text-gray-500 dark:text-white">
+            {startItemNum} - {endItemNum}
+          </span>{' '}
+          of{' '}
+          <span className="text-gray-500 dark:text-white">{resData.total}</span>
+        </span>
+        <ul className="inline-flex items-stretch -space-x-px">
+          <li>
+            <button
+              onClick={() => handlePagination(Number(page) - 1)}
+              className="flex items-center justify-center h-full py-1.5 px-[0.3rem] ml-0 text-gray-500 bg-white rounded-l-lg border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
+            >
+              <span className="sr-only">Previous</span>
+              <svg
+                className="w-5 h-5"
+                aria-hidden="true"
+                fill="currentColor"
+                viewBox="0 0 20 20"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </button>
+          </li>
+          {RenderPaginationButtons(page, totalPages, handlePagination)}
+          <li>
+            <button
+              onClick={() => handlePagination(Number(page) + 1)}
+              className="flex items-center justify-center h-full py-1.5 px-[0.3rem] leading-tight text-gray-500 bg-white rounded-r-lg border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
+            >
+              <span className="sr-only">Next</span>
+              <svg
+                className="w-5 h-5"
+                aria-hidden="true"
+                fill="currentColor"
+                viewBox="0 0 20 20"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </button>
+          </li>
+        </ul>
+      </nav>
+    </div>
   );
 }

--- a/app/contests/[cid]/submits/components/UsersContestSubmitListItem.tsx
+++ b/app/contests/[cid]/submits/components/UsersContestSubmitListItem.tsx
@@ -1,12 +1,23 @@
+import { ContestSubmitInfo } from '@/app/types/contest';
+import { formatDateToYYMMDDHHMM } from '@/app/utils/formatDate';
+import { getCodeSubmitResultTypeDescription } from '@/app/utils/getCodeSubmitResultTypeDescription';
 import { useRouter } from 'next/navigation';
 import React from 'react';
 
 interface UsersContestSubmitListItemProps {
+  contestSubmitInfo: ContestSubmitInfo;
   cid: string;
+  total: number;
+  page: number;
+  index: number;
 }
 
 export default function UsersContestSubmitListItem({
+  contestSubmitInfo,
   cid,
+  total,
+  page,
+  index,
 }: UsersContestSubmitListItemProps) {
   const router = useRouter();
 
@@ -14,30 +25,41 @@ export default function UsersContestSubmitListItem({
     <tr
       className="border-b dark:border-gray-700 text-xs text-center cursor-pointer hover:bg-gray-50 focus:bg-gray-50"
       onClick={(e) => {
-        router.push(`/contests/${cid}/submits/${'650af6fe9c2734584192d5fb'}`);
+        router.push(`/contests/${cid}/submits/${contestSubmitInfo._id}`);
       }}
     >
       <th
         scope="row"
         className="px-4 py-3 font-medium text-gray-900 whitespace-nowrap dark:text-white"
       >
-        1
+        {total - (page - 1) * 10 - index}
       </th>
-      <td className="">충북대학교</td>
-      <td className="">소프트웨어학과</td>
-      <td className="">2020123123</td>
-      <td className="">홍길동</td>
-      <td className="">A+B</td>
-      <td className="text-[#0076C0] font-semibold">정답</td>
+      <td className="">{contestSubmitInfo.user.university}</td>
+      <td className="">{contestSubmitInfo.user.department}</td>
+      <td className="">{contestSubmitInfo.user.no}</td>
+      <td className="">{contestSubmitInfo.user.name}</td>
+      <td className="">{contestSubmitInfo.problem.title}</td>
+      <td
+        className={`${
+          contestSubmitInfo.result.type === 'done'
+            ? 'text-[#0076C0]'
+            : 'text-red-500'
+        } font-semibold`}
+      >
+        {getCodeSubmitResultTypeDescription(contestSubmitInfo.result.type)}
+      </td>
       <td>
-        <span>1527 </span>
-        <span className="ml-[-1px] text-red-500">KB</span>
+        <span>{(contestSubmitInfo.result.memory / 1048576).toFixed(2)} </span>
+        <span className="ml-[-1px] text-red-500">MB</span>
       </td>
       <td className="">
-        <span>64 </span> <span className="ml-[-1px] text-red-500">ms</span>
+        <span>{contestSubmitInfo.result.time} </span>{' '}
+        <span className="ml-[-1px] text-red-500">ms</span>
       </td>
-      <td className="">C++17</td>
-      <td className="">2023.09.26 07:00:00</td>
+      <td className="">{contestSubmitInfo.language}</td>
+      <td className="">
+        {formatDateToYYMMDDHHMM(contestSubmitInfo.createdAt)}
+      </td>
     </tr>
   );
 }

--- a/app/contests/[cid]/submits/page.tsx
+++ b/app/contests/[cid]/submits/page.tsx
@@ -11,6 +11,17 @@ import { fetchCurrentUserInfo } from '@/app/utils/fetchCurrentUserInfo';
 import { UserInfo } from '@/app/types/user';
 import { useRouter } from 'next/navigation';
 import { OPERATOR_ROLES } from '@/app/constants/role';
+import axiosInstance from '@/app/utils/axiosInstance';
+import { useQuery } from '@tanstack/react-query';
+import { ContestInfo } from '@/app/types/contest';
+
+// 대회 게시글 정보 조회 API
+const fetchContestDetailInfo = ({ queryKey }: any) => {
+  const cid = queryKey[1];
+  return axiosInstance.get(
+    `${process.env.NEXT_PUBLIC_API_VERSION}/contest/${cid}`,
+  );
+};
 
 interface DefaultProps {
   params: {
@@ -19,27 +30,40 @@ interface DefaultProps {
 }
 
 export default function UsersContestSubmits(props: DefaultProps) {
+  const cid = props.params.cid;
+
+  const { isPending, data } = useQuery({
+    queryKey: ['contestDetailInfo', cid],
+    queryFn: fetchContestDetailInfo,
+  });
+
   const updateUserInfo = userInfoStore((state: any) => state.updateUserInfo);
+
+  const resData = data?.data.data;
+  const contestInfo: ContestInfo = resData;
 
   const [isLoading, setIsLoading] = useState(true);
 
   const router = useRouter();
 
-  const cid = props.params.cid;
-
-  // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
+  // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인, 그리고 게시글 작성자인지 확인
   useEffect(() => {
     fetchCurrentUserInfo(updateUserInfo).then((userInfo: UserInfo) => {
-      if (userInfo.isAuth && !OPERATOR_ROLES.includes(userInfo.role)) {
-        alert('접근 권한이 없습니다.');
-        router.back();
-        return;
+      if (contestInfo) {
+        if (
+          (userInfo.isAuth && !OPERATOR_ROLES.includes(userInfo.role)) ||
+          userInfo._id !== contestInfo.writer._id
+        ) {
+          alert('접근 권한이 없습니다.');
+          router.back();
+          return;
+        }
+        setIsLoading(false);
       }
-      setIsLoading(false);
     });
-  }, [updateUserInfo, router]);
+  }, [updateUserInfo, contestInfo, router]);
 
-  if (isLoading) return <Loading />;
+  if (isLoading || isPending) return <Loading />;
 
   return (
     <div className="mt-2 px-5 2lg:px-0 overflow-x-auto">
@@ -62,7 +86,7 @@ export default function UsersContestSubmits(props: DefaultProps) {
               href={`/contests/${cid}`}
               className="mt-1 ml-1 text-xl font-medium cursor-pointer hover:underline hover:text-[#0038a8] focus:underline focus:text-[#0038a8] text-[#1048b8]"
             >
-              (대회: 2023년 제2회 충청북도 대학생 프로그래밍 경진대회 본선)
+              ({contestInfo.title})
             </Link>
           </div>
         </p>
@@ -119,147 +143,7 @@ export default function UsersContestSubmits(props: DefaultProps) {
         </div>
 
         <section className="dark:bg-gray-900">
-          <div className="mx-auto w-full">
-            <div className="border dark:bg-gray-800 relative overflow-hidden rounded-sm">
-              <div className="overflow-x-auto">
-                <table className="w-full text-sm text-left text-gray-500 dark:text-gray-400">
-                  <thead className="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-gray-700 dark:text-gray-400 text-center">
-                    <tr>
-                      <th scope="col" className="w-16 px-4 py-2">
-                        번호
-                      </th>
-                      <th scope="col" className="px-4 py-2">
-                        대학
-                      </th>
-                      <th scope="col" className="px-4 py-2">
-                        학과(부)
-                      </th>
-                      <th scope="col" className="px-4 py-2">
-                        학번
-                      </th>
-                      <th scope="col" className="px-4 py-2">
-                        이름
-                      </th>
-                      <th scope="col" className="px-4 py-2">
-                        문제명
-                      </th>
-                      <th scope="col" className="px-4 py-2">
-                        결과
-                      </th>
-                      <th scope="col" className="px-4 py-2">
-                        메모리
-                      </th>
-                      <th scope="col" className="px-4 py-2">
-                        시간
-                      </th>
-                      <th scope="col" className="px-4 py-2">
-                        언어
-                      </th>
-                      <th scope="col" className="px-4 py-2">
-                        제출 시간
-                      </th>
-                    </tr>
-                  </thead>
-                  <UsersContestSubmitList cid={cid} />
-                </table>
-              </div>
-            </div>
-            <nav
-              className="flex flex-col md:flex-row text-xs justify-between items-start md:items-center space-y-3 md:space-y-0 pl-1 mt-3"
-              aria-label="Table navigation"
-            >
-              <span className="text-gray-500 dark:text-gray-400">
-                <span className="text-gray-500 dark:text-white"> 1 - 10</span>{' '}
-                of
-                <span className="text-gray-500 dark:text-white"> 1000</span>
-              </span>
-              <ul className="inline-flex items-stretch -space-x-px">
-                <li>
-                  <a
-                    href="#"
-                    className="flex items-center justify-center h-full py-1.5 px-[0.3rem] ml-0 text-gray-500 bg-white rounded-l-lg border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
-                  >
-                    <span className="sr-only">Previous</span>
-                    <svg
-                      className="w-5 h-5"
-                      aria-hidden="true"
-                      fill="currentColor"
-                      viewBox="0 0 20 20"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        fillRule="evenodd"
-                        d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
-                        clipRule="evenodd"
-                      />
-                    </svg>
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="#"
-                    className="flex items-center justify-center text-sm py-2 px-3 leading-tight text-gray-400 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
-                  >
-                    1
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="#"
-                    className="flex items-center justify-center text-sm py-2 px-3 leading-tight text-gray-400 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
-                  >
-                    2
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="#"
-                    aria-current="page"
-                    className="flex items-center justify-center text-sm z-10 py-2 px-3 leading-tight text-primary-600 bg-primary-50 border border-primary-300 hover:bg-primary-100 hover:text-primary-700 dark:border-gray-700 dark:bg-gray-700 dark:text-white"
-                  >
-                    3
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="#"
-                    className="flex items-center justify-center text-sm py-2 px-3 leading-tight text-gray-400 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
-                  >
-                    ...
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="#"
-                    className="flex items-center justify-center text-sm py-2 px-3 leading-tight text-gray-400 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
-                  >
-                    100
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="#"
-                    className="flex items-center justify-center h-full py-1.5 px-[0.3rem] leading-tight text-gray-500 bg-white rounded-r-lg border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
-                  >
-                    <span className="sr-only">Next</span>
-                    <svg
-                      className="w-5 h-5"
-                      aria-hidden="true"
-                      fill="currentColor"
-                      viewBox="0 0 20 20"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        fillRule="evenodd"
-                        d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-                        clipRule="evenodd"
-                      />
-                    </svg>
-                  </a>
-                </li>
-              </ul>
-            </nav>
-          </div>
+          <UsersContestSubmitList cid={cid} />
         </section>
       </div>
     </div>

--- a/app/contests/[cid]/submits/page.tsx
+++ b/app/contests/[cid]/submits/page.tsx
@@ -12,14 +12,23 @@ import { UserInfo } from '@/app/types/user';
 import { useRouter } from 'next/navigation';
 import { OPERATOR_ROLES } from '@/app/constants/role';
 import axiosInstance from '@/app/utils/axiosInstance';
-import { useQuery } from '@tanstack/react-query';
-import { ContestInfo } from '@/app/types/contest';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { ContestInfo, ContestSubmitInfo } from '@/app/types/contest';
+import * as XLSX from 'xlsx';
+import { getCodeSubmitResultTypeDescription } from '@/app/utils/getCodeSubmitResultTypeDescription';
 
 // 대회 게시글 정보 조회 API
 const fetchContestDetailInfo = ({ queryKey }: any) => {
   const cid = queryKey[1];
   return axiosInstance.get(
     `${process.env.NEXT_PUBLIC_API_VERSION}/contest/${cid}`,
+  );
+};
+
+// 대회 참가자 코드 제출 목록 정보 조회 API
+const fetchContestantSubmitsInfo = (cid: string) => {
+  return axiosInstance.get(
+    `${process.env.NEXT_PUBLIC_API_VERSION}/submit/contest/${cid}`,
   );
 };
 
@@ -35,6 +44,15 @@ export default function UsersContestSubmits(props: DefaultProps) {
   const { isPending, data } = useQuery({
     queryKey: ['contestDetailInfo', cid],
     queryFn: fetchContestDetailInfo,
+  });
+
+  const fetchContestantSubmitsInfoMutation = useMutation({
+    mutationFn: () => fetchContestantSubmitsInfo(cid),
+    onSuccess: (data) => {
+      const resData = data?.data.data;
+      const contestantSubmitsInfo: ContestSubmitInfo[] = resData.documents;
+      downloadSubmitsInfoListAsExcel(contestantSubmitsInfo, contestInfo.title);
+    },
   });
 
   const updateUserInfo = userInfoStore((state: any) => state.updateUserInfo);
@@ -62,6 +80,63 @@ export default function UsersContestSubmits(props: DefaultProps) {
       }
     });
   }, [updateUserInfo, contestInfo, router]);
+
+  const downloadSubmitsInfoListAsExcel = (
+    contestantSubmitsInfo: ContestSubmitInfo[],
+    contestTitle: string,
+  ) => {
+    // 엑셀 파일에 쓸 데이터 생성
+    const data = contestantSubmitsInfo.map((submitInfo, index) => ({
+      번호: index + 1,
+      대학: submitInfo.user.university,
+      '학부(과)': submitInfo.user.department,
+      학번: submitInfo.user.no,
+      이름: submitInfo.user.name,
+      문제명: submitInfo.problem.title,
+      결과: getCodeSubmitResultTypeDescription(submitInfo.result.type), // 결과 처리 로직 필요
+      메모리: `${(submitInfo.result.memory / 1048576).toFixed(2)} MB`, // 메모리 단위 변환
+      시간: `${submitInfo.result.time} ms`,
+      언어: submitInfo.language,
+      '제출 시간': new Date(submitInfo.createdAt).toLocaleString(), // 날짜 형식 변환
+    }));
+
+    // 워크시트 생성
+    const worksheet = XLSX.utils.json_to_sheet(data);
+
+    // 칼럼 너비 설정
+    worksheet['!cols'] = [
+      { wch: 7.5 }, // 번호
+      { wch: 15 }, // 대학
+      { wch: 20 }, // 학부(과)
+      { wch: 12.5 }, // 학번
+      { wch: 10 }, // 이름
+      { wch: 20 }, // 문제명
+      { wch: 12.5 }, // 결과
+      { wch: 10 }, // 메모리
+      { wch: 10 }, // 시간
+      { wch: 10 }, // 언어
+      { wch: 20 }, // 제출 시간
+    ];
+
+    worksheet['!autofilter'] = {
+      ref: `A1:K${contestantSubmitsInfo.length + 1}`,
+    };
+
+    const workbook = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(workbook, worksheet, '대회 제출 목록');
+
+    // 엑셀 파일 생성 및 다운로드
+    const fileName = `${contestTitle}_제출목록.xlsx`;
+    XLSX.writeFile(workbook, fileName);
+  };
+
+  const handleDownloadSubmitsInfoList = () => {
+    // 대회 참가자 정보와 대회명을 인자로 전달
+    const userResponse = confirm('명단을 다운로드 하시겠습니까?');
+    if (!userResponse) return;
+
+    fetchContestantSubmitsInfoMutation.mutate();
+  };
 
   if (isLoading || isPending) return <Loading />;
 
@@ -124,7 +199,7 @@ export default function UsersContestSubmits(props: DefaultProps) {
           <div className="relative ml-auto mt-auto bottom-[-0.75rem]">
             <div className="flex justify-end mb-2">
               <button
-                onClick={() => alert('개발 예정')}
+                onClick={handleDownloadSubmitsInfoList}
                 className="flex justify-center items-center gap-[0.375rem] text-[#f9fafb] bg-[#4fa16a] px-2 py-[0.45rem] rounded-[6px] focus:bg-[#3b8d56] hover:bg-[#3b8d56]"
               >
                 <svg
@@ -136,7 +211,7 @@ export default function UsersContestSubmits(props: DefaultProps) {
                 >
                   <path d="M 28.8125 0.03125 L 0.8125 5.34375 C 0.339844 5.433594 0 5.863281 0 6.34375 L 0 43.65625 C 0 44.136719 0.339844 44.566406 0.8125 44.65625 L 28.8125 49.96875 C 28.875 49.980469 28.9375 50 29 50 C 29.230469 50 29.445313 49.929688 29.625 49.78125 C 29.855469 49.589844 30 49.296875 30 49 L 30 1 C 30 0.703125 29.855469 0.410156 29.625 0.21875 C 29.394531 0.0273438 29.105469 -0.0234375 28.8125 0.03125 Z M 32 6 L 32 13 L 34 13 L 34 15 L 32 15 L 32 20 L 34 20 L 34 22 L 32 22 L 32 27 L 34 27 L 34 29 L 32 29 L 32 35 L 34 35 L 34 37 L 32 37 L 32 44 L 47 44 C 48.101563 44 49 43.101563 49 42 L 49 8 C 49 6.898438 48.101563 6 47 6 Z M 36 13 L 44 13 L 44 15 L 36 15 Z M 6.6875 15.6875 L 11.8125 15.6875 L 14.5 21.28125 C 14.710938 21.722656 14.898438 22.265625 15.0625 22.875 L 15.09375 22.875 C 15.199219 22.511719 15.402344 21.941406 15.6875 21.21875 L 18.65625 15.6875 L 23.34375 15.6875 L 17.75 24.9375 L 23.5 34.375 L 18.53125 34.375 L 15.28125 28.28125 C 15.160156 28.054688 15.035156 27.636719 14.90625 27.03125 L 14.875 27.03125 C 14.8125 27.316406 14.664063 27.761719 14.4375 28.34375 L 11.1875 34.375 L 6.1875 34.375 L 12.15625 25.03125 Z M 36 20 L 44 20 L 44 22 L 36 22 Z M 36 27 L 44 27 L 44 29 L 36 29 Z M 36 35 L 44 35 L 44 37 L 36 37 Z" />
                 </svg>
-                명단 다운로드
+                제출 목록 다운로드
               </button>
             </div>
           </div>

--- a/app/mypage/managing-my-post/components/contestPost/MyContestPostList.tsx
+++ b/app/mypage/managing-my-post/components/contestPost/MyContestPostList.tsx
@@ -41,7 +41,7 @@ export default function MyContestPostList() {
   };
 
   useEffect(() => {
-    // page가 유효한 양의 정수가 아닌 경우, /mypage/managing-my-post?page=1로 리다이렉트
+    // page가 유효한 양의 정수가 아닌 경우, ?page=1로 리다이렉트
     if (!params?.has('page') || !Number.isInteger(page) || page < 1) {
       router.replace('/mypage/managing-my-post?page=1');
     }

--- a/app/mypage/managing-my-post/components/practicePost/MyPracticePostList.tsx
+++ b/app/mypage/managing-my-post/components/practicePost/MyPracticePostList.tsx
@@ -48,7 +48,7 @@ export default function MyPracticePostList() {
   };
 
   useEffect(() => {
-    // page가 유효한 양의 정수가 아닌 경우, /mypage/managing-my-post?page=1로 리다이렉트
+    // page가 유효한 양의 정수가 아닌 경우, ?page=1로 리다이렉트
     if (!params?.has('page') || !Number.isInteger(page) || page < 1) {
       router.replace('/mypage/managing-my-post?page=1');
     }

--- a/app/types/contest.ts
+++ b/app/types/contest.ts
@@ -85,3 +85,43 @@ export interface ContestRankInfo {
   updatedAt: string;
   __v: number;
 }
+
+export interface ContestSubmitInfo {
+  parentId: {
+    _id: string;
+    title: string;
+  };
+  parentType: string;
+  result: {
+    memory: number;
+    time: number;
+    type: string;
+  };
+  _id: string;
+  problem: {
+    _id: string;
+    title: string;
+  };
+  source: string;
+  language: string;
+  user: {
+    center: null;
+    permissions: string[];
+    _id: string;
+    image: null;
+    no: string;
+    name: string;
+    email: string;
+    phone: string;
+    department: string;
+    position: null;
+    joinedAt: string;
+    updatedAt: string;
+    role: string;
+    university: string;
+    __v: number;
+  };
+  createdAt: string;
+  __v: number;
+  code: string;
+}

--- a/app/types/submit.ts
+++ b/app/types/submit.ts
@@ -1,0 +1,72 @@
+export interface SubmitInfo {
+  parentId: {
+    isPassword: boolean;
+    problems: string[];
+    applyingPeriod: null;
+    contestants: string[];
+    _id: string;
+    title: string;
+    content: string;
+    testPeriod: {
+      start: string;
+      end: string;
+    };
+    writer: {
+      _id: string;
+      name: string;
+    };
+    createdAt: string;
+    updatedAt: string;
+    __v: number;
+  };
+  parentType: string;
+  result: {
+    memory: number;
+    time: number;
+    type: string;
+  };
+  _id: string;
+  problem: {
+    parentId: string;
+    parentType: string;
+    published: null;
+    score: number;
+    _id: string;
+    title: string;
+    content: string;
+    ioSet: Array<{
+      inFile: string;
+      outFile: string;
+    }>;
+    options: {
+      maxRealTime: number;
+      maxMemory: number;
+    };
+    writer: string;
+    createdAt: string;
+    updatedAt: string;
+    __v: number;
+  };
+  source: string;
+  language: string;
+  user: {
+    center: null;
+    permissions: string[];
+    _id: string;
+    image: null;
+    no: string;
+    name: string;
+    email: string;
+    phone: string;
+    department: string;
+    position: null;
+    joinedAt: string;
+    updatedAt: string;
+    role: string;
+    university: string;
+    __v: number;
+  };
+  createdAt: string;
+  __v: number;
+  code: string;
+}

--- a/app/utils/formatDate.ts
+++ b/app/utils/formatDate.ts
@@ -1,3 +1,26 @@
+export function formatDateToYYMMDDHHMMSS(dateString: string): string {
+  // Date 객체 생성
+  const date = new Date(dateString);
+
+  // 연도, 월, 일, 시간, 분을 추출
+  const year = date.getFullYear().toString().slice(-2);
+  const month = date.getMonth() + 1; // getMonth()는 0부터 시작하므로 1을 더함
+  const day = date.getDate();
+  const hours = date.getHours();
+  const minutes = date.getMinutes();
+  const seconds = date.getSeconds();
+
+  // 각 부분을 두 자리 문자열로 변환 (예: '01', '02', ...)
+  const monthStr = month.toString().padStart(2, '0');
+  const dayStr = day.toString().padStart(2, '0');
+  const hoursStr = hours.toString().padStart(2, '0');
+  const minutesStr = minutes.toString().padStart(2, '0');
+  const secondsStr = seconds.toString().padStart(2, '0');
+
+  // 최종 형식으로 문자열 구성
+  return `${year}/${monthStr}/${dayStr} ${hoursStr}:${minutesStr}:${secondsStr}`;
+}
+
 export function formatDateToYYMMDDHHMM(dateString: string): string {
   // Date 객체 생성
   const date = new Date(dateString);

--- a/app/utils/getCodeSubmitResultTypeDescription.ts
+++ b/app/utils/getCodeSubmitResultTypeDescription.ts
@@ -1,0 +1,18 @@
+export function getCodeSubmitResultTypeDescription(resultType: string): string {
+  switch (resultType) {
+    case 'compile':
+      return '컴파일 오류';
+    case 'runtime':
+      return '런타임 오류';
+    case 'timeout':
+      return '시간 초과';
+    case 'memory':
+      return '메모리 초과';
+    case 'wrong':
+      return '오답';
+    case 'done':
+      return '정답';
+    default:
+      return '알 수 없음';
+  }
+}

--- a/app/utils/getLanguageCode.ts
+++ b/app/utils/getLanguageCode.ts
@@ -1,0 +1,21 @@
+export function getLanguageCode(language: string): string {
+  switch (language) {
+    case 'c':
+      return 'c';
+    case 'c++':
+      return 'cpp';
+    case 'java':
+      return 'java';
+    case 'javascript':
+      return 'javascript';
+    case 'python2':
+    case 'python3':
+      return 'python';
+    case 'kotlin':
+      return 'kotlin';
+    case 'go':
+      return 'go';
+    default:
+      return '알 수 없음';
+  }
+}


### PR DESCRIPTION
## 👀 이슈

resolve #186 

## 📌 개요

대회 게시글 내에서 `대회 코드 제출 목록` 버튼 클릭 시 참가자의 실제 코드 제출 목록 및
코드가 표시되도록 해당 기능을 추가하였습니다.

## 👩‍💻 작업 사항

- `대회 코드 제출 목록` 표시 기능 추가
- `제출 코드` 표시 기능 추가

## ✅ 참고 사항

- 기능 추가 후 `대회 코드 제출 목록/제출 코드` 페이지 UI

https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/cd7a54d8-db3f-4e43-acee-3ad08dad30e2