### PR TITLE
[feat]: 시험 문제 목록 페이지 컴포넌트 내 데이터 조회 및 문제 순서 변경 기능 추가 (#218)

### DIFF
--- a/app/contests/[cid]/page.tsx
+++ b/app/contests/[cid]/page.tsx
@@ -471,23 +471,24 @@ export default function ContestDetail(props: DefaultProps) {
               </svg>
               대회 순위
             </button>
-            {OPERATOR_ROLES.includes(userInfo.role) && (
-              <button
-                onClick={handleGoToUsersContestSubmits}
-                className="flex justify-center items-center gap-[0.375rem] text-[#f9fafb] bg-[#6860ff] px-2 py-[0.45rem] rounded-[6px] focus:bg-[#5951f0] hover:bg-[#5951f0]"
-              >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  height="20"
-                  viewBox="0 -960 960 960"
-                  width="20"
-                  fill="white"
+            {OPERATOR_ROLES.includes(userInfo.role) &&
+              userInfo._id === contestInfo.writer._id && (
+                <button
+                  onClick={handleGoToUsersContestSubmits}
+                  className="flex justify-center items-center gap-[0.375rem] text-[#f9fafb] bg-[#6860ff] px-2 py-[0.45rem] rounded-[6px] focus:bg-[#5951f0] hover:bg-[#5951f0]"
                 >
-                  <path d="M320-242 80-482l242-242 43 43-199 199 197 197-43 43Zm318 2-43-43 199-199-197-197 43-43 240 240-242 242Z" />
-                </svg>
-                코드 제출 목록
-              </button>
-            )}
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    height="20"
+                    viewBox="0 -960 960 960"
+                    width="20"
+                    fill="white"
+                  >
+                    <path d="M320-242 80-482l242-242 43 43-199 199 197 197-43 43Zm318 2-43-43 199-199-197-197 43-43 240 240-242 242Z" />
+                  </svg>
+                  코드 제출 목록
+                </button>
+              )}
             {shouldShowProblemsButton() && (
               <button
                 onClick={handleGoToContestProblems}

--- a/app/contests/[cid]/problems/components/ContestProblemList.tsx
+++ b/app/contests/[cid]/problems/components/ContestProblemList.tsx
@@ -25,13 +25,10 @@ export default function ContestProblemList({
   problemsInfo,
   setProblemsInfo,
 }: ContestProblemListProps) {
-  const [isLoading, setIsLoading] = useState(true);
-
   const router = useRouter();
 
   const handleChangeProblemOrder = (result: DropResult) => {
     if (!result.destination) return;
-    console.log(result);
     const items = [...problemsInfo];
     const [reorderedItem] = items.splice(result.source.index, 1);
     items.splice(result.destination.index, 0, reorderedItem);
@@ -43,11 +40,6 @@ export default function ContestProblemList({
     router.push(`/contests/${cid}/problems/${id}`);
   };
 
-  useEffect(() => {
-    setIsLoading(false);
-  }, []);
-
-  if (isLoading) return <Loading />;
   if (problemsInfo.length === 0) return <NoneContestProblemListItem />;
 
   return (

--- a/app/contests/[cid]/problems/page.tsx
+++ b/app/contests/[cid]/problems/page.tsx
@@ -101,15 +101,15 @@ export default function ContestProblems(props: DefaultProps) {
     retry: 0,
   });
 
+  const resData = data?.data.data;
+  const contestProblemsInfo: ProblemsInfo = resData;
+
   const contestProblemReorderMutation = useMutation({
     mutationFn: contestProblemReorder,
     onSuccess: () => {
       alert('문제 순서가 변경되었습니다.');
     },
   });
-
-  const resData = data?.data.data;
-  const contestProblemsInfo: ProblemsInfo = resData;
 
   const userInfo = userInfoStore((state: any) => state.userInfo);
   const updateUserInfo = userInfoStore((state: any) => state.updateUserInfo);
@@ -131,9 +131,9 @@ export default function ContestProblems(props: DefaultProps) {
     setIsChangingContestProblemOrderActivate,
   ] = useState(false);
 
-  const router = useRouter();
-
   const changingProblemOrderBtnRef = useRef<HTMLButtonElement>(null);
+
+  const router = useRouter();
 
   useEffect(() => {
     if (contestProblemsInfo) {
@@ -146,11 +146,12 @@ export default function ContestProblems(props: DefaultProps) {
     // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인, 그리고 게시글 작성자인지 확인
     fetchCurrentUserInfo(updateUserInfo).then((userInfo: UserInfo) => {
       if (contestProblemsInfo) {
+        const isWriter = contestProblemsInfo.writer._id === userInfo._id;
         const isContestant = contestProblemsInfo.contestants.some(
           (contestant_id) => contestant_id === userInfo._id,
         );
 
-        if (userInfo.isAuth && isContestant) {
+        if (isContestant) {
           setIsLoading(false);
           const contestPasswordCookie = getCookie(cid);
           if (contestPasswordCookie) {
@@ -176,11 +177,7 @@ export default function ContestProblems(props: DefaultProps) {
           return;
         }
 
-        if (
-          userInfo.isAuth &&
-          (OPERATOR_ROLES.includes(userInfo.role) ||
-            userInfo._id === contestProblemsInfo.writer._id)
-        ) {
+        if (isWriter) {
           setIsLoading(false);
           setIsPasswordChecked(true);
           return;
@@ -360,6 +357,7 @@ export default function ContestProblems(props: DefaultProps) {
                   </button>
                 )}
             </div>
+
             <div className="mt-3">
               <span className="font-semibold">
                 대회 시간:{' '}

--- a/app/contests/[cid]/submits/[submitId]/page.tsx
+++ b/app/contests/[cid]/submits/[submitId]/page.tsx
@@ -3,7 +3,6 @@
 import { OPERATOR_ROLES } from '@/app/constants/role';
 import Loading from '@/app/loading';
 import { userInfoStore } from '@/app/store/UserInfo';
-import { ContestSubmitInfo } from '@/app/types/contest';
 import { SubmitInfo } from '@/app/types/submit';
 import { UserInfo } from '@/app/types/user';
 import axiosInstance from '@/app/utils/axiosInstance';

--- a/app/contests/[cid]/submits/page.tsx
+++ b/app/contests/[cid]/submits/page.tsx
@@ -69,11 +69,9 @@ export default function UsersContestSubmits(props: DefaultProps) {
   useEffect(() => {
     fetchCurrentUserInfo(updateUserInfo).then((userInfo: UserInfo) => {
       if (contestInfo) {
-        if (
-          userInfo.isAuth &&
-          (OPERATOR_ROLES.includes(userInfo.role) ||
-            userInfo._id === contestInfo.writer._id)
-        ) {
+        const isWriter = contestInfo.writer._id === userInfo._id;
+
+        if (isWriter) {
           setIsLoading(false);
           return;
         }

--- a/app/exams/[eid]/edit/page.tsx
+++ b/app/exams/[eid]/edit/page.tsx
@@ -161,6 +161,13 @@ export default function EditExam(props: DefaultProps) {
       return;
     }
 
+    // 시험 시작 시간과 종료 시간의 유효성 검사
+    if (examStartDateTime >= examEndDateTime) {
+      alert('시험 종료 시간은 시작 시간 이후로 설정해야 합니다.');
+      window.scrollTo(0, document.body.scrollHeight);
+      return;
+    }
+
     if (!examPwd) {
       alert('비밀번호를 입력해 주세요');
       window.scrollTo(0, document.body.scrollHeight);

--- a/app/exams/[eid]/problems/components/ExamProblemList.tsx
+++ b/app/exams/[eid]/problems/components/ExamProblemList.tsx
@@ -10,52 +10,37 @@ import {
 import { useRouter } from 'next/navigation';
 import NoneExamProblemListItem from './NoneExamProblemListItem';
 import Loading from '@/app/loading';
+import { ProblemInfo } from '@/app/types/problem';
 
 interface ExamProblemListProps {
   eid: string;
   isChagingExamProblemOrderActivate: boolean;
+  problemsInfo: ProblemInfo[];
+  setProblemsInfo: (problemsInfo: ProblemInfo[]) => void;
 }
 
 export default function ExamProblemList({
   eid,
   isChagingExamProblemOrderActivate,
+  problemsInfo,
+  setProblemsInfo,
 }: ExamProblemListProps) {
-  const [isLoading, setIsLoading] = useState(true);
-  const [isProblemListEmpty, setIsProblemListEmpty] = useState(true);
-
-  const [datas, setDatas] = useState([
-    { id: '650ae1a19c2734584192d58e', idx: 'A', problemTitle: 'A+B' },
-    { id: '650af3809c2734584192d5b2', idx: 'B', problemTitle: 'A-B' },
-    { id: '650af7209c2734584192d603', idx: 'C', problemTitle: '삼각형' },
-    { id: '650af7379c2734584192d612', idx: 'D', problemTitle: '피보나치 수' },
-    { id: '650ce0110b8de0052a8cb971', idx: 'E', problemTitle: '순열의 개수' },
-    { id: '650ce0110b8de0052a8cb925', idx: 'F', problemTitle: '가방 정리' },
-    { id: '650ce0110b8de0052a1cb976', idx: 'G', problemTitle: '카드 색칠' },
-  ]);
-
   const router = useRouter();
 
   const handleChange = (result: DropResult) => {
     if (!result.destination) return;
-    console.log(result);
-    const items = [...datas];
+    const items = [...problemsInfo];
     const [reorderedItem] = items.splice(result.source.index, 1);
     items.splice(result.destination.index, 0, reorderedItem);
 
-    setDatas(items);
+    setProblemsInfo(items);
   };
 
   const handleGoToExamProblem = (id: string) => {
     router.push(`/exams/${eid}/problems/${id}`);
   };
 
-  useEffect(() => {
-    setIsLoading(false);
-    setIsProblemListEmpty(false);
-  }, []);
-
-  if (isLoading) return <Loading />;
-  if (isProblemListEmpty) return <NoneExamProblemListItem />;
+  if (problemsInfo.length === 0) return <NoneExamProblemListItem />;
 
   return (
     <div className="mb-14">
@@ -71,10 +56,10 @@ export default function ExamProblemList({
               ref={provided.innerRef}
               className="flex flex-col gap-4 pl-3"
             >
-              {datas.map((data, idx) => (
-                <div key={data.id} className="flex items-center gap-3">
+              {problemsInfo.map((problem, idx) => (
+                <div key={problem._id} className="flex items-center gap-3">
                   <div className="w-full">
-                    <Draggable draggableId={data.id} index={idx}>
+                    <Draggable draggableId={problem._id} index={idx}>
                       {(provided, snapshot) => (
                         <div
                           ref={
@@ -86,7 +71,7 @@ export default function ExamProblemList({
                           {...provided.dragHandleProps}
                         >
                           <div
-                            onClick={() => handleGoToExamProblem(data.id)}
+                            onClick={() => handleGoToExamProblem(problem._id)}
                             className="flex items-center gap-2 w-full border p-2 cursor-pointer hover:bg-gray-50 focus:bg-gray-50 rounded-sm shadow-sm"
                           >
                             {!isChagingExamProblemOrderActivate ? (
@@ -106,7 +91,7 @@ export default function ExamProblemList({
                               </svg>
                             )}
                             <span className="ml-1 text-[#0076C0] hover:underline focus:underline">
-                              {data.problemTitle}
+                              {problem.title}
                             </span>
                           </div>
                         </div>

--- a/app/exams/[eid]/problems/page.tsx
+++ b/app/exams/[eid]/problems/page.tsx
@@ -7,6 +7,40 @@ import React, { useEffect, useRef, useState } from 'react';
 import ExamProblemList from './components/ExamProblemList';
 import Image from 'next/image';
 import listImg from '@/public/images/list.png';
+import axiosInstance from '@/app/utils/axiosInstance';
+import { ProblemInfo, ProblemsInfo } from '@/app/types/problem';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { userInfoStore } from '@/app/store/UserInfo';
+import { useCountdownTimer } from '@/app/hooks/useCountdownTimer';
+import { fetchCurrentUserInfo } from '@/app/utils/fetchCurrentUserInfo';
+import { UserInfo } from '@/app/types/user';
+import { OPERATOR_ROLES } from '@/app/constants/role';
+import { formatDateToYYMMDDHHMM } from '@/app/utils/formatDate';
+
+// 시험에 등록된 문제 목록 정보 조회 API
+const fetchExamProblemsDetailInfo = ({ queryKey }: any) => {
+  const eid = queryKey[1];
+  return axiosInstance.get(
+    `${process.env.NEXT_PUBLIC_API_VERSION}/assignment/${eid}/problems`,
+  );
+};
+
+// 시험에 등록된 문제 순서 변경 API
+const examProblemReorder = ({
+  eid,
+  params,
+}: {
+  eid: string;
+  params: ProblemInfo[];
+}) => {
+  const requestBody = {
+    problems: params,
+  };
+  return axiosInstance.patch(
+    `${process.env.NEXT_PUBLIC_API_VERSION}/assignment/${eid}/problem/reorder`,
+    requestBody,
+  );
+};
 
 interface DefaultProps {
   params: {
@@ -15,7 +49,37 @@ interface DefaultProps {
 }
 
 export default function ExamProblems(props: DefaultProps) {
+  const eid = props.params.eid;
+
+  const { isPending, isError, data, error } = useQuery({
+    queryKey: ['examProblemsDetailInfo', eid],
+    queryFn: fetchExamProblemsDetailInfo,
+    retry: 0,
+  });
+
+  const resData = data?.data.data;
+  const examProblemsInfo: ProblemsInfo = resData;
+
+  const examProblemReorderMutation = useMutation({
+    mutationFn: examProblemReorder,
+    onSuccess: () => {
+      alert('문제 순서가 변경되었습니다.');
+    },
+  });
+
+  const userInfo = userInfoStore((state: any) => state.userInfo);
+  const updateUserInfo = userInfoStore((state: any) => state.updateUserInfo);
+
   const [isLoading, setIsLoading] = useState(true);
+  const [title, setTitle] = useState('');
+  const [problemsInfo, setProblemsInfo] = useState<ProblemInfo[]>([]);
+
+  const timeUntilStart = useCountdownTimer(examProblemsInfo?.testPeriod.start);
+  const timeUntilEnd = useCountdownTimer(examProblemsInfo?.testPeriod.end);
+  const currentTime = new Date();
+  const examStartTime = new Date(examProblemsInfo?.testPeriod.start);
+  const examEndTime = new Date(examProblemsInfo?.testPeriod.end);
+
   const [
     isChagingExamProblemOrderActivate,
     setIsChangingExamProblemOrderActivate,
@@ -23,35 +87,106 @@ export default function ExamProblems(props: DefaultProps) {
 
   const changingProblemOrderBtnRef = useRef<HTMLButtonElement>(null);
 
-  const eid = props.params.eid;
-
-  const [todos, setTodos] = useState([
-    { id: '650ae1a19c2734584192d58e', problemTitle: 'A+B' },
-    { id: '650af3809c2734584192d5b2', problemTitle: 'A-B' },
-    { id: '650af7209c2734584192d603', problemTitle: '삼각형' },
-    { id: '650af7379c2734584192d612', problemTitle: '피보나치 수' },
-    { id: '650ce0110b8de0052a8cb971', problemTitle: '순열의 개수' },
-    { id: '650ce0110b8de0052a8cb925', problemTitle: '가방 정리' },
-    { id: '650ce0110b8de0052a1cb976', problemTitle: '카드 색칠' },
-  ]);
-
   const router = useRouter();
+
+  useEffect(() => {
+    if (examProblemsInfo) {
+      setTitle(examProblemsInfo.title);
+      setProblemsInfo(examProblemsInfo.problems);
+    }
+  }, [examProblemsInfo]);
+
+  useEffect(() => {
+    // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인, 그리고 게시글 작성자인지 확인
+    fetchCurrentUserInfo(updateUserInfo).then((userInfo: UserInfo) => {
+      if (examProblemsInfo) {
+        const isWriter = examProblemsInfo.writer._id === userInfo._id;
+        const isOperator = OPERATOR_ROLES.includes(userInfo.role);
+        const isContestant = examProblemsInfo.students.some(
+          (student_id) => student_id === userInfo._id,
+        );
+
+        if (isWriter || isContestant) {
+          setIsLoading(false);
+          return;
+        }
+
+        if (isOperator && currentTime > examEndTime) {
+          setIsLoading(false);
+          return;
+        }
+
+        alert('접근 권한이 없습니다.');
+        router.back();
+      }
+    });
+  }, [updateUserInfo, examProblemsInfo, router]);
+
+  // 시험 시간 표시에 사용할 클래스를 결정하는 함수
+  const getTimeDisplayClass = () => {
+    if (currentTime < examStartTime) {
+      // 시험 시작 전
+      return 'text-blue-500';
+    } else if (currentTime >= examStartTime && currentTime <= examEndTime) {
+      // 시험 진행 중
+      return 'text-red-500';
+    }
+  };
+
+  // 시험 시작까지 남은 시간 또는 시험 종료까지 남은 시간을 표시하는 함수
+  const renderRemainingTime = () => {
+    if (currentTime < examStartTime) {
+      // 시험 시작 전: 시험 시작까지 남은 시간 표시
+      return (
+        <span className={`font-semibold ${getTimeDisplayClass()}`}>
+          {timeUntilStart.days > 0 &&
+            `(${timeUntilStart.days}일 ${timeUntilStart.hours}시간 남음)`}
+          {timeUntilStart.days === 0 &&
+            timeUntilStart.hours > 0 &&
+            `(${timeUntilStart.hours}시간 ${timeUntilStart.minutes}분 남음)`}
+          {timeUntilStart.days === 0 &&
+            timeUntilStart.hours === 0 &&
+            timeUntilStart.minutes > 0 &&
+            `(${timeUntilStart.minutes}분 ${timeUntilStart.seconds}초 남음)`}
+          {timeUntilStart.days === 0 &&
+            timeUntilStart.hours === 0 &&
+            timeUntilStart.minutes === 0 &&
+            `(${timeUntilStart.seconds}초 남음)`}
+        </span>
+      );
+    } else if (currentTime >= examStartTime && currentTime <= examEndTime) {
+      // 시험 진행 중: 시험 종료까지 남은 시간 표시
+      return (
+        <span className={`font-semibold ${getTimeDisplayClass()}`}>
+          {timeUntilEnd.days > 0 &&
+            `(${timeUntilEnd.days}일 ${timeUntilEnd.hours}시간 남음)`}
+          {timeUntilEnd.days === 0 &&
+            timeUntilEnd.hours > 0 &&
+            `(${timeUntilEnd.hours}시간 ${timeUntilEnd.minutes}분 남음)`}
+          {timeUntilEnd.days === 0 &&
+            timeUntilEnd.hours === 0 &&
+            timeUntilEnd.minutes > 0 &&
+            `(${timeUntilEnd.minutes}분 ${timeUntilEnd.seconds}초 남음)`}
+          {timeUntilEnd.days === 0 &&
+            timeUntilEnd.hours === 0 &&
+            timeUntilEnd.minutes === 0 &&
+            `(${timeUntilEnd.seconds}초 남음)`}
+        </span>
+      );
+    }
+  };
 
   const handleChangeProblemOrder = () => {
     changingProblemOrderBtnRef.current?.blur();
     setIsChangingExamProblemOrderActivate((prev) => !prev);
     if (isChagingExamProblemOrderActivate) {
-      alert('문제 순서를 변경하였습니다.');
+      examProblemReorderMutation.mutate({ eid, params: problemsInfo });
     }
   };
 
   const handleRegisterExamProblem = () => {
     router.push(`/exams/${eid}/problems/register`);
   };
-
-  useEffect(() => {
-    setIsLoading(false);
-  }, []);
 
   if (isLoading) return <Loading />;
 
@@ -76,7 +211,7 @@ export default function ExamProblems(props: DefaultProps) {
                 href={`/exams/${eid}`}
                 className="mt-1 ml-1 text-xl font-medium cursor-pointer hover:underline hover:text-[#0038a8] focus:underline focus:text-[#0038a8] text-[#1048b8]"
               >
-                (시험: 코딩테스트 1차, 2023-01-자료구조(소프트웨어학부 01반))
+                (시험: {title})
               </Link>
             </div>
           </p>
@@ -85,49 +220,64 @@ export default function ExamProblems(props: DefaultProps) {
             <div className="flex gap-2">
               {!isChagingExamProblemOrderActivate && (
                 <>
-                  <button
-                    onClick={handleRegisterExamProblem}
-                    className="flex justify-center items-center gap-[0.375rem] text-sm text-[#f9fafb] bg-green-500 px-2 py-[0.45rem] rounded-[6px] font-medium focus:bg-[#3e9368] hover:bg-[#3e9368]"
-                  >
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      height="20"
-                      viewBox="0 -960 960 960"
-                      width="20"
-                      fill="white"
-                    >
-                      <path d="M320-240h320v-80H320v80Zm0-160h320v-80H320v80ZM240-80q-33 0-56.5-23.5T160-160v-640q0-33 23.5-56.5T240-880h320l240 240v480q0 33-23.5 56.5T720-80H240Zm280-520h200L520-800v200Z" />
-                    </svg>
-                    문제 등록
-                  </button>
+                  {OPERATOR_ROLES.includes(userInfo.role) &&
+                    userInfo._id === examProblemsInfo.writer._id && (
+                      <button
+                        onClick={handleRegisterExamProblem}
+                        className="flex justify-center items-center gap-[0.375rem] text-sm text-[#f9fafb] bg-green-500 px-2 py-[0.45rem] rounded-[6px] font-medium focus:bg-[#3e9368] hover:bg-[#3e9368]"
+                      >
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          height="20"
+                          viewBox="0 -960 960 960"
+                          width="20"
+                          fill="white"
+                        >
+                          <path d="M320-240h320v-80H320v80Zm0-160h320v-80H320v80ZM240-80q-33 0-56.5-23.5T160-160v-640q0-33 23.5-56.5T240-880h320l240 240v480q0 33-23.5 56.5T720-80H240Zm280-520h200L520-800v200Z" />
+                        </svg>
+                        문제 등록
+                      </button>
+                    )}
                 </>
               )}
 
-              <button
-                onClick={handleChangeProblemOrder}
-                ref={changingProblemOrderBtnRef}
-                className="flex justify-center items-center gap-[0.375rem] text-sm text-[#f9fafb] bg-[#ff5fb1] px-2 py-[0.45rem] rounded-[6px] font-medium focus:bg-[#f555a8] hover:bg-[#f555a8]"
-              >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  height="23"
-                  viewBox="0 -960 960 960"
-                  width="23"
-                  fill="white"
-                >
-                  <path d="M241.5-478.5q0 44.5 16.75 87T311-313l13 13v-61.5q0-15.5 11-26.5t26.5-11q15.5 0 26.5 11t11 26.5v157q0 15.5-11 26.5t-26.5 11h-157q-15.5 0-26.5-11t-11-26.5q0-15.5 11-26.5t26.5-11H277l-18-17q-49.5-46.5-71-103.75T166.5-478.5q0-91.5 47-167t126.5-115q13.5-7 27.5-.5t19 21.5q5 14.5-.25 28.25T367.5-690q-58 31.5-92 87.75t-34 123.75Zm477-3q0-44.5-16.75-87T649-647l-13-13v61.5q0 15.5-11 26.5t-26.5 11q-15.5 0-26.5-11t-11-26.5v-157q0-15.5 11-26.5t26.5-11h157q15.5 0 26.5 11t11 26.5q0 15.5-11 26.5t-26.5 11H683l18 17q48 48 70.25 104.5t22.25 115q0 91.5-47 166.5t-126 115q-13.5 7-27.75.75T573.5-220.5q-5-14.5.25-28.25T592.5-270q58-31.5 92-87.75t34-123.75Z" />
-                </svg>
-                {isChagingExamProblemOrderActivate ? (
-                  <>저장하기</>
-                ) : (
-                  <>순서 변경</>
+              {OPERATOR_ROLES.includes(userInfo.role) &&
+                userInfo._id === examProblemsInfo.writer._id && (
+                  <button
+                    onClick={handleChangeProblemOrder}
+                    ref={changingProblemOrderBtnRef}
+                    className="flex justify-center items-center gap-[0.375rem] text-sm text-[#f9fafb] bg-[#ff5fb1] px-2 py-[0.45rem] rounded-[6px] font-medium focus:bg-[#f555a8] hover:bg-[#f555a8]"
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      height="23"
+                      viewBox="0 -960 960 960"
+                      width="23"
+                      fill="white"
+                    >
+                      <path d="M241.5-478.5q0 44.5 16.75 87T311-313l13 13v-61.5q0-15.5 11-26.5t26.5-11q15.5 0 26.5 11t11 26.5v157q0 15.5-11 26.5t-26.5 11h-157q-15.5 0-26.5-11t-11-26.5q0-15.5 11-26.5t26.5-11H277l-18-17q-49.5-46.5-71-103.75T166.5-478.5q0-91.5 47-167t126.5-115q13.5-7 27.5-.5t19 21.5q5 14.5-.25 28.25T367.5-690q-58 31.5-92 87.75t-34 123.75Zm477-3q0-44.5-16.75-87T649-647l-13-13v61.5q0 15.5-11 26.5t-26.5 11q-15.5 0-26.5-11t-11-26.5v-157q0-15.5 11-26.5t26.5-11h157q15.5 0 26.5 11t11 26.5q0 15.5-11 26.5t-26.5 11H683l18 17q48 48 70.25 104.5t22.25 115q0 91.5-47 166.5t-126 115q-13.5 7-27.75.75T573.5-220.5q-5-14.5.25-28.25T592.5-270q58-31.5 92-87.75t34-123.75Z" />
+                    </svg>
+                    {isChagingExamProblemOrderActivate ? (
+                      <>저장하기</>
+                    ) : (
+                      <>순서 변경</>
+                    )}
+                  </button>
                 )}
-              </button>
             </div>
+
             <div className="mt-3">
               <span className="font-semibold">
                 시험 시간:{' '}
-                <span className="text-red-500 font-bold">41분 3초 후 종료</span>
+                <span className="font-light">
+                  {formatDateToYYMMDDHHMM(examProblemsInfo.testPeriod.start)} ~{' '}
+                  {formatDateToYYMMDDHHMM(examProblemsInfo.testPeriod.end)}{' '}
+                  {timeUntilEnd?.isPast ? (
+                    <span className="text-red-500 font-bold">(종료)</span>
+                  ) : (
+                    renderRemainingTime()
+                  )}
+                </span>
               </span>
             </div>
           </div>
@@ -141,6 +291,8 @@ export default function ExamProblems(props: DefaultProps) {
                     isChagingExamProblemOrderActivate={
                       isChagingExamProblemOrderActivate
                     }
+                    problemsInfo={problemsInfo}
+                    setProblemsInfo={setProblemsInfo}
                   />
                 </div>
               </div>

--- a/app/exams/register/page.tsx
+++ b/app/exams/register/page.tsx
@@ -119,6 +119,13 @@ export default function RegisterExam() {
       return;
     }
 
+    // 시험 시작 시간과 종료 시간의 유효성 검사
+    if (examStartDateTime >= examEndDateTime) {
+      alert('시험 종료 시간은 시작 시간 이후로 설정해야 합니다.');
+      window.scrollTo(0, document.body.scrollHeight);
+      return;
+    }
+
     if (!examPwd) {
       alert('비밀번호를 입력해 주세요');
       window.scrollTo(0, document.body.scrollHeight);

--- a/app/types/problem.ts
+++ b/app/types/problem.ts
@@ -61,6 +61,7 @@ export interface ProblemsInfo {
     end: string;
   };
   contestants: string[];
+  students: string[];
   _id: string;
   title: string;
   content: string;

--- a/app/utils/axiosInstance.ts
+++ b/app/utils/axiosInstance.ts
@@ -26,13 +26,21 @@ axiosInstance.interceptors.response.use(
     if (error.response) {
       switch (error.response.status) {
         case 400:
+          const url = error.request.responseURL;
+          const regex =
+            /https:\/\/swjudgeapi\.cbnu\.ac\.kr\/v1\/(.*?)\/[0-9a-fA-F]{24}\/problems/;
+          const category = url.match(regex);
           switch (error.response.data.code) {
             case 'IS_NOT_CONTESTANT':
-              alert('대회 참가자가 아닙니다.');
+              if (category[1] === 'contest') alert('대회 참가자가 아닙니다.');
+              else if (category[1] === 'assignment')
+                alert('시험 신청자가 아닙니다.');
               if (typeof window !== 'undefined') window.history.back();
               return;
             case 'IS_NOT_TEST_PERIOD':
-              alert('대회 시간이 아닙니다.');
+              if (category[1] === 'contest') alert('대회 시간이 아닙니다.');
+              else if (category[1] === 'assignment')
+                alert('시험 시간이 아닙니다.');
               if (typeof window !== 'undefined') window.history.back();
               return;
           }
@@ -43,6 +51,13 @@ axiosInstance.interceptors.response.use(
           localStorage.removeItem('refresh-token');
           localStorage.removeItem('activeAuthorization');
           if (typeof window !== 'undefined') window.location.href = '/login';
+          break;
+        case 403:
+          switch (error.response.data.code) {
+            case 'FORBIDDEN':
+              alert('권한이 없는 요청입니다.');
+              return;
+          }
           break;
         case 404:
           switch (error.response.data.code) {


### PR DESCRIPTION
## 👀 이슈

resolve #218 

## 📌 개요

시험 문제 목록 페이지 컴포넌트 내 하드코딩되어 있는 데이터가 아닌
서버 API를 통해 실제 DB에 저장되어 있는 문제 목록 정보를 페이지에
표시하고 문제의 순서를 변경하는 기능을 추가하였습니다.

## 👩‍💻 작업 사항

- 시험 문제 목록 페이지 컴포넌트 내 데이터 조회 기능 추가
- 시험 문제 표시 순서 변경 기능 추가

## ✅ 참고 사항

- 기능 추가 후 **시험 문제 목록 페이지** 화면

https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/7e377d35-4fe7-4c6c-bd88-13a8b1c68a58