### PR TITLE
[feat]: 시험 삭제하기 기능 추가 (#202)

### DIFF
--- a/app/contests/[cid]/page.tsx
+++ b/app/contests/[cid]/page.tsx
@@ -24,6 +24,7 @@ const fetchContestDetailInfo = ({ queryKey }: any) => {
   );
 };
 
+// 대회 삭제 API
 const deleteContest = (cid: string) => {
   return axiosInstance.delete(
     `${process.env.NEXT_PUBLIC_API_VERSION}/contest/${cid}`,
@@ -83,7 +84,7 @@ export default function ContestDetail(props: DefaultProps) {
         case 400:
           switch (resData.code) {
             case 'AFTER_TEST_START':
-              alert('대회 시작 시간 이후에는 대회를 삭제하실 수 없습니다.');
+              alert('대회 시작 시간 이후에는 게시글을 삭제하실 수 없습니다.');
               break;
             default:
               alert('정의되지 않은 http code입니다.');

--- a/app/exams/[eid]/page.tsx
+++ b/app/exams/[eid]/page.tsx
@@ -10,7 +10,6 @@ import axiosInstance from '@/app/utils/axiosInstance';
 import { fetchCurrentUserInfo } from '@/app/utils/fetchCurrentUserInfo';
 import { formatDateToYYMMDDHHMM } from '@/app/utils/formatDate';
 import { useMutation, useQuery } from '@tanstack/react-query';
-import { AxiosError } from 'axios';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useState } from 'react';
@@ -19,6 +18,13 @@ import { useCallback, useEffect, useState } from 'react';
 const fetchExamDetailInfo = ({ queryKey }: any) => {
   const eid = queryKey[1];
   return axiosInstance.get(
+    `${process.env.NEXT_PUBLIC_API_VERSION}/assignment/${eid}`,
+  );
+};
+
+// 시험 삭제 API
+const deleteExam = (eid: string) => {
+  return axiosInstance.delete(
     `${process.env.NEXT_PUBLIC_API_VERSION}/assignment/${eid}`,
   );
 };
@@ -55,6 +61,14 @@ export default function ExamDetail(props: DefaultProps) {
     queryKey: ['examDetailInfo', eid],
     queryFn: fetchExamDetailInfo,
     retry: 0,
+  });
+
+  const deleteExamMutation = useMutation({
+    mutationFn: deleteExam,
+    onSuccess: () => {
+      alert('시험이 삭제되었습니다.');
+      router.push('/exams');
+    },
   });
 
   const enrollExamMutation = useMutation({
@@ -186,11 +200,11 @@ export default function ExamDetail(props: DefaultProps) {
 
   const handleDeleteExam = () => {
     const userResponse = confirm(
-      '현재 시험 게시글을 삭제하시겠습니까?\n삭제 후 내용을 되돌릴 수 없습니다.',
+      '시험을 삭제하시겠습니까?\n삭제 후 내용을 되돌릴 수 없습니다.',
     );
     if (!userResponse) return;
-    alert('게시글을 삭제하였습니다.');
-    router.push('/exams');
+
+    deleteExamMutation.mutate(eid);
   };
 
   const handleEnrollExam = () => {


### PR DESCRIPTION
## 👀 이슈

resolve #202 

## 📌 개요

관리자 사용자가 자신이 생성한 시험을 삭제할 수 있도록
해당 기능을 추가하였습니다.

## 👩‍💻 작업 사항

- 대회 삭제하기 기능 추가

## ✅ 참고 사항

- 기능 추가 후 **시험 삭제하기** 기능 시연 화면

https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/716e1b8e-88dc-4340-b631-eebb45c5ff25