### PR TITLE
[feat]: 대회 문제 게시글 페이지 정보 표시 기능 추가 (#228)

### DIFF
--- a/app/contests/[cid]/problems/[problemId]/page.tsx
+++ b/app/contests/[cid]/problems/[problemId]/page.tsx
@@ -1,9 +1,47 @@
 'use client';
 
 import Loading from '@/app/loading';
+import { userInfoStore } from '@/app/store/UserInfo';
+import { ContestInfo } from '@/app/types/contest';
+import { ProblemInfo } from '@/app/types/problem';
+import { UserInfo } from '@/app/types/user';
+import axiosInstance from '@/app/utils/axiosInstance';
+import { fetchCurrentUserInfo } from '@/app/utils/fetchCurrentUserInfo';
+import { useMutation, useQueries } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+import { deleteCookie, getCookie, setCookie } from 'cookies-next';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
+
+// 대회 문제 열람 비밀번호 확인 API
+const confirmContestConfirm = ({
+  cid,
+  password,
+}: {
+  cid: string;
+  password: string;
+}) => {
+  return axiosInstance.get(
+    `${process.env.NEXT_PUBLIC_API_VERSION}/contest/confirm/${cid}?password=${password}`,
+  );
+};
+
+// 문제 정보 조회 API
+const fetchContestProblemDetailInfo = ({ queryKey }: any) => {
+  const problemId = queryKey[1];
+  return axiosInstance.get(
+    `${process.env.NEXT_PUBLIC_API_VERSION}/problem/${problemId}`,
+  );
+};
+
+// 대회 게시글 정보 조회 API
+const fetchContestDetailInfo = ({ queryKey }: any) => {
+  const cid = queryKey[1];
+  return axiosInstance.get(
+    `${process.env.NEXT_PUBLIC_API_VERSION}/contest/${cid}`,
+  );
+};
 
 interface DefaultProps {
   params: {
@@ -17,10 +55,65 @@ const PDFViewer = dynamic(() => import('@/app/components/PDFViewer'), {
 });
 
 export default function ContestProblem(props: DefaultProps) {
-  const [isLoading, setIsLoading] = useState(true);
-
   const cid = props.params.cid;
   const problemId = props.params.problemId;
+
+  const confirmContestConfirmMutation = useMutation({
+    mutationFn: confirmContestConfirm,
+    onError: (error: AxiosError) => {
+      const resData: any = error.response?.data;
+      switch (resData.status) {
+        case 400:
+          switch (resData.code) {
+            case 'CONTEST_PASSWORD_NOT_MATCH':
+              alert('비밀번호가 일치하지 않습니다.');
+              deleteCookie(cid);
+              router.back();
+              break;
+            default:
+              alert('정의되지 않은 http code입니다.');
+          }
+          break;
+        default:
+          alert('정의되지 않은 http status code입니다');
+      }
+    },
+    onSuccess: (data) => {
+      const resData = data.data;
+      const httpStatusCode = resData.status;
+
+      switch (httpStatusCode) {
+        case 200:
+          setCookie(cid, password, { maxAge: 60 * 60 * 24 });
+          setIsPasswordChecked(true);
+          break;
+        default:
+          alert('정의되지 않은 http status code입니다');
+      }
+    },
+  });
+
+  const results = useQueries({
+    queries: [
+      {
+        queryKey: ['contestDetailInfo', cid],
+        queryFn: fetchContestDetailInfo,
+      },
+      {
+        queryKey: ['contestProblemDetailInfo', problemId],
+        queryFn: fetchContestProblemDetailInfo,
+      },
+    ],
+  });
+
+  const contestInfo: ContestInfo = results[0].data?.data.data;
+  const contestProblemInfo: ProblemInfo = results[1].data?.data.data;
+
+  const userInfo = userInfoStore((state: any) => state.userInfo);
+  const updateUserInfo = userInfoStore((state: any) => state.updateUserInfo);
+
+  const [isLoading, setIsLoading] = useState(true);
+  const [isEnrollContest, setIsEnrollContest] = useState(false);
 
   const router = useRouter();
 
@@ -47,17 +140,77 @@ export default function ContestProblem(props: DefaultProps) {
     router.push(`/contests/${cid}/problems`);
   };
 
-  useEffect(() => {
-    setIsLoading(false);
-  }, []);
+  // 대회 신청 여부 확인
+  const isUserContestant = useCallback(() => {
+    return contestInfo.contestants.some(
+      (contestant) => contestant._id === userInfo._id,
+    );
+  }, [contestInfo, userInfo]);
 
-  if (isLoading) return <Loading />;
+  useEffect(() => {
+    if (contestInfo && contestInfo.contestants && userInfo)
+      setIsEnrollContest(isUserContestant());
+  }, [contestInfo, userInfo, isUserContestant]);
+
+  const [password, setPassword] = useState('');
+  const [isPasswordChecked, setIsPasswordChecked] = useState(false);
+
+  useEffect(() => {
+    // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인, 그리고 게시글 작성자인지 확인
+    fetchCurrentUserInfo(updateUserInfo).then((userInfo: UserInfo) => {
+      if (contestProblemInfo) {
+        const isWriter = contestProblemInfo.writer._id === userInfo._id;
+        const isContestant = contestInfo.contestants.some(
+          (contestant) => contestant._id === userInfo._id,
+        );
+
+        if (isContestant) {
+          setIsLoading(false);
+          const contestPasswordCookie = getCookie(cid);
+          if (contestPasswordCookie) {
+            setPassword(contestPasswordCookie);
+            confirmContestConfirmMutation.mutate({
+              cid,
+              password: contestPasswordCookie,
+            });
+            return;
+          }
+
+          const inputPassword = prompt('비밀번호를 입력해 주세요');
+          if (inputPassword !== null && inputPassword.trim() !== '') {
+            setPassword(inputPassword);
+            confirmContestConfirmMutation.mutate({
+              cid,
+              password: inputPassword,
+            });
+            return;
+          }
+
+          router.back();
+          return;
+        }
+
+        if (isWriter) {
+          setIsLoading(false);
+          setIsPasswordChecked(true);
+          return;
+        }
+
+        alert('접근 권한이 없습니다.');
+        router.back();
+      }
+    });
+  }, [updateUserInfo, contestProblemInfo, cid, router]);
+
+  if (isLoading || !isPasswordChecked) return <Loading />;
 
   return (
     <div className="mt-6 mb-24 px-5 2lg:px-0 overflow-x-auto">
       <div className="flex flex-col w-[60rem] mx-auto">
         <div className="flex flex-col gap-8">
-          <p className="text-2xl font-bold tracking-tight">A+B</p>
+          <p className="text-2xl font-bold tracking-tight">
+            {contestProblemInfo.title}
+          </p>
           <div className="flex justify-between pb-3 border-b border-gray-300">
             <div className="flex gap-3">
               <span className="font-semibold">
@@ -65,7 +218,7 @@ export default function ContestProblem(props: DefaultProps) {
                 <span className="font-mono font-light">
                   {' '}
                   <span className="font-mono font-semibold text-blue-600">
-                    1
+                    {contestProblemInfo.score}
                   </span>
                   점
                 </span>
@@ -75,7 +228,7 @@ export default function ContestProblem(props: DefaultProps) {
                 시간 제한:
                 <span className="font-mono font-light">
                   {' '}
-                  <span>1</span>초
+                  <span>{contestProblemInfo.options.maxRealTime}</span>초
                 </span>
               </span>
               <span className='relative bottom-[0.055rem] font-thin before:content-["|"]' />
@@ -83,16 +236,16 @@ export default function ContestProblem(props: DefaultProps) {
                 메모리 제한:
                 <span className="font-mono font-light">
                   {' '}
-                  <span className="mr-1">5</span>MB
+                  <span className="mr-1">
+                    {contestProblemInfo.options.maxMemory}
+                  </span>
+                  MB
                 </span>
               </span>
             </div>
             <div className="flex gap-3">
               <span className="font-semibold">
-                대회:{' '}
-                <span className="font-light">
-                  2023년 제2회 충청북도 대학생 프로그래밍 경진대회 본선
-                </span>
+                대회: <span className="font-light">{contestInfo.title}</span>
               </span>
             </div>
           </div>
@@ -114,61 +267,70 @@ export default function ContestProblem(props: DefaultProps) {
             </svg>
             문제 목록
           </button>
-          <button
-            onClick={handleGoToUserContestSubmits}
-            className="flex justify-center items-center gap-[0.375rem] text-sm text-[#f9fafb] bg-[#6860ff] px-2 py-[0.45rem] rounded-[6px] font-medium focus:bg-[#5951f0] hover:bg-[#5951f0]"
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              height="20"
-              viewBox="0 -960 960 960"
-              width="20"
-              fill="white"
-            >
-              <path d="M320-242 80-482l242-242 43 43-199 199 197 197-43 43Zm318 2-43-43 199-199-197-197 43-43 240 240-242 242Z" />
-            </svg>
-            내 제출 현황
-          </button>
-          <button
-            onClick={handleGoToSubmitContestProblemCode}
-            className="flex justify-center items-center gap-[0.375rem] text-sm text-[#f9fafb] bg-[#3a8af9] px-3 py-[0.45rem] rounded-[6px] font-medium focus:bg-[#1c6cdb] hover:bg-[#1c6cdb]"
-          >
-            제출하기
-          </button>
-          <button
-            onClick={handleEditProblem}
-            className="flex justify-center items-center gap-[0.375rem] text-sm text-[#f9fafb] bg-[#eba338] px-2 py-[0.45rem] rounded-[6px] font-medium focus:bg-[#dc9429] hover:bg-[#dc9429]"
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              height="20"
-              viewBox="0 -960 960 960"
-              width="20"
-              fill="white"
-            >
-              <path d="M794-666 666-794l42-42q17-17 42.5-16.5T793-835l43 43q17 17 17 42t-17 42l-42 42Zm-42 42L248-120H120v-128l504-504 128 128Z" />
-            </svg>
-            문제 수정
-          </button>
-          <button
-            onClick={handleDeleteProblem}
-            className="flex justify-center items-center gap-[0.375rem] text-sm text-[#f9fafb] bg-red-500 px-2 py-[0.45rem] rounded-[6px] font-medium focus:bg-[#e14343] hover:bg-[#e14343]"
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              height="20"
-              viewBox="0 -960 960 960"
-              width="20"
-              fill="white"
-            >
-              <path d="m361-299 119-121 120 121 47-48-119-121 119-121-47-48-120 121-119-121-48 48 120 121-120 121 48 48ZM261-120q-24 0-42-18t-18-42v-570h-41v-60h188v-30h264v30h188v60h-41v570q0 24-18 42t-42 18H261Z" />
-            </svg>
-            문제 삭제
-          </button>
+          {isUserContestant() && (
+            <>
+              <button
+                onClick={handleGoToUserContestSubmits}
+                className="flex justify-center items-center gap-[0.375rem] text-sm text-[#f9fafb] bg-[#6860ff] px-2 py-[0.45rem] rounded-[6px] font-medium focus:bg-[#5951f0] hover:bg-[#5951f0]"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  height="20"
+                  viewBox="0 -960 960 960"
+                  width="20"
+                  fill="white"
+                >
+                  <path d="M320-242 80-482l242-242 43 43-199 199 197 197-43 43Zm318 2-43-43 199-199-197-197 43-43 240 240-242 242Z" />
+                </svg>
+                내 제출 현황
+              </button>
+              <button
+                onClick={handleGoToSubmitContestProblemCode}
+                className="flex justify-center items-center gap-[0.375rem] text-sm text-[#f9fafb] bg-[#3a8af9] px-3 py-[0.45rem] rounded-[6px] font-medium focus:bg-[#1c6cdb] hover:bg-[#1c6cdb]"
+              >
+                제출하기
+              </button>
+            </>
+          )}
+
+          {userInfo._id === contestInfo.writer._id && (
+            <>
+              <button
+                onClick={handleEditProblem}
+                className="flex justify-center items-center gap-[0.375rem] text-sm text-[#f9fafb] bg-[#eba338] px-2 py-[0.45rem] rounded-[6px] font-medium focus:bg-[#dc9429] hover:bg-[#dc9429]"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  height="20"
+                  viewBox="0 -960 960 960"
+                  width="20"
+                  fill="white"
+                >
+                  <path d="M794-666 666-794l42-42q17-17 42.5-16.5T793-835l43 43q17 17 17 42t-17 42l-42 42Zm-42 42L248-120H120v-128l504-504 128 128Z" />
+                </svg>
+                문제 수정
+              </button>
+              <button
+                onClick={handleDeleteProblem}
+                className="flex justify-center items-center gap-[0.375rem] text-sm text-[#f9fafb] bg-red-500 px-2 py-[0.45rem] rounded-[6px] font-medium focus:bg-[#e14343] hover:bg-[#e14343]"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  height="20"
+                  viewBox="0 -960 960 960"
+                  width="20"
+                  fill="white"
+                >
+                  <path d="m361-299 119-121 120 121 47-48-119-121 119-121-47-48-120 121-119-121-48 48 120 121-120 121 48 48ZM261-120q-24 0-42-18t-18-42v-570h-41v-60h188v-30h264v30h188v60h-41v570q0 24-18 42t-42 18H261Z" />
+                </svg>
+                문제 삭제
+              </button>
+            </>
+          )}
         </div>
 
         <div className="gap-5 border-b mt-8 mb-4 pb-5">
-          <PDFViewer pdfFileURL={'/pdfs/test.pdf'} />
+          <PDFViewer pdfFileURL={contestProblemInfo.content} />
         </div>
       </div>
     </div>

--- a/app/practices/[pid]/page.tsx
+++ b/app/practices/[pid]/page.tsx
@@ -5,9 +5,11 @@ import Loading from '@/app/loading';
 import { userInfoStore } from '@/app/store/UserInfo';
 import { ProblemInfo } from '@/app/types/problem';
 import axiosInstance from '@/app/utils/axiosInstance';
+import { fetchCurrentUserInfo } from '@/app/utils/fetchCurrentUserInfo';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
 
 // 연습문제 게시글 정보 조회 API
 const fetchPracticeDetailInfo = ({ queryKey }: any) => {
@@ -61,9 +63,12 @@ export default function PracticeProblem(props: DefaultProps) {
   });
 
   const userInfo = userInfoStore((state: any) => state.userInfo);
+  const updateUserInfo = userInfoStore((state: any) => state.updateUserInfo);
 
   const resData = data?.data.data;
   const practiceInfo: ProblemInfo = resData;
+
+  const [isLoading, setIsLoading] = useState(true);
 
   const router = useRouter();
 
@@ -92,7 +97,16 @@ export default function PracticeProblem(props: DefaultProps) {
     deletePracticeMutation.mutate(pid);
   };
 
-  if (isPending) return <Loading />;
+  // (로그인 한) 사용자 정보 조회
+  useEffect(() => {
+    fetchCurrentUserInfo(updateUserInfo).then((userInfo) => {
+      if (practiceInfo) {
+        if (userInfo.isAuth) setIsLoading(false);
+      }
+    });
+  }, [updateUserInfo, practiceInfo]);
+
+  if (isLoading) return <Loading />;
 
   return (
     <div className="mt-6 mb-24 px-5 2lg:px-0 overflow-x-auto">

--- a/app/utils/axiosInstance.ts
+++ b/app/utils/axiosInstance.ts
@@ -26,21 +26,13 @@ axiosInstance.interceptors.response.use(
     if (error.response) {
       switch (error.response.status) {
         case 400:
-          const url = error.request.responseURL;
-          const regex =
-            /https:\/\/swjudgeapi\.cbnu\.ac\.kr\/v1\/(.*?)\/[0-9a-fA-F]{24}\/problems/;
-          const category = url.match(regex);
           switch (error.response.data.code) {
             case 'IS_NOT_CONTESTANT':
-              if (category[1] === 'contest') alert('대회 참가자가 아닙니다.');
-              else if (category[1] === 'assignment')
-                alert('시험 신청자가 아닙니다.');
+              alert('대상자가 아닙니다.');
               if (typeof window !== 'undefined') window.history.back();
               return;
             case 'IS_NOT_TEST_PERIOD':
-              if (category[1] === 'contest') alert('대회 시간이 아닙니다.');
-              else if (category[1] === 'assignment')
-                alert('시험 시간이 아닙니다.');
+              alert('진행 시간이 아닙니다.');
               if (typeof window !== 'undefined') window.history.back();
               return;
           }


### PR DESCRIPTION
## 👀 이슈

resolve #228 

## 📌 개요

대회에 등록된 문제 게시글 페이지 내 실제 정보가 표시되도록
해당 기능을 추가하였습니다.

## 👩‍💻 작업 사항

- 대회 문제 게시글 페이지 정보 표시 기능 추가
-  **axios response interceptor** 내 `400` **http status code**에 대한 처리 로직 수정
- 연습문제 게시글 상세 페이지 컴포넌트 내 사용자의 로그인 완료 여부 확인 기능 추가

## ✅ 참고 사항

- 기능 추가 후 **대회 문제 게시글 상세 페이지** 화면

https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/357d7124-4183-4cf7-abd9-c4974ea36b76