### PR TITLE
[feat]: react query onMutation hook onSuccess 콜백함수 data/reso 파라미터를 통한 통신 요청 성공 여부 확인 기능 추가 (#222)

### DIFF
--- a/app/contests/[cid]/edit/page.tsx
+++ b/app/contests/[cid]/edit/page.tsx
@@ -56,9 +56,18 @@ export default function EditContest(props: DefaultProps) {
 
   const editContestMutation = useMutation({
     mutationFn: editContest,
-    onSuccess: () => {
-      alert('대회 내용이 수정되었습니다.');
-      router.push(`/contests/${cid}`);
+    onSuccess: (data) => {
+      const resData = data.data;
+      const httpStatusCode = resData.status;
+
+      switch (httpStatusCode) {
+        case 200:
+          alert('대회 내용이 수정되었습니다.');
+          router.push(`/contests/${cid}`);
+          break;
+        default:
+          alert('정의되지 않은 http status code입니다');
+      }
     },
   });
 

--- a/app/contests/[cid]/page.tsx
+++ b/app/contests/[cid]/page.tsx
@@ -67,9 +67,18 @@ export default function ContestDetail(props: DefaultProps) {
 
   const deleteContestMutation = useMutation({
     mutationFn: deleteContest,
-    onSuccess: () => {
-      alert('대회가 삭제되었습니다.');
-      router.push('/contests');
+    onSuccess: (data) => {
+      const resData = data.data;
+      const httpStatusCode = resData.status;
+
+      switch (httpStatusCode) {
+        case 200:
+          alert('대회가 삭제되었습니다.');
+          router.push('/contests');
+          break;
+        default:
+          alert('정의되지 않은 http status code입니다');
+      }
     },
     onError: (error: AxiosError) => {
       const resData: any = error.response?.data;
@@ -91,45 +100,65 @@ export default function ContestDetail(props: DefaultProps) {
 
   const enrollContestMutation = useMutation({
     mutationFn: enrollContest,
-    onSuccess: () => {
-      setIsEnrollContest(true);
-      alert(
-        '대회 참가 신청이 완료되었습니다.\n대회 시간을 확인한 후, 해당 시간에 참가해 주세요',
-      );
+    onSuccess: (data) => {
+      const resData = data.data;
+      const httpStatusCode = resData.status;
 
-      // 쿼리 데이터 업데이트
-      const updatedContestants = [...contestInfo.contestants, userInfo];
-      queryClient.setQueryData(['contestDetailInfo', cid], {
-        ...data,
-        data: {
-          ...data?.data,
-          data: {
-            ...contestInfo,
-            contestants: updatedContestants,
-          },
-        },
-      });
+      switch (httpStatusCode) {
+        case 200:
+          setIsEnrollContest(true);
+          alert(
+            '대회 참가 신청이 완료되었습니다.\n대회 시간을 확인한 후, 해당 시간에 참가해 주세요',
+          );
+
+          // 쿼리 데이터 업데이트
+          const updatedContestants = [...contestInfo.contestants, userInfo];
+          queryClient.setQueryData(['contestDetailInfo', cid], {
+            ...data,
+            data: {
+              ...data?.data,
+              data: {
+                ...contestInfo,
+                contestants: updatedContestants,
+              },
+            },
+          });
+          break;
+        default:
+          alert('정의되지 않은 http status code입니다');
+      }
     },
   });
 
   const unErollContestMutation = useMutation({
     mutationFn: unEnrollContest,
-    onSuccess: () => {
-      setIsEnrollContest(false);
-      alert('대회 참가 신청이 취소되었습니다.');
-      const updatedContestants = contestInfo.contestants.filter(
-        (contestant) => contestant._id !== userInfo._id,
-      );
-      queryClient.setQueryData(['contestDetailInfo', cid], {
-        ...data,
-        data: {
-          ...data?.data,
-          data: {
-            ...contestInfo,
-            contestants: updatedContestants,
-          },
-        },
-      });
+    onSuccess: (data) => {
+      const resData = data.data;
+      const httpStatusCode = resData.status;
+
+      switch (httpStatusCode) {
+        case 200:
+          setIsEnrollContest(false);
+          alert('대회 참가 신청이 취소되었습니다.');
+          const updatedContestants = contestInfo.contestants.filter(
+            (contestant) => contestant._id !== userInfo._id,
+          );
+
+          // 쿼리 데이터 업데이트
+          queryClient.setQueryData(['contestDetailInfo', cid], {
+            ...data,
+            data: {
+              ...data?.data,
+              data: {
+                ...contestInfo,
+                contestants: updatedContestants,
+              },
+            },
+          });
+          break;
+        default:
+          alert('정의되지 않은 http status code입니다');
+      }
     },
   });
 

--- a/app/contests/[cid]/problems/page.tsx
+++ b/app/contests/[cid]/problems/page.tsx
@@ -86,9 +86,18 @@ export default function ContestProblems(props: DefaultProps) {
           alert('정의되지 않은 http status code입니다');
       }
     },
-    onSuccess: () => {
-      setCookie(cid, password, { maxAge: 60 * 60 * 24 });
-      setIsPasswordChecked(true);
+    onSuccess: (data) => {
+      const resData = data.data;
+      const httpStatusCode = resData.status;
+
+      switch (httpStatusCode) {
+        case 200:
+          setCookie(cid, password, { maxAge: 60 * 60 * 24 });
+          setIsPasswordChecked(true);
+          break;
+        default:
+          alert('정의되지 않은 http status code입니다');
+      }
     },
   });
 
@@ -106,8 +115,17 @@ export default function ContestProblems(props: DefaultProps) {
 
   const contestProblemReorderMutation = useMutation({
     mutationFn: contestProblemReorder,
-    onSuccess: () => {
-      alert('문제 순서가 변경되었습니다.');
+    onSuccess: (data) => {
+      const resData = data.data;
+      const httpStatusCode = resData.status;
+
+      switch (httpStatusCode) {
+        case 200:
+          alert('문제 순서가 변경되었습니다.');
+          break;
+        default:
+          alert('정의되지 않은 http status code입니다');
+      }
     },
   });
 

--- a/app/contests/register/page.tsx
+++ b/app/contests/register/page.tsx
@@ -38,11 +38,19 @@ const CustomCKEditor = dynamic(() => import('@/components/CustomCKEditor'), {
 export default function RegisterContest() {
   const registerContestMutation = useMutation({
     mutationFn: registerContest,
-    onSuccess: (response) => {
-      const resData = response?.data.data;
-      const cid = resData?._id;
-      alert('대회가 등록되었습니다.');
-      router.push(`/contests/${cid}`);
+    onSuccess: (data) => {
+      const resData = data?.data;
+      const httpStatusCode = resData.status;
+
+      switch (httpStatusCode) {
+        case 200:
+          const cid = resData?.data._id;
+          alert('대회가 등록되었습니다.');
+          router.push(`/contests/${cid}`);
+          break;
+        default:
+          alert('정의되지 않은 http status code입니다');
+      }
     },
   });
 

--- a/app/exams/[eid]/edit/page.tsx
+++ b/app/exams/[eid]/edit/page.tsx
@@ -65,9 +65,18 @@ export default function EditExam(props: DefaultProps) {
 
   const editExamMutation = useMutation({
     mutationFn: editExam,
-    onSuccess: () => {
-      alert('시험 내용이 수정되었습니다.');
-      router.push(`/exams/${eid}`);
+    onSuccess: (data) => {
+      const resData = data?.data;
+      const httpStatusCode = resData.status;
+
+      switch (httpStatusCode) {
+        case 200:
+          alert('시험 내용이 수정되었습니다.');
+          router.push(`/exams/${eid}`);
+          break;
+        default:
+          alert('정의되지 않은 http status code입니다');
+      }
     },
   });
 

--- a/app/exams/[eid]/page.tsx
+++ b/app/exams/[eid]/page.tsx
@@ -65,27 +65,54 @@ export default function ExamDetail(props: DefaultProps) {
 
   const deleteExamMutation = useMutation({
     mutationFn: deleteExam,
-    onSuccess: () => {
-      alert('시험이 삭제되었습니다.');
-      router.push('/exams');
+    onSuccess: (data) => {
+      const resData = data?.data;
+      const httpStatusCode = resData.status;
+
+      switch (httpStatusCode) {
+        case 200:
+          alert('시험이 삭제되었습니다.');
+          router.push('/exams');
+          break;
+        default:
+          alert('정의되지 않은 http status code입니다');
+      }
     },
   });
 
   const enrollExamMutation = useMutation({
     mutationFn: enrollExam,
-    onSuccess: () => {
-      setIsEnrollExam(true);
-      alert(
-        '시험 응시가 완료되었습니다.\n시험 시간을 확인한 후, 해당 시간에 시작해 주세요',
-      );
+    onSuccess: (data) => {
+      const resData = data?.data;
+      const httpStatusCode = resData.status;
+
+      switch (httpStatusCode) {
+        case 200:
+          setIsEnrollExam(true);
+          alert(
+            '시험 응시가 완료되었습니다.\n시험 시간을 확인한 후, 해당 시간에 시작해 주세요',
+          );
+          break;
+        default:
+          alert('정의되지 않은 http status code입니다');
+      }
     },
   });
 
   const unErollExamMutation = useMutation({
     mutationFn: unEnrollExam,
-    onSuccess: () => {
-      setIsEnrollExam(false);
-      alert('시험 응시가 취소되었습니다.');
+    onSuccess: (data) => {
+      const resData = data?.data;
+      const httpStatusCode = resData.status;
+
+      switch (httpStatusCode) {
+        case 200:
+          setIsEnrollExam(false);
+          alert('시험 응시가 취소되었습니다.');
+          break;
+        default:
+          alert('정의되지 않은 http status code입니다');
+      }
     },
   });
 

--- a/app/exams/[eid]/problems/page.tsx
+++ b/app/exams/[eid]/problems/page.tsx
@@ -62,8 +62,17 @@ export default function ExamProblems(props: DefaultProps) {
 
   const examProblemReorderMutation = useMutation({
     mutationFn: examProblemReorder,
-    onSuccess: () => {
-      alert('문제 순서가 변경되었습니다.');
+    onSuccess: (data) => {
+      const resData = data?.data;
+      const httpStatusCode = resData.status;
+
+      switch (httpStatusCode) {
+        case 200:
+          alert('문제 순서가 변경되었습니다.');
+          break;
+        default:
+          alert('정의되지 않은 http status code입니다');
+      }
     },
   });
 

--- a/app/exams/register/page.tsx
+++ b/app/exams/register/page.tsx
@@ -37,11 +37,19 @@ const CustomCKEditor = dynamic(() => import('@/components/CustomCKEditor'), {
 export default function RegisterExam() {
   const registerExamMutation = useMutation({
     mutationFn: registerExam,
-    onSuccess: (response) => {
-      const resData = response?.data.data;
-      const eid = resData?._id;
-      alert('시험이 등록되었습니다.');
-      router.push(`/exams/${eid}`);
+    onSuccess: (data) => {
+      const resData = data?.data;
+      const httpStatusCode = resData.status;
+
+      switch (httpStatusCode) {
+        case 200:
+          const eid = resData?.data._id;
+          alert('시험이 등록되었습니다.');
+          router.push(`/exams/${eid}`);
+          break;
+        default:
+          alert('정의되지 않은 http status code입니다');
+      }
     },
   });
 

--- a/app/practices/[pid]/edit/page.tsx
+++ b/app/practices/[pid]/edit/page.tsx
@@ -55,9 +55,18 @@ export default function EditPractice(props: DefaultProps) {
 
   const editPracticeMutation = useMutation({
     mutationFn: editPractice,
-    onSuccess: () => {
-      alert('연습문제 내용이 수정되었습니다.');
-      router.push(`/practices/${pid}`);
+    onSuccess: (data) => {
+      const resData = data?.data;
+      const httpStatusCode = resData.status;
+
+      switch (httpStatusCode) {
+        case 200:
+          alert('연습문제 내용이 수정되었습니다.');
+          router.push(`/practices/${pid}`);
+          break;
+        default:
+          alert('정의되지 않은 http status code입니다');
+      }
     },
   });
 

--- a/app/practices/[pid]/page.tsx
+++ b/app/practices/[pid]/page.tsx
@@ -45,9 +45,18 @@ export default function PracticeProblem(props: DefaultProps) {
 
   const deletePracticeMutation = useMutation({
     mutationFn: deletePractice,
-    onSuccess: () => {
-      alert('연습문제가 삭제되었습니다.');
-      router.push('/practices');
+    onSuccess: (data) => {
+      const resData = data?.data;
+      const httpStatusCode = resData.status;
+
+      switch (httpStatusCode) {
+        case 200:
+          alert('연습문제가 삭제되었습니다.');
+          router.push('/practices');
+          break;
+        default:
+          alert('정의되지 않은 http status code입니다');
+      }
     },
   });
 

--- a/app/practices/register/page.tsx
+++ b/app/practices/register/page.tsx
@@ -23,11 +23,19 @@ const registerPractice = (params: RegisterProblemParams) => {
 export default function RegisterPractice() {
   const registerPracticeMutation = useMutation({
     mutationFn: registerPractice,
-    onSuccess: (response) => {
-      const resData = response?.data.data;
-      const pid = resData?._id;
-      alert('연습문제가 등록되었습니다.');
-      router.push(`/practices/${pid}`);
+    onSuccess: (data) => {
+      const resData = data?.data;
+      const httpStatusCode = resData.status;
+
+      switch (httpStatusCode) {
+        case 200:
+          const pid = resData?.data._id;
+          alert('연습문제가 등록되었습니다.');
+          router.push(`/practices/${pid}`);
+          break;
+        default:
+          alert('정의되지 않은 http status code입니다');
+      }
     },
   });
 


### PR DESCRIPTION
## 👀 이슈

resolve #222 

## 📌 개요

현재 react query onMutation hook의 onSuccess 콜백함수가 사용되는
코드에서 별도의 검증 과정 없이 통신 요청 성공에 대한 피드백 로직만 실행되는
코드가 있어 실제 통신 요청이 성공적으로 수행되었는지를 http response data를
기준으로 확인하는 코드를 추가하였습니다.

## 👩‍💻 작업 사항

- react query onMutation hook onSuccess 콜백함수 data 파라미터를 통한 통신 요청 성공 여부 확인 기능 추가

## ✅ 참고 사항

없습니다
