### PR TITLE
[feat]: 대회 문제 게시글 삭제 기능 추가 (#232)

### DIFF
--- a/app/contests/[cid]/page.tsx
+++ b/app/contests/[cid]/page.tsx
@@ -185,7 +185,7 @@ export default function ContestDetail(props: DefaultProps) {
       return 'text-blue-500';
     } else if (
       currentTime >= contestStartTime &&
-      currentTime <= contestEndTime
+      currentTime < contestEndTime
     ) {
       // 대회 진행 중
       return 'text-red-500';
@@ -215,7 +215,7 @@ export default function ContestDetail(props: DefaultProps) {
       );
     } else if (
       currentTime >= contestStartTime &&
-      currentTime <= contestEndTime
+      currentTime < contestEndTime
     ) {
       // 대회 진행 중: 대회 종료까지 남은 시간 표시
       return (
@@ -257,7 +257,7 @@ export default function ContestDetail(props: DefaultProps) {
     if (
       isEnrollContest &&
       currentTime >= contestStartTime &&
-      currentTime <= contestEndTime
+      currentTime < contestEndTime
     ) {
       return true;
     }
@@ -355,7 +355,7 @@ export default function ContestDetail(props: DefaultProps) {
       }
     } else if (
       currentTime >= contestStartTime &&
-      currentTime <= contestEndTime
+      currentTime < contestEndTime
     ) {
       // 대회 진행 중
       return (

--- a/app/contests/[cid]/problems/[problemId]/page.tsx
+++ b/app/contests/[cid]/problems/[problemId]/page.tsx
@@ -43,6 +43,13 @@ const fetchContestDetailInfo = ({ queryKey }: any) => {
   );
 };
 
+// 대회 문제 삭제 API
+const deleteContestProblem = (problemId: string) => {
+  return axiosInstance.delete(
+    `${process.env.NEXT_PUBLIC_API_VERSION}/problem/${problemId}`,
+  );
+};
+
 interface DefaultProps {
   params: {
     cid: string;
@@ -106,6 +113,23 @@ export default function ContestProblem(props: DefaultProps) {
     ],
   });
 
+  const deleteContestMutation = useMutation({
+    mutationFn: deleteContestProblem,
+    onSuccess: (data) => {
+      const resData = data.data;
+      const httpStatusCode = resData.status;
+
+      switch (httpStatusCode) {
+        case 200:
+          alert('문제가 삭제되었습니다.');
+          router.push(`/contests/${cid}/problems`);
+          break;
+        default:
+          alert('정의되지 않은 http status code입니다');
+      }
+    },
+  });
+
   const contestInfo: ContestInfo = results[0].data?.data.data;
   const contestProblemInfo: ProblemInfo = results[1].data?.data.data;
 
@@ -114,6 +138,9 @@ export default function ContestProblem(props: DefaultProps) {
 
   const [isLoading, setIsLoading] = useState(true);
   const [isEnrollContest, setIsEnrollContest] = useState(false);
+
+  const currentTime = new Date();
+  const contestEndTime = new Date(contestInfo?.testPeriod.end);
 
   const router = useRouter();
 
@@ -136,8 +163,8 @@ export default function ContestProblem(props: DefaultProps) {
   const handleDeleteProblem = () => {
     const userResponse = confirm('문제를 삭제하시겠습니까?');
     if (!userResponse) return;
-    alert('문제를 삭제하였습니다.');
-    router.push(`/contests/${cid}/problems`);
+
+    deleteContestMutation.mutate(problemId);
   };
 
   // 대회 신청 여부 확인
@@ -267,7 +294,7 @@ export default function ContestProblem(props: DefaultProps) {
             </svg>
             문제 목록
           </button>
-          {isUserContestant() && (
+          {isEnrollContest && (
             <>
               <button
                 onClick={handleGoToUserContestSubmits}
@@ -293,40 +320,41 @@ export default function ContestProblem(props: DefaultProps) {
             </>
           )}
 
-          {userInfo._id === contestInfo.writer._id && (
-            <>
-              <button
-                onClick={handleEditProblem}
-                className="flex justify-center items-center gap-[0.375rem] text-sm text-[#f9fafb] bg-[#eba338] px-2 py-[0.45rem] rounded-[6px] font-medium focus:bg-[#dc9429] hover:bg-[#dc9429]"
-              >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  height="20"
-                  viewBox="0 -960 960 960"
-                  width="20"
-                  fill="white"
+          {currentTime < contestEndTime &&
+            userInfo._id === contestInfo.writer._id && (
+              <>
+                <button
+                  onClick={handleEditProblem}
+                  className="flex justify-center items-center gap-[0.375rem] text-sm text-[#f9fafb] bg-[#eba338] px-2 py-[0.45rem] rounded-[6px] font-medium focus:bg-[#dc9429] hover:bg-[#dc9429]"
                 >
-                  <path d="M794-666 666-794l42-42q17-17 42.5-16.5T793-835l43 43q17 17 17 42t-17 42l-42 42Zm-42 42L248-120H120v-128l504-504 128 128Z" />
-                </svg>
-                문제 수정
-              </button>
-              <button
-                onClick={handleDeleteProblem}
-                className="flex justify-center items-center gap-[0.375rem] text-sm text-[#f9fafb] bg-red-500 px-2 py-[0.45rem] rounded-[6px] font-medium focus:bg-[#e14343] hover:bg-[#e14343]"
-              >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  height="20"
-                  viewBox="0 -960 960 960"
-                  width="20"
-                  fill="white"
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    height="20"
+                    viewBox="0 -960 960 960"
+                    width="20"
+                    fill="white"
+                  >
+                    <path d="M794-666 666-794l42-42q17-17 42.5-16.5T793-835l43 43q17 17 17 42t-17 42l-42 42Zm-42 42L248-120H120v-128l504-504 128 128Z" />
+                  </svg>
+                  문제 수정
+                </button>
+                <button
+                  onClick={handleDeleteProblem}
+                  className="flex justify-center items-center gap-[0.375rem] text-sm text-[#f9fafb] bg-red-500 px-2 py-[0.45rem] rounded-[6px] font-medium focus:bg-[#e14343] hover:bg-[#e14343]"
                 >
-                  <path d="m361-299 119-121 120 121 47-48-119-121 119-121-47-48-120 121-119-121-48 48 120 121-120 121 48 48ZM261-120q-24 0-42-18t-18-42v-570h-41v-60h188v-30h264v30h188v60h-41v570q0 24-18 42t-42 18H261Z" />
-                </svg>
-                문제 삭제
-              </button>
-            </>
-          )}
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    height="20"
+                    viewBox="0 -960 960 960"
+                    width="20"
+                    fill="white"
+                  >
+                    <path d="m361-299 119-121 120 121 47-48-119-121 119-121-47-48-120 121-119-121-48 48 120 121-120 121 48 48ZM261-120q-24 0-42-18t-18-42v-570h-41v-60h188v-30h264v30h188v60h-41v570q0 24-18 42t-42 18H261Z" />
+                  </svg>
+                  문제 삭제
+                </button>
+              </>
+            )}
         </div>
 
         <div className="gap-5 border-b mt-8 mb-4 pb-5">

--- a/app/contests/[cid]/problems/page.tsx
+++ b/app/contests/[cid]/problems/page.tsx
@@ -331,7 +331,8 @@ export default function ContestProblems(props: DefaultProps) {
                     대회 순위
                   </button>
                   {OPERATOR_ROLES.includes(userInfo.role) &&
-                    userInfo._id === contestProblemsInfo.writer._id && (
+                    userInfo._id === contestProblemsInfo.writer._id &&
+                    currentTime < contestEndTime && (
                       <button
                         onClick={handleRegisterContestProblem}
                         className="flex justify-center items-center gap-[0.375rem] text-[#f9fafb] bg-green-500 px-2 py-[0.45rem] rounded-[6px] focus:bg-[#3e9368] hover:bg-[#3e9368]"
@@ -352,7 +353,8 @@ export default function ContestProblems(props: DefaultProps) {
               )}
 
               {OPERATOR_ROLES.includes(userInfo.role) &&
-                userInfo._id === contestProblemsInfo.writer._id && (
+                userInfo._id === contestProblemsInfo.writer._id &&
+                currentTime < contestEndTime && (
                   <button
                     onClick={handleChangeProblemOrder}
                     ref={changingProblemOrderBtnRef}

--- a/app/contests/[cid]/problems/page.tsx
+++ b/app/contests/[cid]/problems/page.tsx
@@ -222,7 +222,7 @@ export default function ContestProblems(props: DefaultProps) {
       return 'text-blue-500';
     } else if (
       currentTime >= contestStartTime &&
-      currentTime <= contestEndTime
+      currentTime < contestEndTime
     ) {
       // 대회 진행 중
       return 'text-red-500';
@@ -252,7 +252,7 @@ export default function ContestProblems(props: DefaultProps) {
       );
     } else if (
       currentTime >= contestStartTime &&
-      currentTime <= contestEndTime
+      currentTime < contestEndTime
     ) {
       // 대회 진행 중: 대회 종료까지 남은 시간 표시
       return (

--- a/app/contests/[cid]/problems/register/page.tsx
+++ b/app/contests/[cid]/problems/register/page.tsx
@@ -90,6 +90,9 @@ export default function RegisterContestProblem(props: DefaultProps) {
   const maxMemCapRef = useRef<HTMLInputElement>(null);
   const scoreRef = useRef<HTMLInputElement>(null);
 
+  const currentTime = new Date();
+  const contestEndTime = new Date(contestInfo?.testPeriod.end);
+
   const router = useRouter();
 
   const handleProblemNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -187,7 +190,7 @@ export default function RegisterContestProblem(props: DefaultProps) {
       if (contestInfo) {
         const isWriter = contestInfo.writer._id === userInfo._id;
 
-        if (isWriter) {
+        if (isWriter && currentTime < contestEndTime) {
           setIsLoading(false);
           return;
         }

--- a/app/contests/[cid]/ranklist/page.tsx
+++ b/app/contests/[cid]/ranklist/page.tsx
@@ -88,7 +88,7 @@ export default function ContestRankList(props: DefaultProps) {
     if (
       isEnrollContest &&
       currentTime >= contestStartTime &&
-      currentTime <= contestEndTime
+      currentTime < contestEndTime
     ) {
       return true;
     }
@@ -103,7 +103,7 @@ export default function ContestRankList(props: DefaultProps) {
       return 'text-blue-500';
     } else if (
       currentTime >= contestStartTime &&
-      currentTime <= contestEndTime
+      currentTime < contestEndTime
     ) {
       // 대회 진행 중
       return 'text-red-500';
@@ -133,7 +133,7 @@ export default function ContestRankList(props: DefaultProps) {
       );
     } else if (
       currentTime >= contestStartTime &&
-      currentTime <= contestEndTime
+      currentTime < contestEndTime
     ) {
       // 대회 진행 중: 대회 종료까지 남은 시간 표시
       return (

--- a/app/exams/[eid]/page.tsx
+++ b/app/exams/[eid]/page.tsx
@@ -139,7 +139,7 @@ export default function ExamDetail(props: DefaultProps) {
     if (currentTime < examStartTime) {
       // 시험 시작 전
       return 'text-blue-500';
-    } else if (currentTime >= examStartTime && currentTime <= examEndTime) {
+    } else if (currentTime >= examStartTime && currentTime < examEndTime) {
       // 시험 진행 중
       return 'text-red-500';
     }
@@ -166,7 +166,7 @@ export default function ExamDetail(props: DefaultProps) {
             `(${timeUntilStart.seconds}초 남음)`}
         </span>
       );
-    } else if (currentTime >= examStartTime && currentTime <= examEndTime) {
+    } else if (currentTime >= examStartTime && currentTime < examEndTime) {
       // 시험 진행 중: 시험 종료까지 남은 시간 표시
       return (
         <span className={`font-semibold ${getTimeDisplayClass()}`}>
@@ -204,7 +204,7 @@ export default function ExamDetail(props: DefaultProps) {
     if (
       isEnrollExam &&
       currentTime >= examStartTime &&
-      currentTime <= examEndTime
+      currentTime < examEndTime
     ) {
       return true;
     }
@@ -304,7 +304,7 @@ export default function ExamDetail(props: DefaultProps) {
           시험 응시하기
         </button>
       );
-    } else if (currentTime >= examStartTime && currentTime <= examEndTime) {
+    } else if (currentTime >= examStartTime && currentTime < examEndTime) {
       // 시험 진행 중
       if (isEnrollExam) {
         return (

--- a/app/exams/[eid]/problems/page.tsx
+++ b/app/exams/[eid]/problems/page.tsx
@@ -136,7 +136,7 @@ export default function ExamProblems(props: DefaultProps) {
     if (currentTime < examStartTime) {
       // 시험 시작 전
       return 'text-blue-500';
-    } else if (currentTime >= examStartTime && currentTime <= examEndTime) {
+    } else if (currentTime >= examStartTime && currentTime < examEndTime) {
       // 시험 진행 중
       return 'text-red-500';
     }
@@ -163,7 +163,7 @@ export default function ExamProblems(props: DefaultProps) {
             `(${timeUntilStart.seconds}초 남음)`}
         </span>
       );
-    } else if (currentTime >= examStartTime && currentTime <= examEndTime) {
+    } else if (currentTime >= examStartTime && currentTime < examEndTime) {
       // 시험 진행 중: 시험 종료까지 남은 시간 표시
       return (
         <span className={`font-semibold ${getTimeDisplayClass()}`}>


### PR DESCRIPTION
## 👀 이슈

resolve #232 

## 📌 개요

대회에 등록된 문제를 삭제할 수 있는 기능을
추가하였습니다.

## 👩‍💻 작업 사항

- 대회 문제 게시글 삭제 기능 추가
- 대회 문제 `등록/수정`, 대회 문제 목록 페이지 내 `문제 등록/ 문제 순서 변경` 버튼 접근 및 은닉 기능 추가

## ✅ 참고 사항

- 기능 추가 후 **대회 문제 게시글 삭제** 기능 사용 화면

https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/ad0ecdd2-79ad-45c8-be8d-fdee6fb90c92