### PR TITLE
[feat]: 대회 문제 게시글 정보 수정 기능 추가 (#230)

### DIFF
--- a/app/contests/[cid]/problems/[problemId]/page.tsx
+++ b/app/contests/[cid]/problems/[problemId]/page.tsx
@@ -158,7 +158,7 @@ export default function ContestProblem(props: DefaultProps) {
   useEffect(() => {
     // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인, 그리고 게시글 작성자인지 확인
     fetchCurrentUserInfo(updateUserInfo).then((userInfo: UserInfo) => {
-      if (contestProblemInfo) {
+      if (contestInfo && contestProblemInfo) {
         const isWriter = contestProblemInfo.writer._id === userInfo._id;
         const isContestant = contestInfo.contestants.some(
           (contestant) => contestant._id === userInfo._id,
@@ -200,7 +200,7 @@ export default function ContestProblem(props: DefaultProps) {
         router.back();
       }
     });
-  }, [updateUserInfo, contestProblemInfo, cid, router]);
+  }, [updateUserInfo, contestInfo, contestProblemInfo, cid, router]);
 
   if (isLoading || !isPasswordChecked) return <Loading />;
 
@@ -228,7 +228,7 @@ export default function ContestProblem(props: DefaultProps) {
                 시간 제한:
                 <span className="font-mono font-light">
                   {' '}
-                  <span>{contestProblemInfo.options.maxRealTime}</span>초
+                  <span>{contestProblemInfo.options.maxRealTime / 1000}</span>초
                 </span>
               </span>
               <span className='relative bottom-[0.055rem] font-thin before:content-["|"]' />

--- a/app/contests/[cid]/problems/register/page.tsx
+++ b/app/contests/[cid]/problems/register/page.tsx
@@ -144,7 +144,7 @@ export default function RegisterContestProblem(props: DefaultProps) {
       return;
     }
 
-    if (!score) {
+    if (!score || score <= 0) {
       alert('문제 점수를 입력해 주세요');
       window.scrollTo(0, 0);
       scoreRef.current?.focus();
@@ -160,6 +160,7 @@ export default function RegisterContestProblem(props: DefaultProps) {
 
     if (ioSetData.length === 0) {
       alert('입/출력 파일 셋(in/out)을 업로드해 주세요');
+      window.scrollTo(0, document.body.scrollHeight);
       return;
     }
 

--- a/app/practices/[pid]/edit/page.tsx
+++ b/app/practices/[pid]/edit/page.tsx
@@ -94,6 +94,12 @@ export default function EditPractice(props: DefaultProps) {
     setIsInAndOutFileUploadingValidFail,
   ] = useState(false);
 
+  const practiceNameRef = useRef<HTMLInputElement>(null);
+  const maxExeTimeRef = useRef<HTMLInputElement>(null);
+  const maxMemCapRef = useRef<HTMLInputElement>(null);
+
+  const router = useRouter();
+
   useEffect(() => {
     if (practiceInfo) {
       setTitle(practiceInfo.title);
@@ -107,12 +113,6 @@ export default function EditPractice(props: DefaultProps) {
   useEffect(() => {
     if (ioSetData.length !== 0) setIsIoSetDataEmpty(false);
   }, [ioSetData]);
-
-  const practiceNameRef = useRef<HTMLInputElement>(null);
-  const maxExeTimeRef = useRef<HTMLInputElement>(null);
-  const maxMemCapRef = useRef<HTMLInputElement>(null);
-
-  const router = useRouter();
 
   const handlePracticeNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setTitle(e.target.value);
@@ -205,7 +205,7 @@ export default function EditPractice(props: DefaultProps) {
     });
   }, [updateUserInfo, practiceInfo, router]);
 
-  if (isLoading || isPending) return <Loading />;
+  if (isLoading) return <Loading />;
 
   return (
     <div className="mt-2 px-5 2lg:px-0 overflow-x-auto">

--- a/app/practices/register/page.tsx
+++ b/app/practices/register/page.tsx
@@ -119,6 +119,7 @@ export default function RegisterPractice() {
 
     if (ioSetData.length === 0) {
       alert('입/출력 파일 셋(in/out)을 업로드해 주세요');
+      window.scrollTo(0, document.body.scrollHeight);
       return;
     }
 


### PR DESCRIPTION
## 👀 이슈

resolve #230 

## 📌 개요

대회에 등록된 문제에 대한 정보를 수정하는 기능을 추가하였습니다.

## 👩‍💻 작업 사항

- 대회 문제 게시글 정보 수정 기능 추가

## ✅ 참고 사항

- 기능 추가 후 **대회 문제 수정** 페이지 화면

https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/9e3dee55-12d0-42a4-bae6-009b83c6ac01