### PR TITLE
[fix]: useQuery hook의 queryFn 속성 함수의 일반 변수 파라미터에서 queryKey 파라미터로 일괄 수정 (#190)

### DIFF
--- a/app/contests/components/ContestList.tsx
+++ b/app/contests/components/ContestList.tsx
@@ -16,7 +16,9 @@ interface ContestListProps {
 }
 
 // 대회 목록 반환 API (10개 게시글 단위로)
-const fetchContests = async (page: number, searchQuery: string) => {
+const fetchContests = async ({ queryKey }: any) => {
+  const page = queryKey[1];
+  const searchQuery = queryKey[2];
   const response = await axiosInstance.get(
     `${process.env.NEXT_PUBLIC_API_VERSION}/contest/?page=${page}&limit=10&sort=-createdAt&q=title=${searchQuery}`,
   );
@@ -32,7 +34,7 @@ export default function ContestList({ searchQuery }: ContestListProps) {
 
   const { isPending, data } = useQuery({
     queryKey: ['contestList', page, debouncedSearchQuery],
-    queryFn: () => fetchContests(page, searchQuery),
+    queryFn: fetchContests,
   });
 
   const router = useRouter();

--- a/app/exams/[eid]/page.tsx
+++ b/app/exams/[eid]/page.tsx
@@ -16,7 +16,8 @@ import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useState } from 'react';
 
 // 시험 게시글 정보 조회 API
-const fetchExamDetailInfo = (eid: string) => {
+const fetchExamDetailInfo = ({ queryKey }: any) => {
+  const eid = queryKey[1];
   return axiosInstance.get(
     `${process.env.NEXT_PUBLIC_API_VERSION}/assignment/${eid}`,
   );
@@ -52,7 +53,7 @@ export default function ExamDetail(props: DefaultProps) {
 
   const { isPending, isError, data, error } = useQuery({
     queryKey: ['examDetailInfo', eid],
-    queryFn: () => fetchExamDetailInfo(eid),
+    queryFn: fetchExamDetailInfo,
     retry: 0,
   });
 

--- a/app/exams/components/ExamList.tsx
+++ b/app/exams/components/ExamList.tsx
@@ -16,7 +16,9 @@ interface ExamListProps {
 }
 
 // 시험 목록 반환 API (10개 게시글 단위로)
-const fetchExams = async (page: number, searchQuery: string) => {
+const fetchExams = async ({ queryKey }: any) => {
+  const page = queryKey[1];
+  const searchQuery = queryKey[2];
   const response = await axiosInstance.get(
     `${process.env.NEXT_PUBLIC_API_VERSION}/assignment/?page=${page}&limit=10&sort=-createdAt&q=title,course,writer=${searchQuery}`,
   );
@@ -32,7 +34,7 @@ export default function ExamList({ searchQuery }: ExamListProps) {
 
   const { isPending, data } = useQuery({
     queryKey: ['examList', page, debouncedSearchQuery],
-    queryFn: () => fetchExams(page, searchQuery),
+    queryFn: fetchExams,
   });
 
   const router = useRouter();

--- a/app/mypage/managing-my-post/components/contestPost/MyContestPostList.tsx
+++ b/app/mypage/managing-my-post/components/contestPost/MyContestPostList.tsx
@@ -11,7 +11,8 @@ import { ContestInfo } from '@/app/types/contest';
 import { RenderPaginationButtons } from '@/app/components/RenderPaginationButtons';
 
 // 본인이 작성한 대회 게시글 목록 반환 API (10개 게시글 단위로)
-const fetchMyContests = async (page: number) => {
+const fetchMyContests = async ({ queryKey }: any) => {
+  const page = queryKey[1];
   const response = await axiosInstance.get(
     `${process.env.NEXT_PUBLIC_API_VERSION}/contest/me?page=${page}&limit=10&sort=-createdAt`,
   );
@@ -25,7 +26,7 @@ export default function MyContestPostList() {
 
   const { isPending, data } = useQuery({
     queryKey: ['myContests', page],
-    queryFn: () => fetchMyContests(page),
+    queryFn: fetchMyContests,
   });
 
   const router = useRouter();

--- a/app/mypage/managing-my-post/components/examPost/MyExamPostList.tsx
+++ b/app/mypage/managing-my-post/components/examPost/MyExamPostList.tsx
@@ -10,7 +10,8 @@ import { ExamInfo } from '@/app/types/exam';
 import { RenderPaginationButtons } from '@/app/components/RenderPaginationButtons';
 
 // 본인이 작성한 시험 게시글 목록 반환 API (10개 게시글 단위로)
-const fetchMyExams = async (page: number) => {
+const fetchMyExams = async ({ queryKey }: any) => {
+  const page = queryKey[1];
   const response = await axiosInstance.get(
     `${process.env.NEXT_PUBLIC_API_VERSION}/assignment/me?page=${page}&limit=10&sort=-createdAt`,
   );
@@ -24,7 +25,7 @@ export default function MyExamPostList() {
 
   const { isPending, data } = useQuery({
     queryKey: ['myExams', page],
-    queryFn: () => fetchMyExams(page),
+    queryFn: fetchMyExams,
   });
 
   const router = useRouter();

--- a/app/mypage/managing-my-post/components/practicePost/MyPracticePostList.tsx
+++ b/app/mypage/managing-my-post/components/practicePost/MyPracticePostList.tsx
@@ -12,7 +12,8 @@ import { RenderPaginationButtons } from '@/app/components/RenderPaginationButton
 import { userInfoStore } from '@/app/store/UserInfo';
 
 // 본인이 작성한 대회 게시글 목록 반환 API (10개 게시글 단위로)
-const fetchMyPractices = async (page: number) => {
+const fetchMyPractices = async ({ queryKey }: any) => {
+  const page = queryKey[1];
   const response = await axiosInstance.get(
     `${process.env.NEXT_PUBLIC_API_VERSION}/practice/?page=${page}&limit=10&sort=-createdAt`,
   );
@@ -28,7 +29,7 @@ export default function MyPracticePostList() {
 
   const { isPending, data } = useQuery({
     queryKey: ['myPractices', page],
-    queryFn: () => fetchMyPractices(page),
+    queryFn: fetchMyPractices,
   });
 
   const router = useRouter();

--- a/app/practices/[pid]/page.tsx
+++ b/app/practices/[pid]/page.tsx
@@ -11,7 +11,8 @@ import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
 
 // 연습문제 게시글 정보 조회 API
-const fetchPracticeDetailInfo = (eid: string) => {
+const fetchPracticeDetailInfo = ({ queryKey }: any) => {
+  const eid = queryKey[1];
   return axiosInstance.get(
     `${process.env.NEXT_PUBLIC_API_VERSION}/practice/${eid}`,
   );
@@ -32,7 +33,7 @@ export default function PracticeProblem(props: DefaultProps) {
 
   const { isPending, isError, data, error } = useQuery({
     queryKey: ['practiceDetailInfo', pid],
-    queryFn: () => fetchPracticeDetailInfo(pid),
+    queryFn: fetchPracticeDetailInfo,
     retry: 0,
   });
 

--- a/app/practices/components/PracticeList.tsx
+++ b/app/practices/components/PracticeList.tsx
@@ -17,7 +17,9 @@ interface PracticeListProps {
 }
 
 // 연습문제 목록 반환 API (10개 게시글 단위로)
-const fetchPractices = async (page: number, searchQuery: string) => {
+const fetchPractices = async ({ queryKey }: any) => {
+  const page = queryKey[1];
+  const searchQuery = queryKey[2];
   const response = await axiosInstance.get(
     `${process.env.NEXT_PUBLIC_API_VERSION}/practice/?page=${page}&limit=10&sort=-createdAt&q=title,writer=${searchQuery}`,
   );
@@ -33,7 +35,7 @@ export default function PracticeList({ searchQuery }: PracticeListProps) {
 
   const { isPending, data } = useQuery({
     queryKey: ['practiceList', page, debouncedSearchQuery],
-    queryFn: () => fetchPractices(page, searchQuery),
+    queryFn: fetchPractices,
   });
 
   const router = useRouter();


### PR DESCRIPTION
## 👀 이슈

resolve #190 

## 📌 개요

react query의 useQuery hook을 사용하는 컴포넌트에서
queryFn 속성을 통해 API 호출 함수에 직접적으로 인수를
넘겨주는 로직 대신에 `queryKey`를 파라미터로 사용하는 방식으로
코드를 통일성 있게 수정하였습니다.

## 👩‍💻 작업 사항

- useQuery hook의 queryFn 속성 함수의 일반 변수 파라미터를 사용하는 컴포넌트 내 API 함수의 인자를 `queryKey` 파라미터로 일괄 수정

## ✅ 참고 사항

없습니다
