### PR TITLE
[feat]: 대회 문제 코드 제출, 제출 목록 및 제출 정보 상세 페이지 내 정보 표시 기능 추가 (#234)

### DIFF
--- a/app/components/MyDropzone.tsx
+++ b/app/components/MyDropzone.tsx
@@ -9,9 +9,9 @@ interface MyDropzoneProps {
   guideMsg: string;
   setIsFileUploaded: (isUploaded: boolean) => void;
   isFileUploaded: boolean;
-  initPdfUrl: string;
-  initInAndOutFiles: IoSetItem[];
-  setUploadedPdfFileUrl?: (url: string) => void; // PDF 파일 URL 업데이트 함수
+  initUrl?: string;
+  initInAndOutFiles?: IoSetItem[];
+  setUploadedFileUrl?: (url: string) => void;
   setIoSetData?: (
     ioSetData: IoSetItem[] | ((prevIoSetData: IoSetItem[]) => IoSetItem[]),
   ) => void;
@@ -27,9 +27,9 @@ function MyDropzone(props: MyDropzoneProps) {
     guideMsg,
     setIsFileUploaded,
     isFileUploaded,
-    initPdfUrl,
+    initUrl,
     initInAndOutFiles,
-    setUploadedPdfFileUrl,
+    setUploadedFileUrl,
     setIoSetData,
   } = props;
 
@@ -100,7 +100,8 @@ function MyDropzone(props: MyDropzoneProps) {
             .then((response) => {
               const newFile = response.data; // 서버로부터 받은 파일 정보
               setFileList([newFile]);
-              if (type === 'pdf') setUploadedPdfFileUrl?.(newFile.url);
+              if (type === 'pdf' || type === 'code')
+                setUploadedFileUrl?.(newFile.url);
               setFileNameList([newFile.filename]);
               setIsFileUploaded(true);
             })
@@ -110,13 +111,7 @@ function MyDropzone(props: MyDropzoneProps) {
         });
       }
     },
-    [
-      uploadService,
-      type,
-      setIsFileUploaded,
-      setUploadedPdfFileUrl,
-      setIoSetData,
-    ],
+    [uploadService, type, setIsFileUploaded, setUploadedFileUrl, setIoSetData],
   );
 
   useEffect(() => {
@@ -200,13 +195,13 @@ function MyDropzone(props: MyDropzoneProps) {
 
   useEffect(() => {
     if (!isInitialized) {
-      if (type === 'pdf' && initPdfUrl) {
+      if (type === 'pdf' && initUrl) {
         // PDF 파일 초기화 로직
         const newFile = {
           ref: null,
           refModel: null,
           _id: '',
-          url: initPdfUrl,
+          url: initUrl,
           filename: '',
           mimetype: '',
           size: 0,
@@ -216,7 +211,11 @@ function MyDropzone(props: MyDropzoneProps) {
         };
         setFileList([newFile]);
         setIsFileUploaded(true);
-      } else if (type === 'inOut' && initInAndOutFiles.length > 0) {
+      } else if (
+        type === 'inOut' &&
+        initInAndOutFiles &&
+        initInAndOutFiles.length > 0
+      ) {
         // In/Out 파일 초기화 로직
         const files: UploadedFileInfo[] = initInAndOutFiles.reduce(
           (acc: UploadedFileInfo[], ioSetItem: IoSetItem) => {
@@ -232,7 +231,7 @@ function MyDropzone(props: MyDropzoneProps) {
       }
       setIsInitialized(true);
     }
-  }, [type, initPdfUrl, initInAndOutFiles, isInitialized, setIsFileUploaded]);
+  }, [type, initUrl, initInAndOutFiles, isInitialized, setIsFileUploaded]);
 
   return (
     <div className="flex flex-col gap-2 items-center justify-center w-full">

--- a/app/contests/[cid]/problems/[problemId]/submit/page.tsx
+++ b/app/contests/[cid]/problems/[problemId]/submit/page.tsx
@@ -4,9 +4,53 @@ import MyDropzone from '@/app/components/MyDropzone';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import codeImg from '@/public/images/code.png';
-import { IoSetItem } from '@/app/types/problem';
+import { ProblemInfo } from '@/app/types/problem';
+import axiosInstance from '@/app/utils/axiosInstance';
+import { SubmitCode } from '@/app/types/submit';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { fetchCurrentUserInfo } from '@/app/utils/fetchCurrentUserInfo';
+import { userInfoStore } from '@/app/store/UserInfo';
+import { deleteCookie, getCookie, setCookie } from 'cookies-next';
+import { AxiosError } from 'axios';
+import { UserInfo } from '@/app/types/user';
+import Loading from '@/app/loading';
+
+// 대회 문제 열람 비밀번호 확인 API
+const confirmContestConfirm = ({
+  cid,
+  password,
+}: {
+  cid: string;
+  password: string;
+}) => {
+  return axiosInstance.get(
+    `${process.env.NEXT_PUBLIC_API_VERSION}/contest/confirm/${cid}?password=${password}`,
+  );
+};
+
+// 문제 정보 조회 API
+const fetchContestProblemDetailInfo = ({ queryKey }: any) => {
+  const problemId = queryKey[1];
+  return axiosInstance.get(
+    `${process.env.NEXT_PUBLIC_API_VERSION}/problem/${problemId}`,
+  );
+};
+
+// 코드 제출 API
+const submitCode = ({
+  problemId,
+  params,
+}: {
+  problemId: string;
+  params: SubmitCode;
+}) => {
+  return axiosInstance.post(
+    `${process.env.NEXT_PUBLIC_API_VERSION}/problem/${problemId}/submit`,
+    params,
+  );
+};
 
 interface DefaultProps {
   params: {
@@ -16,12 +60,79 @@ interface DefaultProps {
 }
 
 export default function SubmitContestProblemCode(props: DefaultProps) {
+  const cid = props.params.cid;
+  const problemId = props.params.problemId;
+
+  const confirmContestConfirmMutation = useMutation({
+    mutationFn: confirmContestConfirm,
+    onError: (error: AxiosError) => {
+      const resData: any = error.response?.data;
+      switch (resData.status) {
+        case 400:
+          switch (resData.code) {
+            case 'CONTEST_PASSWORD_NOT_MATCH':
+              alert('비밀번호가 일치하지 않습니다.');
+              deleteCookie(cid);
+              router.back();
+              break;
+            default:
+              alert('정의되지 않은 http code입니다.');
+          }
+          break;
+        default:
+          alert('정의되지 않은 http status code입니다');
+      }
+    },
+    onSuccess: (data) => {
+      const resData = data.data;
+      const httpStatusCode = resData.status;
+
+      switch (httpStatusCode) {
+        case 200:
+          setCookie(cid, password, { maxAge: 60 * 60 * 24 });
+          setIsPasswordChecked(true);
+          break;
+        default:
+          alert('정의되지 않은 http status code입니다');
+      }
+    },
+  });
+
+  const [password, setPassword] = useState('');
+  const [isPasswordChecked, setIsPasswordChecked] = useState(false);
+
+  const { isPending, isError, data, error } = useQuery({
+    queryKey: ['contestProblemDetailInfo', problemId],
+    queryFn: fetchContestProblemDetailInfo,
+    retry: 0,
+  });
+
+  const submitCodeMutation = useMutation({
+    mutationFn: submitCode,
+    onSuccess: (data) => {
+      const resData = data?.data;
+      const httpStatusCode = resData.status;
+
+      switch (httpStatusCode) {
+        case 200:
+          alert('소스코드가 제출되었습니다.');
+          router.push(`/contests/${cid}/problems/${problemId}/submits`);
+          break;
+        default:
+          alert('정의되지 않은 http status code입니다');
+      }
+    },
+  });
+
+  const resData = data?.data.data;
+  const contestProblemInfo: ProblemInfo = resData;
+
+  const updateUserInfo = userInfoStore((state: any) => state.updateUserInfo);
+
+  const [isLoading, setIsLoading] = useState(true);
   const [selectedSubmitLanguage, setSelectedSubmitLanguage] =
     useState('언어 선택 *');
   const [uploadedCodeFileUrl, setUploadedCodeFileUrl] = useState('');
-  const [uploadedProblemPdfFileUrl, setUploadedProblemPdfFileUrl] =
-    useState('');
-  const [ioSetData, setIoSetData] = useState<IoSetItem[]>([]);
 
   const [
     isSelectedSubmitLanguageValidFail,
@@ -30,8 +141,8 @@ export default function SubmitContestProblemCode(props: DefaultProps) {
   const [isCodeFileUploadingValidFail, setIsCodeFileUploadingValidFail] =
     useState(false);
 
-  const cid = props.params.cid;
-  const problemId = props.params.cid;
+  const currentTime = new Date();
+  const contestEndTime = new Date(contestProblemInfo?.parentId.testPeriod.end);
 
   const router = useRouter();
 
@@ -60,8 +171,58 @@ export default function SubmitContestProblemCode(props: DefaultProps) {
       return;
     }
 
-    router.push(`/contests/${cid}/problems/${problemId}/submits`);
+    const submitCodeData = {
+      parentId: cid,
+      parentType: 'Contest',
+      problem: problemId,
+      source: uploadedCodeFileUrl,
+      language: selectedSubmitLanguage.toLowerCase(),
+    };
+
+    submitCodeMutation.mutate({ problemId, params: submitCodeData });
   };
+
+  useEffect(() => {
+    // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인, 그리고 게시글 작성자인지 확인
+    fetchCurrentUserInfo(updateUserInfo).then((userInfo: UserInfo) => {
+      if (contestProblemInfo) {
+        const isContestant = contestProblemInfo.parentId.contestants.some(
+          (contestant_id) => contestant_id === userInfo._id,
+        );
+
+        if (isContestant && currentTime < contestEndTime) {
+          setIsLoading(false);
+          const contestPasswordCookie = getCookie(cid);
+          if (contestPasswordCookie) {
+            setPassword(contestPasswordCookie);
+            confirmContestConfirmMutation.mutate({
+              cid,
+              password: contestPasswordCookie,
+            });
+            return;
+          }
+
+          const inputPassword = prompt('비밀번호를 입력해 주세요');
+          if (inputPassword !== null && inputPassword.trim() !== '') {
+            setPassword(inputPassword);
+            confirmContestConfirmMutation.mutate({
+              cid,
+              password: inputPassword,
+            });
+            return;
+          }
+
+          router.back();
+          return;
+        }
+
+        alert('접근 권한이 없습니다.');
+        router.back();
+      }
+    });
+  }, [updateUserInfo, contestProblemInfo, cid, router]);
+
+  if (isLoading || !isPasswordChecked) return <Loading />;
 
   return (
     <div className="mt-2 mb-24 px-5 2lg:px-0 overflow-x-auto">
@@ -85,7 +246,7 @@ export default function SubmitContestProblemCode(props: DefaultProps) {
                 href={`/contests/${cid}/problems/${problemId}`}
                 className="mt-1 ml-1 text-xl font-medium cursor-pointer hover:underline hover:text-[#0038a8] focus:underline focus:text-[#0038a8] text-[#1048b8]"
               >
-                (A+B)
+                ({contestProblemInfo.title})
               </Link>
             </div>
           </p>
@@ -96,7 +257,7 @@ export default function SubmitContestProblemCode(props: DefaultProps) {
                 <span className="font-mono font-light">
                   {' '}
                   <span className="font-mono font-semibold text-blue-600">
-                    1
+                    {contestProblemInfo.score}
                   </span>
                   점
                 </span>
@@ -106,7 +267,7 @@ export default function SubmitContestProblemCode(props: DefaultProps) {
                 시간 제한:
                 <span className="font-mono font-light">
                   {' '}
-                  <span>1</span>초
+                  <span>{contestProblemInfo.options.maxRealTime / 1000}</span>초
                 </span>
               </span>
               <span className='relative bottom-[0.055rem] font-thin before:content-["|"]' />
@@ -114,15 +275,16 @@ export default function SubmitContestProblemCode(props: DefaultProps) {
                 메모리 제한:
                 <span className="font-mono font-light">
                   {' '}
-                  <span className="mr-1">5</span>MB
+                  {contestProblemInfo.options.maxMemory}
                 </span>
+                MB
               </span>
             </div>
             <div className="flex gap-3">
               <span className="font-semibold">
                 대회:{' '}
                 <span className="font-light">
-                  2023년 제2회 충청북도 대학생 프로그래밍 경진대회 본선
+                  {contestProblemInfo.parentId.title}
                 </span>
               </span>
             </div>
@@ -135,10 +297,9 @@ export default function SubmitContestProblemCode(props: DefaultProps) {
               name="languages"
               id="lang"
               className={`text-sm w-full pl-0 py-1 ${
-                selectedSubmitLanguage === '언어 선택 *' &&
                 isSelectedSubmitLanguageValidFail
                   ? 'text-red-500'
-                  : 'text-gray-500'
+                  : selectedSubmitLanguage === '언어 선택 *' && 'text-gray-500'
               }   bg-transparent border-0 border-b border-${
                 isSelectedSubmitLanguageValidFail ? 'red-500' : 'gray-400'
               }  gray-400 appearance-none focus:outline-none focus:ring-0 focus:border-${
@@ -175,8 +336,8 @@ export default function SubmitContestProblemCode(props: DefaultProps) {
               guideMsg="코드 파일을 이곳에 업로드해 주세요"
               setIsFileUploaded={setIsCodeFileUploadingValidFail}
               isFileUploaded={isCodeFileUploadingValidFail}
-              initPdfUrl={''}
-              initInAndOutFiles={[]}
+              initUrl={''}
+              setUploadedFileUrl={setUploadedCodeFileUrl}
             />
           </div>
         </div>

--- a/app/contests/[cid]/problems/[problemId]/submits/components/UserContestSubmitListItem.tsx
+++ b/app/contests/[cid]/problems/[problemId]/submits/components/UserContestSubmitListItem.tsx
@@ -1,14 +1,23 @@
+import { ContestSubmitInfo } from '@/app/types/contest';
+import { formatDateToYYMMDDHHMM } from '@/app/utils/formatDate';
+import { getCodeSubmitResultTypeDescription } from '@/app/utils/getCodeSubmitResultTypeDescription';
 import { useRouter } from 'next/navigation';
 import React from 'react';
 
 interface ContestSubmitListItemProps {
+  personalUserContestSubmitInfo: ContestSubmitInfo;
   cid: string;
   problemId: string;
+  total: number;
+  index: number;
 }
 
 export default function UserContestSubmitListItem({
+  personalUserContestSubmitInfo,
   cid,
   problemId,
+  total,
+  index,
 }: ContestSubmitListItemProps) {
   const router = useRouter();
 
@@ -17,7 +26,7 @@ export default function UserContestSubmitListItem({
       className="border-b dark:border-gray-700 text-xs text-center cursor-pointer hover:bg-gray-50 focus:bg-gray-50"
       onClick={(e) => {
         router.push(
-          `/contests/${cid}/problems/${problemId}/submits/${'65445155c4fc3d9d4396ae0e'}`,
+          `/contests/${cid}/problems/${problemId}/submits/${personalUserContestSubmitInfo._id}`,
         );
       }}
     >
@@ -25,19 +34,35 @@ export default function UserContestSubmitListItem({
         scope="row"
         className="px-4 py-3 font-medium text-gray-900 whitespace-nowrap dark:text-white"
       >
-        1
+        {total - index}
       </th>
-      <td className="">A+B</td>
-      <td className="text-[#0076C0] font-semibold">정답</td>
+      <td className="">{personalUserContestSubmitInfo.problem.title}</td>
+      <td
+        className={`${
+          personalUserContestSubmitInfo.result?.type === 'done'
+            ? 'text-[#0076C0]'
+            : 'text-red-500'
+        } font-semibold`}
+      >
+        {getCodeSubmitResultTypeDescription(
+          personalUserContestSubmitInfo.result?.type,
+        )}
+      </td>
       <td>
-        <span>1527 </span>
-        <span className="ml-[-1px] text-red-500">KB</span>
+        <span>
+          {(personalUserContestSubmitInfo.result.memory / 1048576).toFixed(2)}{' '}
+        </span>
+        <span className="ml-[-1px] text-red-500">MB</span>
       </td>
       <td className="">
-        <span>64 </span> <span className="ml-[-1px] text-red-500">ms</span>
+        <span>{personalUserContestSubmitInfo.result.time} </span>{' '}
+        <span className="ml-[-1px] text-red-500">ms</span>
       </td>
-      <td className="">C++17</td>
-      <td className="">2023.09.26 07:00:00</td>
+      <td className="">{personalUserContestSubmitInfo.language}</td>
+      <td className="">
+        {' '}
+        {formatDateToYYMMDDHHMM(personalUserContestSubmitInfo.createdAt)}
+      </td>
     </tr>
   );
 }

--- a/app/contests/[cid]/problems/components/ContestProblemList.tsx
+++ b/app/contests/[cid]/problems/components/ContestProblemList.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
 import NoneContestProblemListItem from './NoneContestProblemListItem';
 import {
   DragDropContext,
@@ -9,7 +8,6 @@ import {
   Droppable,
 } from 'react-beautiful-dnd';
 import { useRouter } from 'next/navigation';
-import Loading from '@/app/loading';
 import { ProblemInfo } from '@/app/types/problem';
 
 interface ContestProblemListProps {

--- a/app/contests/[cid]/problems/page.tsx
+++ b/app/contests/[cid]/problems/page.tsx
@@ -133,7 +133,6 @@ export default function ContestProblems(props: DefaultProps) {
   const updateUserInfo = userInfoStore((state: any) => state.updateUserInfo);
 
   const [isLoading, setIsLoading] = useState(true);
-  const [title, setTitle] = useState('');
   const [problemsInfo, setProblemsInfo] = useState<ProblemInfo[]>([]);
 
   const timeUntilStart = useCountdownTimer(
@@ -155,7 +154,6 @@ export default function ContestProblems(props: DefaultProps) {
 
   useEffect(() => {
     if (contestProblemsInfo) {
-      setTitle(contestProblemsInfo.title);
       setProblemsInfo(contestProblemsInfo.problems);
     }
   }, [contestProblemsInfo]);
@@ -169,7 +167,7 @@ export default function ContestProblems(props: DefaultProps) {
           (contestant_id) => contestant_id === userInfo._id,
         );
 
-        if (isContestant) {
+        if (isContestant && currentTime < contestEndTime) {
           setIsLoading(false);
           const contestPasswordCookie = getCookie(cid);
           if (contestPasswordCookie) {
@@ -306,7 +304,7 @@ export default function ContestProblems(props: DefaultProps) {
                 href={`/contests/${cid}`}
                 className="mt-1 ml-1 text-xl font-medium cursor-pointer hover:underline hover:text-[#0038a8] focus:underline focus:text-[#0038a8] text-[#1048b8]"
               >
-                (대회: {title})
+                (대회: {contestProblemsInfo.title})
               </Link>
             </div>
           </p>

--- a/app/contests/[cid]/problems/register/page.tsx
+++ b/app/contests/[cid]/problems/register/page.tsx
@@ -363,10 +363,8 @@ export default function RegisterContestProblem(props: DefaultProps) {
               guideMsg="문제 파일(PDF)을 이곳에 업로드해 주세요"
               setIsFileUploaded={setIsPdfFileUploadingValidFail}
               isFileUploaded={isPdfFileUploadingValidFail}
-              initPdfUrl={''}
-              initInAndOutFiles={[]}
-              setUploadedPdfFileUrl={setUploadedPdfFileUrl}
-              setIoSetData={setIoSetData}
+              initUrl={''}
+              setUploadedFileUrl={setUploadedPdfFileUrl}
             />
           </div>
 
@@ -397,9 +395,7 @@ export default function RegisterContestProblem(props: DefaultProps) {
                 guideMsg="입/출력 파일(in, out)들을 이곳에 업로드해 주세요"
                 setIsFileUploaded={setIsInAndOutFileUploadingValidFail}
                 isFileUploaded={isInAndOutFileUploadingValidFail}
-                initPdfUrl={''}
                 initInAndOutFiles={[]}
-                setUploadedPdfFileUrl={setUploadedPdfFileUrl}
                 setIoSetData={setIoSetData}
               />
             </div>

--- a/app/contests/[cid]/submits/[submitId]/page.tsx
+++ b/app/contests/[cid]/submits/[submitId]/page.tsx
@@ -161,7 +161,7 @@ ${submitInfo.code}`}
                     <span>
                       {(submitInfo.result.memory / 1048576).toFixed(2)}{' '}
                     </span>
-                    <span className="ml-[-1px] text-red-500">KB</span>
+                    <span className="ml-[-1px] text-red-500">MB</span>
                   </td>
                   <td className="">
                     <span>{submitInfo.result.time} </span>{' '}

--- a/app/exams/[eid]/problems/[problemId]/edit/page.tsx
+++ b/app/exams/[eid]/problems/[problemId]/edit/page.tsx
@@ -268,10 +268,8 @@ export default function EditExamProblem(props: DefaultProps) {
               guideMsg="문제 파일(PDF)을 이곳에 업로드해 주세요"
               setIsFileUploaded={setIsProblemFileUploadingValidFail}
               isFileUploaded={isProblemFileUploadingValidFail}
-              initPdfUrl={problemInfo.problemPdfFileUrl}
-              initInAndOutFiles={[]}
-              setUploadedPdfFileUrl={setUploadedPdfFileUrl}
-              setIoSetData={setIoSetData}
+              initUrl={problemInfo.problemPdfFileUrl}
+              setUploadedFileUrl={setUploadedPdfFileUrl}
             />
           </div>
 
@@ -302,9 +300,7 @@ export default function EditExamProblem(props: DefaultProps) {
                 guideMsg="입/출력 파일(in, out)들을 이곳에 업로드해 주세요"
                 setIsFileUploaded={setIsInAndOutFileUploadingValidFail}
                 isFileUploaded={isInAndOutFileUploadingValidFail}
-                initPdfUrl={''}
                 initInAndOutFiles={ioSetData}
-                setUploadedPdfFileUrl={setUploadedPdfFileUrl}
                 setIoSetData={setIoSetData}
               />
             </div>

--- a/app/exams/[eid]/problems/[problemId]/submit/page.tsx
+++ b/app/exams/[eid]/problems/[problemId]/submit/page.tsx
@@ -19,9 +19,6 @@ export default function SubmitExamProblemCode(props: DefaultProps) {
   const [selectedSubmitLanguage, setSelectedSubmitLanguage] =
     useState('언어 선택 *');
   const [uploadedCodeFileUrl, setUploadedCodeFileUrl] = useState('');
-  const [uploadedProblemPdfFileUrl, setUploadedProblemPdfFileUrl] =
-    useState('');
-  const [ioSetData, setIoSetData] = useState<IoSetItem[]>([]);
 
   const [
     isSelectedSubmitLanguageValidFail,
@@ -162,14 +159,13 @@ export default function SubmitExamProblemCode(props: DefaultProps) {
 
           <div className="flex flex-col gap-1 mt-5">
             <p className="text-lg">소스 코드 파일</p>
-
             <MyDropzone
               type="code"
               guideMsg="코드 파일을 이곳에 업로드해 주세요"
               setIsFileUploaded={setIsCodeFileUploadingValidFail}
               isFileUploaded={isCodeFileUploadingValidFail}
-              initPdfUrl={''}
-              initInAndOutFiles={[]}
+              initUrl={''}
+              setUploadedFileUrl={setUploadedCodeFileUrl}
             />
           </div>
         </div>

--- a/app/exams/[eid]/problems/[problemId]/submits/[submitId]/page.tsx
+++ b/app/exams/[eid]/problems/[problemId]/submits/[submitId]/page.tsx
@@ -123,7 +123,7 @@ int main(int argc, const char* argv[]) {
                   <td className="text-[#0076C0] font-semibold">정답</td>
                   <td>
                     <span>1527 </span>
-                    <span className="ml-[-1px] text-red-500">KB</span>
+                    <span className="ml-[-1px] text-red-500">MB</span>
                   </td>
                   <td className="">
                     <span>64 </span>{' '}

--- a/app/exams/[eid]/problems/[problemId]/submits/components/UserExamSubmitListItem.tsx
+++ b/app/exams/[eid]/problems/[problemId]/submits/components/UserExamSubmitListItem.tsx
@@ -31,7 +31,7 @@ export default function UserExamSubmitListItem({
       <td className="text-[#0076C0] font-semibold">정답</td>
       <td>
         <span>1527 </span>
-        <span className="ml-[-1px] text-red-500">KB</span>
+        <span className="ml-[-1px] text-red-500">MB</span>
       </td>
       <td className="">
         <span>64 </span> <span className="ml-[-1px] text-red-500">ms</span>

--- a/app/exams/[eid]/problems/register/page.tsx
+++ b/app/exams/[eid]/problems/register/page.tsx
@@ -246,10 +246,8 @@ export default function RegisterExamProblem(props: DefaultProps) {
               guideMsg="문제 파일(PDF)을 이곳에 업로드해 주세요"
               setIsFileUploaded={setIsProblemFileUploadingValidFail}
               isFileUploaded={isProblemFileUploadingValidFail}
-              initPdfUrl={''}
-              initInAndOutFiles={[]}
-              setUploadedPdfFileUrl={setUploadedPdfFileUrl}
-              setIoSetData={setIoSetData}
+              initUrl={''}
+              setUploadedFileUrl={setUploadedPdfFileUrl}
             />
           </div>
 
@@ -280,9 +278,7 @@ export default function RegisterExamProblem(props: DefaultProps) {
                 guideMsg="입/출력 파일(in, out)들을 이곳에 업로드해 주세요"
                 setIsFileUploaded={setIsInAndOutFileUploadingValidFail}
                 isFileUploaded={isInAndOutFileUploadingValidFail}
-                initPdfUrl={''}
                 initInAndOutFiles={[]}
-                setUploadedPdfFileUrl={setUploadedPdfFileUrl}
                 setIoSetData={setIoSetData}
               />
             </div>

--- a/app/exams/[eid]/submits/[submitId]/page.tsx
+++ b/app/exams/[eid]/submits/[submitId]/page.tsx
@@ -162,7 +162,7 @@ ${submitInfo.code}`}
                     <span>
                       {(submitInfo.result.memory / 1048576).toFixed(2)}{' '}
                     </span>
-                    <span className="ml-[-1px] text-red-500">KB</span>
+                    <span className="ml-[-1px] text-red-500">MB</span>
                   </td>
                   <td className="">
                     <span>{submitInfo.result.time} </span>{' '}

--- a/app/globals.css
+++ b/app/globals.css
@@ -132,6 +132,10 @@
 }
 
 /* uiw markdown(Preview) CSS */
+.code-highlight {
+  padding-bottom: 1.75rem !important;
+}
+
 .markdown-preview {
   letter-spacing: 0.04rem;
 }

--- a/app/practices/[pid]/edit/page.tsx
+++ b/app/practices/[pid]/edit/page.tsx
@@ -332,10 +332,8 @@ export default function EditPractice(props: DefaultProps) {
                 guideMsg="문제 파일(PDF)을 이곳에 업로드해 주세요"
                 setIsFileUploaded={setIsPdfFileUploadingValidFail}
                 isFileUploaded={isPdfFileUploadingValidFail}
-                initPdfUrl={uploadedProblemPdfFileUrl}
-                initInAndOutFiles={[]}
-                setUploadedPdfFileUrl={setUploadedProblemPdfFileUrl}
-                setIoSetData={setIoSetData}
+                initUrl={uploadedProblemPdfFileUrl}
+                setUploadedFileUrl={setUploadedProblemPdfFileUrl}
               />
             )}
           </div>
@@ -368,9 +366,7 @@ export default function EditPractice(props: DefaultProps) {
                   guideMsg="입/출력 파일(in, out)들을 이곳에 업로드해 주세요"
                   setIsFileUploaded={setIsInAndOutFileUploadingValidFail}
                   isFileUploaded={isInAndOutFileUploadingValidFail}
-                  initPdfUrl={''}
                   initInAndOutFiles={ioSetData}
-                  setUploadedPdfFileUrl={setUploadedProblemPdfFileUrl}
                   setIoSetData={setIoSetData}
                 />
               )}

--- a/app/practices/[pid]/submit/page.tsx
+++ b/app/practices/[pid]/submit/page.tsx
@@ -17,7 +17,7 @@ interface DefaultProps {
 export default function SubmitPracticeProblemCode(props: DefaultProps) {
   const [selectedSubmitLanguage, setSelectedSubmitLanguage] =
     useState('언어 선택 *');
-  const [uploadedCodeFileUrl, setUploadedPdfFileUrl] = useState('');
+  const [uploadedCodeFileUrl, setUploadedCodeFileUrl] = useState('');
 
   const [
     isSelectedSubmitLanguageValidFail,
@@ -151,8 +151,8 @@ export default function SubmitPracticeProblemCode(props: DefaultProps) {
               guideMsg="코드 파일을 이곳에 업로드해 주세요"
               setIsFileUploaded={setIsCodeFileUploadingValidFail}
               isFileUploaded={isCodeFileUploadingValidFail}
-              initPdfUrl={''}
-              initInAndOutFiles={[]}
+              initUrl={''}
+              setUploadedFileUrl={setUploadedCodeFileUrl}
             />
           </div>
         </div>

--- a/app/practices/[pid]/submits/[submitId]/page.tsx
+++ b/app/practices/[pid]/submits/[submitId]/page.tsx
@@ -115,7 +115,7 @@ int main(int argc, const char* argv[]) {
                   <td className="text-[#0076C0] font-semibold">정답</td>
                   <td>
                     <span>1527 </span>
-                    <span className="ml-[-1px] text-red-500">KB</span>
+                    <span className="ml-[-1px] text-red-500">MB</span>
                   </td>
                   <td className="">
                     <span>64 </span>{' '}

--- a/app/practices/[pid]/submits/components/UserPracticeSubmitListItem.tsx
+++ b/app/practices/[pid]/submits/components/UserPracticeSubmitListItem.tsx
@@ -28,7 +28,7 @@ export default function UserPracticeSubmitListItem({
       <td className="text-[#0076C0] font-semibold">정답</td>
       <td>
         <span>1527 </span>
-        <span className="ml-[-1px] text-red-500">KB</span>
+        <span className="ml-[-1px] text-red-500">MB</span>
       </td>
       <td className="">
         <span>64 </span> <span className="ml-[-1px] text-red-500">ms</span>

--- a/app/practices/register/page.tsx
+++ b/app/practices/register/page.tsx
@@ -279,10 +279,8 @@ export default function RegisterPractice() {
               guideMsg="문제 파일(PDF)을 이곳에 업로드해 주세요"
               setIsFileUploaded={setIsPdfFileUploadingValidFail}
               isFileUploaded={isPdfFileUploadingValidFail}
-              initPdfUrl={''}
-              initInAndOutFiles={[]}
-              setUploadedPdfFileUrl={setUploadedPdfFileUrl}
-              setIoSetData={setIoSetData}
+              initUrl={''}
+              setUploadedFileUrl={setUploadedPdfFileUrl}
             />
           </div>
 
@@ -313,9 +311,7 @@ export default function RegisterPractice() {
                 guideMsg="입/출력 파일(in, out)들을 이곳에 업로드해 주세요"
                 setIsFileUploaded={setIsInAndOutFileUploadingValidFail}
                 isFileUploaded={isInAndOutFileUploadingValidFail}
-                initPdfUrl={''}
                 initInAndOutFiles={[]}
-                setUploadedPdfFileUrl={setUploadedPdfFileUrl}
                 setIoSetData={setIoSetData}
               />
             </div>

--- a/app/types/problem.ts
+++ b/app/types/problem.ts
@@ -1,5 +1,25 @@
 export interface ProblemInfo {
-  parentId: null | string;
+  parentId: {
+    isPassword: boolean;
+    problems: string[];
+    applyingPeriod: null;
+    contestants: string[];
+    students: string[];
+    _id: string;
+    title: string;
+    content: string;
+    testPeriod: {
+      start: string;
+      end: string;
+    };
+    writer: {
+      _id: string;
+      name: string;
+    };
+    createdAt: string;
+    updatedAt: string;
+    __v: number;
+  };
   parentType: string;
   published: null | boolean;
   score: number;
@@ -12,8 +32,20 @@ export interface ProblemInfo {
     maxMemory: number;
   };
   writer: {
+    center: null;
+    permissions: string[];
     _id: string;
+    no: string;
     name: string;
+    email: string;
+    phone: string;
+    department: string;
+    university: string;
+    position: null;
+    role: string;
+    joinedAt: string;
+    updatedAt: string;
+    __v: number;
   };
   createdAt: string; // Date 타입으로 변환할 수도 있습니다.
   updatedAt: string; // Date 타입으로 변환할 수도 있습니다.

--- a/app/types/submit.ts
+++ b/app/types/submit.ts
@@ -71,3 +71,11 @@ export interface SubmitInfo {
   __v: number;
   code: string;
 }
+
+export interface SubmitCode {
+  parentId: string;
+  parentType: string;
+  problem: string;
+  source: string;
+  language: string;
+}


### PR DESCRIPTION
## 👀 이슈

resolve #234 

## 📌 개요

대회에 등록된 문제에 대하여 참가자가 코드를 제출하고 제출한 코드 목록 및
세부 정보를 확인하는 페이지 컴포넌트 내 실제 DB 정보를 표시할 수 있도록
하고자 관련 기능을 추가하였습니다.

## 👩‍💻 작업 사항

- 대회 문제 코드 제출 기능 추가
- 대회 문제 코드 제출 목록 페이지 컴포넌트 내 정보 표시 기능 추가
- 대회 문제 코드 제출 정보 상세 페이지 컴포넌트 내 정보 표시 기능 추가

## ✅ 참고 사항

- 기능 추가 후 **대회 문제 코드 제출/제출 목록/ 제출 정보 상세** 페이지 화면

https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/7ef62252-600f-4d51-8944-ffe191801b65