### PR TITLE
[feat]: 임시 공지사항 게시글 추가 (#212)

### DIFF
--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -79,7 +79,7 @@ export default function Navbar() {
               연습문제
             </Link>
             <Link
-              href="/notices"
+              href="/notice"
               className="px-3 py-2 rounded-md hover:bg-[#f3f4f5] focus:bg-[#f3f4f5]"
             >
               공지사항
@@ -231,7 +231,7 @@ export default function Navbar() {
                 연습문제
               </Link>
               <Link
-                href="/notices"
+                href="/notice"
                 onClick={(e) => {
                   e.stopPropagation();
                   setRightPos('-right-full');

--- a/app/mypage/managing-my-post/page.tsx
+++ b/app/mypage/managing-my-post/page.tsx
@@ -82,7 +82,7 @@ export default function ManagingMyPost() {
             )}
           </div>
         </div>
-        <div>
+        {/* <div>
           <div>
             <button
               onClick={() => handleChangeCategory('notice')}
@@ -96,7 +96,7 @@ export default function ManagingMyPost() {
               <div className="relative top-[3px] h-[2px] rounded-full bg-[#1a1f27]" />
             )}
           </div>
-        </div>
+        </div> */}
       </div>
       <div>
         {category === 'contest' ? (

--- a/app/notice/page.tsx
+++ b/app/notice/page.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+
+const MarkdownPreview = dynamic(
+  () => import('@uiw/react-markdown-preview').then((mod) => mod.default),
+  { ssr: false },
+);
+
+export default function NoticeTemp() {
+  return (
+    <div className="mt-6 mb-24 px-5 2lg:px-0 overflow-x-auto">
+      <div className="flex flex-col w-[60rem] mx-auto">
+        <div className="flex flex-col gap-3">
+          <p className="text-2xl font-bold tracking-tight">공지사항</p>
+          <div className="flex justify-between border-b border-gray-300"></div>
+        </div>
+        <div className="border-b mt-8 mb-4 pb-5">
+          <MarkdownPreview
+            className="markdown-preview"
+            source={`
+상기 시스템은 현재 <span style="color:hsl(240, 75%, 60%);"><strong>베타 테스트</strong></span> 중에 있습니다.
+
+사용에 있어 궁금하신 사항은 <u>홈페이지 우측 하단의</u>
+
+<b>문의 공간</b>을 이용하여 남겨주세요.
+
+<br />
+
+### 💻 컴파일러 버전 정보
+- **c**: gnu11
+- **c++**: c++17
+- **python2**: 2.7.17
+- **python3**: 3.9.2
+- **openjdk**: 1.8.0_292
+- **kotlin**: 1.5.31-release-548
+- **go**: 1.17.2
+- **node**: 10.24.1
+`}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 👀 이슈

resolve #212 

## 📌 개요

현재 공지사항을 게시판 형태로 관리할 수 있는 기능이 서버 측에 별도로
존재하지 않으므로, 기존 시스템에서 임시로 사용 중이던 내용으로
구성된 임시 공지사항 게시글을 `Navbar` 내 **공지사항** 메뉴 클릭 시
해당 게시글로 리다이렉트 되도록 하였습니다.

## 👩‍💻 작업 사항

- 임시 공지사항 게시글 추가

## ✅ 참고 사항

- 추가된 **임시 공지사항 게시글** 페이지 화면

<img width="1608" alt="Screenshot 2024-02-22 at 10 28 19 PM" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/2e279e8c-95b7-4b78-96cd-2441a6c467c2">