### PR TITLE
[feat]: 대회 문제 목록 페이지 컴포넌트 내 데이터 조회 기능 추가 (#216)

### DIFF
--- a/app/contests/[cid]/problems/components/ContestProblemList.tsx
+++ b/app/contests/[cid]/problems/components/ContestProblemList.tsx
@@ -10,39 +10,33 @@ import {
 } from 'react-beautiful-dnd';
 import { useRouter } from 'next/navigation';
 import Loading from '@/app/loading';
+import { ProblemInfo } from '@/app/types/problem';
 
 interface ContestProblemListProps {
   cid: string;
   isChagingContestProblemOrderActivate: boolean;
+  problemsInfo: ProblemInfo[];
+  setProblemsInfo: (problemsInfo: ProblemInfo[]) => void;
 }
 
 export default function ContestProblemList({
   cid,
   isChagingContestProblemOrderActivate,
+  problemsInfo,
+  setProblemsInfo,
 }: ContestProblemListProps) {
   const [isLoading, setIsLoading] = useState(true);
-  const [isProblemListEmpty, setIsProblemListEmpty] = useState(true);
-
-  const [datas, setDatas] = useState([
-    { id: '650ae1a19c2734584192d58e', idx: 'A', problemTitle: 'A+B' },
-    { id: '650af3809c2734584192d5b2', idx: 'B', problemTitle: 'A-B' },
-    { id: '650af7209c2734584192d603', idx: 'C', problemTitle: '삼각형' },
-    { id: '650af7379c2734584192d612', idx: 'D', problemTitle: '피보나치 수' },
-    { id: '650ce0110b8de0052a8cb971', idx: 'E', problemTitle: '순열의 개수' },
-    { id: '650ce0110b8de0052a8cb925', idx: 'F', problemTitle: '가방 정리' },
-    { id: '650ce0110b8de0052a1cb976', idx: 'G', problemTitle: '카드 색칠' },
-  ]);
 
   const router = useRouter();
 
   const handleChangeProblemOrder = (result: DropResult) => {
     if (!result.destination) return;
     console.log(result);
-    const items = [...datas];
+    const items = [...problemsInfo];
     const [reorderedItem] = items.splice(result.source.index, 1);
     items.splice(result.destination.index, 0, reorderedItem);
 
-    setDatas(items);
+    setProblemsInfo(items);
   };
 
   const handleGoToContestProblem = (id: string) => {
@@ -51,11 +45,10 @@ export default function ContestProblemList({
 
   useEffect(() => {
     setIsLoading(false);
-    setIsProblemListEmpty(false);
   }, []);
 
   if (isLoading) return <Loading />;
-  if (isProblemListEmpty) return <NoneContestProblemListItem />;
+  if (problemsInfo.length === 0) return <NoneContestProblemListItem />;
 
   return (
     <div className="mb-14">
@@ -71,10 +64,10 @@ export default function ContestProblemList({
               ref={provided.innerRef}
               className="flex flex-col gap-4 pl-3"
             >
-              {datas.map((data, idx) => (
-                <div key={data.id} className="flex items-center gap-3">
+              {problemsInfo.map((problem, idx) => (
+                <div key={problem._id} className="flex items-center gap-3">
                   <div className="w-full">
-                    <Draggable draggableId={data.id} index={idx}>
+                    <Draggable draggableId={problem._id} index={idx}>
                       {(provided, snapshot) => (
                         <div
                           ref={
@@ -86,7 +79,9 @@ export default function ContestProblemList({
                           {...provided.dragHandleProps}
                         >
                           <div
-                            onClick={() => handleGoToContestProblem(data.id)}
+                            onClick={() =>
+                              handleGoToContestProblem(problem._id)
+                            }
                             className="flex items-center gap-2 w-full border p-2 cursor-pointer hover:bg-gray-50 focus:bg-gray-50 rounded-sm shadow-sm"
                           >
                             {!isChagingContestProblemOrderActivate ? (
@@ -106,7 +101,7 @@ export default function ContestProblemList({
                               </svg>
                             )}
                             <span className="ml-1 text-[#0076C0] hover:underline focus:underline">
-                              {data.problemTitle}
+                              {problem.title}
                             </span>
                           </div>
                         </div>

--- a/app/types/problem.ts
+++ b/app/types/problem.ts
@@ -51,3 +51,40 @@ export interface RegisterProblemParams {
   };
   score: number;
 }
+
+export interface ProblemsInfo {
+  password: string;
+  isPassword: boolean;
+  problems: ProblemInfo[];
+  applyingPeriod?: {
+    start: string;
+    end: string;
+  };
+  contestants: string[];
+  _id: string;
+  title: string;
+  content: string;
+  testPeriod: {
+    start: string; // Date 타입으로 변환할 수도 있습니다.
+    end: string; // Date 타입으로 변환할 수도 있습니다.
+  };
+  writer: {
+    center?: any; // 'null'이거나 더 구체적인 타입이 필요할 수 있습니다.
+    permissions: string[];
+    _id: string;
+    no: string;
+    name: string;
+    email: string;
+    phone: string;
+    department: string;
+    university: string;
+    position: string;
+    role: string;
+    joinedAt: string; // Date 타입으로 변환할 수도 있습니다.
+    updatedAt: string; // Date 타입으로 변환할 수도 있습니다.
+    __v: number;
+  };
+  createdAt: string; // Date 타입으로 변환할 수도 있습니다.
+  updatedAt: string; // Date 타입으로 변환할 수도 있습니다.
+  __v: number;
+}

--- a/app/utils/axiosInstance.ts
+++ b/app/utils/axiosInstance.ts
@@ -25,6 +25,18 @@ axiosInstance.interceptors.response.use(
     // 응답 에러 처리
     if (error.response) {
       switch (error.response.status) {
+        case 400:
+          switch (error.response.data.code) {
+            case 'IS_NOT_CONTESTANT':
+              alert('대회 참가자가 아닙니다.');
+              if (typeof window !== 'undefined') window.history.back();
+              return;
+            case 'IS_NOT_TEST_PERIOD':
+              alert('대회 시간이 아닙니다.');
+              if (typeof window !== 'undefined') window.history.back();
+              return;
+          }
+          break;
         case 401:
           // 401 Unauthorized 에러 처리
           localStorage.removeItem('access-token');
@@ -33,22 +45,21 @@ axiosInstance.interceptors.response.use(
           if (typeof window !== 'undefined') window.location.href = '/login';
           break;
         case 404:
-          console.log(error.code);
-          switch (error.code) {
+          switch (error.response.data.code) {
             case 'CONTEST_NOT_FOUND':
             case 'ASSIGNMENT_NOT_FOUND':
             case 'PROBLEM_NOT_FOUND':
             case 'ERR_BAD_REQUEST':
               alert('존재하지 않는 게시글입니다.');
-              if (typeof window !== 'undefined') window.location.href = '/';
+              if (typeof window !== 'undefined') window.history.back();
               return;
           }
+          break;
         case 500:
           // 500 Internal Server Error 에러 처리
           alert('서버에 오류가 발생하였습니다. 잠시 후 다시 시도해주세요.');
           break;
         default:
-          break;
       }
     }
     return Promise.reject(error);


### PR DESCRIPTION
## 👀 이슈

resolve #216 

## 📌 개요

대회 문제 목록 페이지 컴포넌트 내 하드코딩되어 있는 데이터가 아닌
서버 API를 통해 실제 DB에 저장되어 있는 문제 목록 정보를 페이지에
표시해 주는 기능을 추가하였습니다.

## 👩‍💻 작업 사항

- 대회 문제 목록 페이지 컴포넌트 내 데이터 조회 기능 추가
- 대회 문제 표시 순서 변경 기능 추가

## ✅ 참고 사항

- 기능 추가 후 **대회 문제 목록 페이지** 화면

https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/b3a8447c-aa8c-44a3-ade0-9e989bf83bdd