### PR TITLE
[refactor]: 페이지 별 사용자 권한 확인 로직 리팩토링 (#220)

### DIFF
--- a/app/contests/[cid]/edit/page.tsx
+++ b/app/contests/[cid]/edit/page.tsx
@@ -243,15 +243,19 @@ export default function EditContest(props: DefaultProps) {
   // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
     fetchCurrentUserInfo(updateUserInfo).then((userInfo: UserInfo) => {
-      if (userInfo.isAuth && OPERATOR_ROLES.includes(userInfo.role)) {
-        setIsLoading(false);
-        return;
-      }
+      if (contestInfo) {
+        const isWriter = contestInfo.writer._id === userInfo._id;
 
-      alert('접근 권한이 없습니다.');
-      router.back();
+        if (isWriter) {
+          setIsLoading(false);
+          return;
+        }
+
+        alert('접근 권한이 없습니다.');
+        router.back();
+      }
     });
-  }, [updateUserInfo, router]);
+  }, [updateUserInfo, contestInfo, router]);
 
   if (isLoading || isPending) return <Loading />;
 

--- a/app/contests/[cid]/submits/[submitId]/page.tsx
+++ b/app/contests/[cid]/submits/[submitId]/page.tsx
@@ -61,12 +61,12 @@ export default function UsersContestSubmit(props: DefaultProps) {
   useEffect(() => {
     fetchCurrentUserInfo(updateUserInfo).then((userInfo: UserInfo) => {
       if (submitInfo) {
-        if (
-          userInfo.isAuth &&
-          ((OPERATOR_ROLES.includes(userInfo.role) &&
-            userInfo._id === submitInfo.parentId.writer._id) ||
-            submitInfo.parentId.contestants[0] === userInfo._id)
-        ) {
+        const isWriter = submitInfo.parentId.writer._id === userInfo._id;
+        const isContestant = submitInfo.parentId.contestants.some(
+          (contestant_id) => contestant_id === userInfo._id,
+        );
+
+        if (isWriter || isContestant) {
           setIsLoading(false);
           return;
         }

--- a/app/contests/[cid]/submits/page.tsx
+++ b/app/contests/[cid]/submits/page.tsx
@@ -10,7 +10,6 @@ import { userInfoStore } from '@/app/store/UserInfo';
 import { fetchCurrentUserInfo } from '@/app/utils/fetchCurrentUserInfo';
 import { UserInfo } from '@/app/types/user';
 import { useRouter } from 'next/navigation';
-import { OPERATOR_ROLES } from '@/app/constants/role';
 import axiosInstance from '@/app/utils/axiosInstance';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { ContestInfo, ContestSubmitInfo } from '@/app/types/contest';

--- a/app/contests/register/page.tsx
+++ b/app/contests/register/page.tsx
@@ -193,7 +193,9 @@ export default function RegisterContest() {
   // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
     fetchCurrentUserInfo(updateUserInfo).then((userInfo: UserInfo) => {
-      if (userInfo.isAuth && OPERATOR_ROLES.includes(userInfo.role)) {
+      const isOperator = OPERATOR_ROLES.includes(userInfo.role);
+
+      if (isOperator) {
         setIsLoading(false);
         return;
       }

--- a/app/exams/[eid]/edit/page.tsx
+++ b/app/exams/[eid]/edit/page.tsx
@@ -193,15 +193,19 @@ export default function EditExam(props: DefaultProps) {
   // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
     fetchCurrentUserInfo(updateUserInfo).then((userInfo: UserInfo) => {
-      if (userInfo.isAuth && OPERATOR_ROLES.includes(userInfo.role)) {
-        setIsLoading(false);
-        return;
-      }
+      if (examInfo) {
+        const isWriter = examInfo.writer._id === userInfo._id;
 
-      alert('접근 권한이 없습니다.');
-      router.back();
+        if (isWriter) {
+          setIsLoading(false);
+          return;
+        }
+
+        alert('접근 권한이 없습니다.');
+        router.back();
+      }
     });
-  }, [updateUserInfo, router]);
+  }, [updateUserInfo, examInfo, router]);
 
   if (isLoading || isPending) return <Loading />;
 

--- a/app/exams/register/page.tsx
+++ b/app/exams/register/page.tsx
@@ -151,7 +151,9 @@ export default function RegisterExam() {
   // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
     fetchCurrentUserInfo(updateUserInfo).then((userInfo: UserInfo) => {
-      if (userInfo.isAuth && OPERATOR_ROLES.includes(userInfo.role)) {
+      const isOperator = OPERATOR_ROLES.includes(userInfo.role);
+
+      if (isOperator) {
         setIsLoading(false);
         return;
       }

--- a/app/practices/[pid]/edit/page.tsx
+++ b/app/practices/[pid]/edit/page.tsx
@@ -182,15 +182,19 @@ export default function EditPractice(props: DefaultProps) {
   // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
     fetchCurrentUserInfo(updateUserInfo).then((userInfo: UserInfo) => {
-      if (userInfo.isAuth && OPERATOR_ROLES.includes(userInfo.role)) {
-        setIsLoading(false);
-        return;
-      }
+      if (practiceInfo) {
+        const isWriter = practiceInfo.writer._id === userInfo._id;
 
-      alert('접근 권한이 없습니다.');
-      router.back();
+        if (isWriter) {
+          setIsLoading(false);
+          return;
+        }
+
+        alert('접근 권한이 없습니다.');
+        router.back();
+      }
     });
-  }, [updateUserInfo, router]);
+  }, [updateUserInfo, practiceInfo, router]);
 
   if (isLoading || isPending) return <Loading />;
 

--- a/app/practices/register/page.tsx
+++ b/app/practices/register/page.tsx
@@ -128,7 +128,9 @@ export default function RegisterPractice() {
   // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
     fetchCurrentUserInfo(updateUserInfo).then((userInfo: UserInfo) => {
-      if (userInfo.isAuth && OPERATOR_ROLES.includes(userInfo.role)) {
+      const isOperator = OPERATOR_ROLES.includes(userInfo.role);
+
+      if (isOperator) {
         setIsLoading(false);
         return;
       }

--- a/app/utils/axiosInstance.ts
+++ b/app/utils/axiosInstance.ts
@@ -56,6 +56,7 @@ axiosInstance.interceptors.response.use(
           switch (error.response.data.code) {
             case 'FORBIDDEN':
               alert('권한이 없는 요청입니다.');
+              if (typeof window !== 'undefined') window.history.back();
               return;
           }
           break;


### PR DESCRIPTION
## 👀 이슈

resolve #220 

## 📌 개요

페이지 내에서 사용자의 권한을 용도에 맞게 확인하는 로직의 코드를
일관성 있게 리팩토링 하였습니다.

## 👩‍💻 작업 사항

- 페이지 별 사용자 권한 확인 로직 리팩토링

## ✅ 참고 사항

없습니다