### PR TITLE
[feat]: 시험 문제 게시글 페이지 정보 표시 기능 추가 (#238)

### DIFF
--- a/app/contests/[cid]/problems/[problemId]/page.tsx
+++ b/app/contests/[cid]/problems/[problemId]/page.tsx
@@ -14,7 +14,7 @@ import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useState } from 'react';
 
 // 대회 문제 열람 비밀번호 확인 API
-const confirmContestConfirm = ({
+const confirmContestPassword = ({
   cid,
   password,
 }: {
@@ -56,8 +56,8 @@ export default function ContestProblem(props: DefaultProps) {
   const cid = props.params.cid;
   const problemId = props.params.problemId;
 
-  const confirmContestConfirmMutation = useMutation({
-    mutationFn: confirmContestConfirm,
+  const confirmContestPasswordMutation = useMutation({
+    mutationFn: confirmContestPassword,
     onError: (error: AxiosError) => {
       const resData: any = error.response?.data;
       switch (resData.status) {
@@ -191,7 +191,7 @@ export default function ContestProblem(props: DefaultProps) {
           const contestPasswordCookie = getCookie(cid);
           if (contestPasswordCookie) {
             setPassword(contestPasswordCookie);
-            confirmContestConfirmMutation.mutate({
+            confirmContestPasswordMutation.mutate({
               cid,
               password: contestPasswordCookie,
             });
@@ -201,7 +201,7 @@ export default function ContestProblem(props: DefaultProps) {
           const inputPassword = prompt('비밀번호를 입력해 주세요');
           if (inputPassword !== null && inputPassword.trim() !== '') {
             setPassword(inputPassword);
-            confirmContestConfirmMutation.mutate({
+            confirmContestPasswordMutation.mutate({
               cid,
               password: inputPassword,
             });

--- a/app/contests/[cid]/problems/[problemId]/submit/page.tsx
+++ b/app/contests/[cid]/problems/[problemId]/submit/page.tsx
@@ -18,7 +18,7 @@ import { UserInfo } from '@/app/types/user';
 import Loading from '@/app/loading';
 
 // 대회 문제 열람 비밀번호 확인 API
-const confirmContestConfirm = ({
+const confirmContestPassword = ({
   cid,
   password,
 }: {
@@ -63,8 +63,8 @@ export default function SubmitContestProblemCode(props: DefaultProps) {
   const cid = props.params.cid;
   const problemId = props.params.problemId;
 
-  const confirmContestConfirmMutation = useMutation({
-    mutationFn: confirmContestConfirm,
+  const confirmContestPasswordMutation = useMutation({
+    mutationFn: confirmContestPassword,
     onError: (error: AxiosError) => {
       const resData: any = error.response?.data;
       switch (resData.status) {
@@ -202,7 +202,7 @@ export default function SubmitContestProblemCode(props: DefaultProps) {
           const contestPasswordCookie = getCookie(cid);
           if (contestPasswordCookie) {
             setPassword(contestPasswordCookie);
-            confirmContestConfirmMutation.mutate({
+            confirmContestPasswordMutation.mutate({
               cid,
               password: contestPasswordCookie,
             });
@@ -212,7 +212,7 @@ export default function SubmitContestProblemCode(props: DefaultProps) {
           const inputPassword = prompt('비밀번호를 입력해 주세요');
           if (inputPassword !== null && inputPassword.trim() !== '') {
             setPassword(inputPassword);
-            confirmContestConfirmMutation.mutate({
+            confirmContestPasswordMutation.mutate({
               cid,
               password: inputPassword,
             });

--- a/app/contests/[cid]/problems/[problemId]/submits/[submitId]/page.tsx
+++ b/app/contests/[cid]/problems/[problemId]/submits/[submitId]/page.tsx
@@ -17,7 +17,7 @@ import { useRouter } from 'next/navigation';
 import React, { useEffect, useState } from 'react';
 
 // 대회 문제 열람 비밀번호 확인 API
-const confirmContestConfirm = ({
+const confirmContestPassword = ({
   cid,
   password,
 }: {
@@ -55,8 +55,8 @@ export default function UserContestSubmit(props: DefaultProps) {
   const problemId = props.params.problemId;
   const submitId = props.params.submitId;
 
-  const confirmContestConfirmMutation = useMutation({
-    mutationFn: confirmContestConfirm,
+  const confirmContestPasswordMutation = useMutation({
+    mutationFn: confirmContestPassword,
     onError: (error: AxiosError) => {
       const resData: any = error.response?.data;
       switch (resData.status) {
@@ -133,7 +133,7 @@ export default function UserContestSubmit(props: DefaultProps) {
           const contestPasswordCookie = getCookie(cid);
           if (contestPasswordCookie) {
             setPassword(contestPasswordCookie);
-            confirmContestConfirmMutation.mutate({
+            confirmContestPasswordMutation.mutate({
               cid,
               password: contestPasswordCookie,
             });
@@ -143,7 +143,7 @@ export default function UserContestSubmit(props: DefaultProps) {
           const inputPassword = prompt('비밀번호를 입력해 주세요');
           if (inputPassword !== null && inputPassword.trim() !== '') {
             setPassword(inputPassword);
-            confirmContestConfirmMutation.mutate({
+            confirmContestPasswordMutation.mutate({
               cid,
               password: inputPassword,
             });

--- a/app/contests/[cid]/problems/[problemId]/submits/page.tsx
+++ b/app/contests/[cid]/problems/[problemId]/submits/page.tsx
@@ -17,7 +17,7 @@ import { UserInfo } from '@/app/types/user';
 import { ProblemInfo } from '@/app/types/problem';
 
 // 대회 문제 열람 비밀번호 확인 API
-const confirmContestConfirm = ({
+const confirmContestPassword = ({
   cid,
   password,
 }: {
@@ -48,8 +48,8 @@ export default function UserContestSubmits(props: DefaultProps) {
   const cid = props.params.cid;
   const problemId = props.params.problemId;
 
-  const confirmContestConfirmMutation = useMutation({
-    mutationFn: confirmContestConfirm,
+  const confirmContestPasswordMutation = useMutation({
+    mutationFn: confirmContestPassword,
     onError: (error: AxiosError) => {
       const resData: any = error.response?.data;
       switch (resData.status) {
@@ -121,7 +121,7 @@ export default function UserContestSubmits(props: DefaultProps) {
           const contestPasswordCookie = getCookie(cid);
           if (contestPasswordCookie) {
             setPassword(contestPasswordCookie);
-            confirmContestConfirmMutation.mutate({
+            confirmContestPasswordMutation.mutate({
               cid,
               password: contestPasswordCookie,
             });
@@ -131,7 +131,7 @@ export default function UserContestSubmits(props: DefaultProps) {
           const inputPassword = prompt('비밀번호를 입력해 주세요');
           if (inputPassword !== null && inputPassword.trim() !== '') {
             setPassword(inputPassword);
-            confirmContestConfirmMutation.mutate({
+            confirmContestPasswordMutation.mutate({
               cid,
               password: inputPassword,
             });

--- a/app/contests/[cid]/problems/page.tsx
+++ b/app/contests/[cid]/problems/page.tsx
@@ -20,7 +20,7 @@ import { AxiosError } from 'axios';
 import { deleteCookie, getCookie, setCookie } from 'cookies-next';
 
 // 대회 문제 열람 비밀번호 확인 API
-const confirmContestConfirm = ({
+const confirmContestPassword = ({
   cid,
   password,
 }: {
@@ -66,8 +66,8 @@ interface DefaultProps {
 export default function ContestProblems(props: DefaultProps) {
   const cid = props.params.cid;
 
-  const confirmContestConfirmMutation = useMutation({
-    mutationFn: confirmContestConfirm,
+  const confirmContestPasswordMutation = useMutation({
+    mutationFn: confirmContestPassword,
     onError: (error: AxiosError) => {
       const resData: any = error.response?.data;
       switch (resData.status) {
@@ -176,7 +176,7 @@ export default function ContestProblems(props: DefaultProps) {
           const contestPasswordCookie = getCookie(cid);
           if (contestPasswordCookie) {
             setPassword(contestPasswordCookie);
-            confirmContestConfirmMutation.mutate({
+            confirmContestPasswordMutation.mutate({
               cid,
               password: contestPasswordCookie,
             });
@@ -186,7 +186,7 @@ export default function ContestProblems(props: DefaultProps) {
           const inputPassword = prompt('비밀번호를 입력해 주세요');
           if (inputPassword !== null && inputPassword.trim() !== '') {
             setPassword(inputPassword);
-            confirmContestConfirmMutation.mutate({
+            confirmContestPasswordMutation.mutate({
               cid,
               password: inputPassword,
             });

--- a/app/exams/[eid]/problems/[problemId]/page.tsx
+++ b/app/exams/[eid]/problems/[problemId]/page.tsx
@@ -1,9 +1,30 @@
 'use client';
 
 import Loading from '@/app/loading';
+import { userInfoStore } from '@/app/store/UserInfo';
+import { ProblemInfo } from '@/app/types/problem';
+import { UserInfo } from '@/app/types/user';
+import axiosInstance from '@/app/utils/axiosInstance';
+import { fetchCurrentUserInfo } from '@/app/utils/fetchCurrentUserInfo';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
+
+// 문제 정보 조회 API
+const fetchExamProblemDetailInfo = ({ queryKey }: any) => {
+  const problemId = queryKey[1];
+  return axiosInstance.get(
+    `${process.env.NEXT_PUBLIC_API_VERSION}/problem/${problemId}`,
+  );
+};
+
+// 시험 문제 삭제 API
+const deleteExamProblem = (problemId: string) => {
+  return axiosInstance.delete(
+    `${process.env.NEXT_PUBLIC_API_VERSION}/problem/${problemId}`,
+  );
+};
 
 interface DefaultProps {
   params: {
@@ -17,10 +38,44 @@ const PDFViewer = dynamic(() => import('@/app/components/PDFViewer'), {
 });
 
 export default function ExamProblem(props: DefaultProps) {
-  const [isLoading, setIsLoading] = useState(true);
-
   const eid = props.params.eid;
   const problemId = props.params.problemId;
+
+  const { isPending, isError, data, error } = useQuery({
+    queryKey: ['examProblemDetailInfo', problemId],
+    queryFn: fetchExamProblemDetailInfo,
+    retry: 0,
+  });
+
+  const deleteExamMutation = useMutation({
+    mutationFn: deleteExamProblem,
+    onSuccess: (data) => {
+      const resData = data.data;
+      const httpStatusCode = resData.status;
+
+      switch (httpStatusCode) {
+        case 200:
+          alert('문제가 삭제되었습니다.');
+          router.push(`/exams/${eid}/problems`);
+          break;
+        default:
+          alert('정의되지 않은 http status code입니다');
+      }
+    },
+  });
+
+  const resData = data?.data.data;
+  const examProblemInfo: ProblemInfo = resData;
+
+  const userInfo = userInfoStore((state: any) => state.userInfo);
+  const updateUserInfo = userInfoStore((state: any) => state.updateUserInfo);
+
+  const [isLoading, setIsLoading] = useState(true);
+  const [isEnrollExam, setIsEnrollExam] = useState(false);
+
+  const currentTime = new Date();
+  const examStartTime = new Date(examProblemInfo?.parentId.testPeriod.start);
+  const examEndTime = new Date(examProblemInfo?.parentId.testPeriod.end);
 
   const router = useRouter();
 
@@ -28,11 +83,11 @@ export default function ExamProblem(props: DefaultProps) {
     router.push(`/exams/${eid}/problems`);
   };
 
-  const handleGoToUserContestSubmits = () => {
+  const handleGoToUserExamSubmits = () => {
     router.push(`/exams/${eid}/problems/${problemId}/submits`);
   };
 
-  const handleGoToSubmitContestProblemCode = () => {
+  const handleGoToSubmitExamProblemCode = () => {
     router.push(`/exams/${eid}/problems/${problemId}/submit`);
   };
 
@@ -43,13 +98,52 @@ export default function ExamProblem(props: DefaultProps) {
   const handleDeleteProblem = () => {
     const userResponse = confirm('문제를 삭제하시겠습니까?');
     if (!userResponse) return;
-    alert('문제를 삭제하였습니다.');
-    router.push(`/exams/${eid}/problems`);
+
+    deleteExamMutation.mutate(problemId);
   };
 
+  // 시험 신청 여부 확인
+  const isUserContestant = useCallback(() => {
+    return examProblemInfo.parentId.students.some(
+      (student_id) => student_id === userInfo._id,
+    );
+  }, [examProblemInfo, userInfo]);
+
   useEffect(() => {
-    setIsLoading(false);
-  }, []);
+    if (examProblemInfo && examProblemInfo.parentId.students && userInfo)
+      setIsEnrollExam(isUserContestant());
+  }, [examProblemInfo, userInfo, isUserContestant]);
+
+  console.log(isEnrollExam);
+
+  useEffect(() => {
+    // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인, 그리고 게시글 작성자인지 확인
+    fetchCurrentUserInfo(updateUserInfo).then((userInfo: UserInfo) => {
+      if (examProblemInfo) {
+        const isWriter = examProblemInfo.writer._id === userInfo._id;
+        const isContestant = examProblemInfo.parentId.students.some(
+          (student_id) => student_id === userInfo._id,
+        );
+
+        if (
+          isContestant &&
+          examStartTime <= currentTime &&
+          currentTime < examEndTime
+        ) {
+          setIsLoading(false);
+          return;
+        }
+
+        if (isWriter) {
+          setIsLoading(false);
+          return;
+        }
+
+        alert('접근 권한이 없습니다.');
+        router.back();
+      }
+    });
+  }, [updateUserInfo, examProblemInfo, eid, router]);
 
   if (isLoading) return <Loading />;
 
@@ -57,14 +151,16 @@ export default function ExamProblem(props: DefaultProps) {
     <div className="mt-6 mb-24 px-5 2lg:px-0 overflow-x-auto">
       <div className="flex flex-col w-[60rem] mx-auto">
         <div className="flex flex-col gap-8">
-          <p className="text-2xl font-bold tracking-tight">A+B</p>
+          <p className="text-2xl font-bold tracking-tight">
+            {examProblemInfo.title}
+          </p>
           <div className="flex justify-between pb-3 border-b border-gray-300">
             <div className="flex gap-3">
               <span className="font-semibold">
                 시간 제한:
                 <span className="font-mono font-light">
                   {' '}
-                  <span>1</span>초
+                  <span>{examProblemInfo.options.maxRealTime / 1000}</span>초
                 </span>
               </span>
               <span className='relative bottom-[0.055rem] font-thin before:content-["|"]' />
@@ -72,19 +168,25 @@ export default function ExamProblem(props: DefaultProps) {
                 메모리 제한:
                 <span className="font-mono font-light">
                   {' '}
-                  <span className="mr-1">5</span>MB
+                  <span className="mr-1">
+                    {examProblemInfo.options.maxMemory}
+                  </span>
+                  MB
                 </span>
               </span>
             </div>
             <div className="flex gap-3">
               <span className="font-semibold">
-                시험명: <span className="font-light">코딩테스트 1차</span>
+                시험명:{' '}
+                <span className="font-light">
+                  {examProblemInfo.parentId.title}
+                </span>
               </span>
               <span className='relative bottom-[0.055rem] font-thin before:content-["|"]' />
               <span className="font-semibold">
                 수업명:{' '}
                 <span className="font-light">
-                  2023-01-자료구조(소프트웨어학부 01반)
+                  {examProblemInfo.parentId.course}
                 </span>
               </span>
             </div>
@@ -107,61 +209,71 @@ export default function ExamProblem(props: DefaultProps) {
             </svg>
             문제 목록
           </button>
-          <button
-            onClick={handleGoToUserContestSubmits}
-            className="flex justify-center items-center gap-[0.375rem] text-sm text-[#f9fafb] bg-[#6860ff] px-2 py-[0.45rem] rounded-[6px] font-medium focus:bg-[#5951f0] hover:bg-[#5951f0]"
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              height="20"
-              viewBox="0 -960 960 960"
-              width="20"
-              fill="white"
-            >
-              <path d="M320-242 80-482l242-242 43 43-199 199 197 197-43 43Zm318 2-43-43 199-199-197-197 43-43 240 240-242 242Z" />
-            </svg>
-            내 제출 현황
-          </button>
-          <button
-            onClick={handleGoToSubmitContestProblemCode}
-            className="flex justify-center items-center gap-[0.375rem] text-sm text-[#f9fafb] bg-[#3a8af9] px-3 py-[0.45rem] rounded-[6px] font-medium focus:bg-[#1c6cdb] hover:bg-[#1c6cdb]"
-          >
-            제출하기
-          </button>
-          <button
-            onClick={handleEditProblem}
-            className="flex justify-center items-center gap-[0.375rem] text-sm text-[#f9fafb] bg-[#eba338] px-2 py-[0.45rem] rounded-[6px] font-medium focus:bg-[#dc9429] hover:bg-[#dc9429]"
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              height="20"
-              viewBox="0 -960 960 960"
-              width="20"
-              fill="white"
-            >
-              <path d="M794-666 666-794l42-42q17-17 42.5-16.5T793-835l43 43q17 17 17 42t-17 42l-42 42Zm-42 42L248-120H120v-128l504-504 128 128Z" />
-            </svg>
-            문제 수정
-          </button>
-          <button
-            onClick={handleDeleteProblem}
-            className="flex justify-center items-center gap-[0.375rem] text-sm text-[#f9fafb] bg-red-500 px-2 py-[0.45rem] rounded-[6px] font-medium focus:bg-[#e14343] hover:bg-[#e14343]"
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              height="20"
-              viewBox="0 -960 960 960"
-              width="20"
-              fill="white"
-            >
-              <path d="m361-299 119-121 120 121 47-48-119-121 119-121-47-48-120 121-119-121-48 48 120 121-120 121 48 48ZM261-120q-24 0-42-18t-18-42v-570h-41v-60h188v-30h264v30h188v60h-41v570q0 24-18 42t-42 18H261Z" />
-            </svg>
-            문제 삭제
-          </button>
+          {isEnrollExam && (
+            <>
+              <button
+                onClick={handleGoToUserExamSubmits}
+                className="flex justify-center items-center gap-[0.375rem] text-sm text-[#f9fafb] bg-[#6860ff] px-2 py-[0.45rem] rounded-[6px] font-medium focus:bg-[#5951f0] hover:bg-[#5951f0]"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  height="20"
+                  viewBox="0 -960 960 960"
+                  width="20"
+                  fill="white"
+                >
+                  <path d="M320-242 80-482l242-242 43 43-199 199 197 197-43 43Zm318 2-43-43 199-199-197-197 43-43 240 240-242 242Z" />
+                </svg>
+                내 제출 현황
+              </button>
+              <button
+                onClick={handleGoToSubmitExamProblemCode}
+                className="flex justify-center items-center gap-[0.375rem] text-sm text-[#f9fafb] bg-[#3a8af9] px-3 py-[0.45rem] rounded-[6px] font-medium focus:bg-[#1c6cdb] hover:bg-[#1c6cdb]"
+              >
+                제출하기
+              </button>
+            </>
+          )}
+
+          {currentTime < examEndTime &&
+            userInfo._id === examProblemInfo.writer._id && (
+              <>
+                <button
+                  onClick={handleEditProblem}
+                  className="flex justify-center items-center gap-[0.375rem] text-sm text-[#f9fafb] bg-[#eba338] px-2 py-[0.45rem] rounded-[6px] font-medium focus:bg-[#dc9429] hover:bg-[#dc9429]"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    height="20"
+                    viewBox="0 -960 960 960"
+                    width="20"
+                    fill="white"
+                  >
+                    <path d="M794-666 666-794l42-42q17-17 42.5-16.5T793-835l43 43q17 17 17 42t-17 42l-42 42Zm-42 42L248-120H120v-128l504-504 128 128Z" />
+                  </svg>
+                  문제 수정
+                </button>
+                <button
+                  onClick={handleDeleteProblem}
+                  className="flex justify-center items-center gap-[0.375rem] text-sm text-[#f9fafb] bg-red-500 px-2 py-[0.45rem] rounded-[6px] font-medium focus:bg-[#e14343] hover:bg-[#e14343]"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    height="20"
+                    viewBox="0 -960 960 960"
+                    width="20"
+                    fill="white"
+                  >
+                    <path d="m361-299 119-121 120 121 47-48-119-121 119-121-47-48-120 121-119-121-48 48 120 121-120 121 48 48ZM261-120q-24 0-42-18t-18-42v-570h-41v-60h188v-30h264v30h188v60h-41v570q0 24-18 42t-42 18H261Z" />
+                  </svg>
+                  문제 삭제
+                </button>
+              </>
+            )}
         </div>
 
         <div className="gap-5 border-b mt-8 mb-4 pb-5">
-          <PDFViewer pdfFileURL={'/pdfs/test.pdf'} />
+          <PDFViewer pdfFileURL={examProblemInfo.content} />
         </div>
       </div>
     </div>

--- a/app/types/problem.ts
+++ b/app/types/problem.ts
@@ -7,6 +7,7 @@ export interface ProblemInfo {
     students: string[];
     _id: string;
     title: string;
+    course?: string;
     content: string;
     testPeriod: {
       start: string;


### PR DESCRIPTION
## 👀 이슈

resolve #238 

## 📌 개요

시험에 등록된 문제 게시글 페이지 내 실제 정보가 표시되도록
해당 기능을 추가하였습니다.

## 👩‍💻 작업 사항

- 대회 문제 게시글 페이지 정보 표시 기능 추가

## ✅ 참고 사항

- 기능 추가 후 **시험 문제 게시글 페이지** 화면

https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/6135ff05-32a7-4b36-9f8e-2ffda688966c