### PR TITLE
[feat]: 시험 문제 코드 제출, 제출 목록 및 제출 정보 상세 페이지 내 정보 표시 기능 추가 (#242)

### DIFF
--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -16,10 +16,18 @@ const logout = () => {
 export default function Navbar() {
   const logoutMutation = useMutation({
     mutationFn: logout,
+    onSettled: () => {
+      localStorage.removeItem('access-token');
+      localStorage.removeItem('refresh-token');
+      localStorage.removeItem('activeAuthorization');
+      if (typeof window !== 'undefined') window.location.href = '/login';
+      removeUserInfo.mutate();
+    },
   });
 
   const userInfo = userInfoStore((state: any) => state.userInfo);
   const updateUserInfo = userInfoStore((state: any) => state.updateUserInfo);
+  const removeUserInfo = userInfoStore((state: any) => state.removeUserInfo);
 
   const [rightPos, setRightPos] = useState('-right-full');
 

--- a/app/contests/[cid]/problems/[problemId]/submits/components/UserContestSubmitList.tsx
+++ b/app/contests/[cid]/problems/[problemId]/submits/components/UserContestSubmitList.tsx
@@ -3,7 +3,6 @@
 import UserContestSubmitListItem from './UserContestSubmitListItem';
 import NoneUserContestSubmitListItem from './NoneUserContestSubmitListItem';
 import Loading from '@/app/loading';
-import { useRouter } from 'next/navigation';
 import axiosInstance from '@/app/utils/axiosInstance';
 import { ContestSubmitInfo } from '@/app/types/contest';
 import { useQuery } from '@tanstack/react-query';
@@ -30,8 +29,6 @@ export default function UserContestSubmitList({
     queryFn: fetchPersonalUserContestSubmitsInfo,
     retry: 0,
   });
-
-  const router = useRouter();
 
   const resData = data?.data.data;
   const personalUserContestSubmitsInfo: ContestSubmitInfo[] =

--- a/app/contests/[cid]/problems/[problemId]/submits/components/UserContestSubmitListItem.tsx
+++ b/app/contests/[cid]/problems/[problemId]/submits/components/UserContestSubmitListItem.tsx
@@ -60,7 +60,6 @@ export default function UserContestSubmitListItem({
       </td>
       <td className="">{personalUserContestSubmitInfo.language}</td>
       <td className="">
-        {' '}
         {formatDateToYYMMDDHHMM(personalUserContestSubmitInfo.createdAt)}
       </td>
     </tr>

--- a/app/contests/[cid]/problems/[problemId]/submits/page.tsx
+++ b/app/contests/[cid]/problems/[problemId]/submits/page.tsx
@@ -100,6 +100,9 @@ export default function UserContestSubmits(props: DefaultProps) {
   const [isLoading, setIsLoading] = useState(true);
 
   const currentTime = new Date();
+  const contestStartTime = new Date(
+    contestProblemInfo?.parentId.testPeriod.start,
+  );
   const contestEndTime = new Date(contestProblemInfo?.parentId.testPeriod.end);
 
   const router = useRouter();
@@ -114,7 +117,7 @@ export default function UserContestSubmits(props: DefaultProps) {
 
         if (
           isContestant &&
-          contestEndTime <= currentTime &&
+          contestStartTime <= currentTime &&
           currentTime < contestEndTime
         ) {
           setIsLoading(false);

--- a/app/exams/[eid]/problems/[problemId]/edit/page.tsx
+++ b/app/exams/[eid]/problems/[problemId]/edit/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import MyDropzone from '@/app/components/MyDropzone';
-import { OPERATOR_ROLES } from '@/app/constants/role';
 import Loading from '@/app/loading';
 import { userInfoStore } from '@/app/store/UserInfo';
 import {
@@ -101,7 +100,7 @@ export default function EditExamProblem(props: DefaultProps) {
   const maxMemCapRef = useRef<HTMLInputElement>(null);
 
   const currentTime = new Date();
-  const contestEndTime = new Date(examProblemInfo?.parentId.testPeriod.end);
+  const examEndTime = new Date(examProblemInfo?.parentId.testPeriod.end);
 
   const router = useRouter();
 
@@ -203,7 +202,7 @@ export default function EditExamProblem(props: DefaultProps) {
       if (examProblemInfo) {
         const isWriter = examProblemInfo.writer._id === userInfo._id;
 
-        if (isWriter && currentTime < contestEndTime) {
+        if (isWriter && currentTime < examEndTime) {
           setIsLoading(false);
           return;
         }

--- a/app/exams/[eid]/problems/[problemId]/submit/page.tsx
+++ b/app/exams/[eid]/problems/[problemId]/submit/page.tsx
@@ -176,7 +176,7 @@ export default function SubmitExamProblemCode(props: DefaultProps) {
                 href={`/exams/${eid}/problems/${problemId}`}
                 className="mt-1 ml-1 text-xl font-medium cursor-pointer hover:underline hover:text-[#0038a8] focus:underline focus:text-[#0038a8] text-[#1048b8]"
               >
-                (A+B)
+                ({examProblemInfo.title})
               </Link>
             </div>
           </p>
@@ -186,7 +186,7 @@ export default function SubmitExamProblemCode(props: DefaultProps) {
                 시간 제한:
                 <span className="font-mono font-light">
                   {' '}
-                  <span>1</span>초
+                  <span>{examProblemInfo.options.maxRealTime / 1000}</span>초
                 </span>
               </span>
               <span className='relative bottom-[0.055rem] font-thin before:content-["|"]' />
@@ -194,19 +194,23 @@ export default function SubmitExamProblemCode(props: DefaultProps) {
                 메모리 제한:
                 <span className="font-mono font-light">
                   {' '}
-                  <span className="mr-1">5</span>MB
+                  {examProblemInfo.options.maxMemory}
                 </span>
+                MB
               </span>
             </div>
             <div className="flex gap-3">
               <span className="font-semibold">
-                시험명: <span className="font-light">코딩테스트 1차</span>
+                시험명:{' '}
+                <span className="font-light">
+                  {examProblemInfo.parentId.title}
+                </span>
               </span>
               <span className='relative bottom-[0.055rem] font-thin before:content-["|"]' />
               <span className="font-semibold">
                 수업명:{' '}
                 <span className="font-light">
-                  2023-01-자료구조(소프트웨어학부 01반)
+                  {examProblemInfo.parentId.course}
                 </span>
               </span>
             </div>
@@ -219,10 +223,9 @@ export default function SubmitExamProblemCode(props: DefaultProps) {
               name="languages"
               id="lang"
               className={`text-sm w-full pl-0 py-1 ${
-                selectedSubmitLanguage === '언어 선택 *' &&
                 isSelectedSubmitLanguageValidFail
                   ? 'text-red-500'
-                  : 'text-gray-500'
+                  : selectedSubmitLanguage === '언어 선택 *' && 'text-gray-500'
               }   bg-transparent border-0 border-b border-${
                 isSelectedSubmitLanguageValidFail ? 'red-500' : 'gray-400'
               }  gray-400 appearance-none focus:outline-none focus:ring-0 focus:border-${

--- a/app/exams/[eid]/problems/[problemId]/submits/[submitId]/page.tsx
+++ b/app/exams/[eid]/problems/[problemId]/submits/[submitId]/page.tsx
@@ -1,14 +1,32 @@
 'use client';
 
 import Loading from '@/app/loading';
+import { userInfoStore } from '@/app/store/UserInfo';
+import { SubmitInfo } from '@/app/types/submit';
+import { UserInfo } from '@/app/types/user';
+import axiosInstance from '@/app/utils/axiosInstance';
+import { fetchCurrentUserInfo } from '@/app/utils/fetchCurrentUserInfo';
+import { formatDateToYYMMDDHHMMSS } from '@/app/utils/formatDate';
+import { getCodeSubmitResultTypeDescription } from '@/app/utils/getCodeSubmitResultTypeDescription';
+import { getLanguageCode } from '@/app/utils/getLanguageCode';
+import { useQuery } from '@tanstack/react-query';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
 import React, { useEffect, useState } from 'react';
+
+// 코드 제출 정보 조회 API
+const fetchSubmitInfo = ({ queryKey }: any) => {
+  const submitId = queryKey[1];
+  return axiosInstance.get(
+    `${process.env.NEXT_PUBLIC_API_VERSION}/submit/${submitId}`,
+  );
+};
 
 interface DefaultProps {
   params: {
     eid: string;
     problemId: string;
+    submitId: string;
   };
 }
 
@@ -18,10 +36,25 @@ const MarkdownPreview = dynamic(
 );
 
 export default function UserExamSubmit(props: DefaultProps) {
-  const [isLoading, setIsLoading] = useState(true);
-
   const eid = props.params.eid;
   const problemId = props.params.problemId;
+  const submitId = props.params.submitId;
+
+  const { isPending, data } = useQuery({
+    queryKey: ['submitInfo', submitId],
+    queryFn: fetchSubmitInfo,
+  });
+
+  const updateUserInfo = userInfoStore((state: any) => state.updateUserInfo);
+
+  const resData = data?.data.data;
+  const submitInfo: SubmitInfo = resData;
+
+  const [isLoading, setIsLoading] = useState(true);
+
+  const currentTime = new Date();
+  const examStartTime = new Date(submitInfo?.parentId.testPeriod.start);
+  const examEndTime = new Date(submitInfo?.parentId.testPeriod.end);
 
   const router = useRouter();
 
@@ -30,8 +63,27 @@ export default function UserExamSubmit(props: DefaultProps) {
   };
 
   useEffect(() => {
-    setIsLoading(false);
-  }, []);
+    // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인, 그리고 게시글 작성자인지 확인
+    fetchCurrentUserInfo(updateUserInfo).then((userInfo: UserInfo) => {
+      if (submitInfo) {
+        const isContestant = submitInfo.parentId.students.some(
+          (student_id) => student_id === userInfo._id,
+        );
+
+        if (
+          isContestant &&
+          examStartTime <= currentTime &&
+          currentTime < examEndTime
+        ) {
+          setIsLoading(false);
+          return;
+        }
+
+        alert('접근 권한이 없습니다.');
+        router.back();
+      }
+    });
+  }, [updateUserInfo, submitInfo, eid, router]);
 
   if (isLoading) return <Loading />;
 
@@ -59,23 +111,8 @@ export default function UserExamSubmit(props: DefaultProps) {
           <MarkdownPreview
             className="markdown-preview"
             source={`
-\`\`\`cpp
-#include <iostream>
-
-using namespace std;
-
-int main(int argc, const char* argv[]) {
-  ios_base::sync_with_stdio(false);
-  cin.tie(0);
-
-  int a, b;
-  cin >> a >> b;
-  cout << a + b;
-
-  return 0;
-}
-\`\`\`
-`}
+\`\`\`${getLanguageCode(submitInfo.language)}
+${submitInfo.code}`}
           />
         </div>
 
@@ -116,21 +153,33 @@ int main(int argc, const char* argv[]) {
                     scope="row"
                     className="py-3 font-medium text-gray-900 whitespace-nowrap dark:text-white"
                   >
-                    코딩테스트 1차
+                    {submitInfo.parentId.title}
                   </th>
-                  <td className="">2023-01-자료구조(소프트웨어학부 01반)</td>
-                  <td className="">A+B</td>
-                  <td className="text-[#0076C0] font-semibold">정답</td>
+                  <td className="">{submitInfo.parentId.course}</td>
+                  <td className="">{submitInfo.problem.title}</td>
+                  <td
+                    className={`${
+                      submitInfo.result.type === 'done'
+                        ? 'text-[#0076C0]'
+                        : 'text-red-500'
+                    } font-semibold`}
+                  >
+                    {getCodeSubmitResultTypeDescription(submitInfo.result.type)}
+                  </td>
                   <td>
-                    <span>1527 </span>
+                    <span>
+                      {(submitInfo.result.memory / 1048576).toFixed(2)}{' '}
+                    </span>
                     <span className="ml-[-1px] text-red-500">MB</span>
                   </td>
                   <td className="">
-                    <span>64 </span>{' '}
+                    <span>{submitInfo.result.time} </span>{' '}
                     <span className="ml-[-1px] text-red-500">ms</span>
                   </td>
-                  <td className="">C++17</td>
-                  <td className="">2023.09.26 07:00:00</td>
+                  <td className="">{submitInfo.language}</td>
+                  <td className="">
+                    {formatDateToYYMMDDHHMMSS(submitInfo.createdAt)}
+                  </td>
                 </tr>
               </tbody>
             </table>

--- a/app/exams/[eid]/problems/[problemId]/submits/components/UserExamSubmitListItem.tsx
+++ b/app/exams/[eid]/problems/[problemId]/submits/components/UserExamSubmitListItem.tsx
@@ -1,14 +1,23 @@
+import { ExamSubmitInfo } from '@/app/types/exam';
+import { formatDateToYYMMDDHHMM } from '@/app/utils/formatDate';
+import { getCodeSubmitResultTypeDescription } from '@/app/utils/getCodeSubmitResultTypeDescription';
 import { useRouter } from 'next/navigation';
 import React from 'react';
 
 interface ExamSubmitListItemProps {
+  personalUserExamSubmitInfo: ExamSubmitInfo;
   eid: string;
   problemId: string;
+  total: number;
+  index: number;
 }
 
 export default function UserExamSubmitListItem({
+  personalUserExamSubmitInfo,
   eid,
   problemId,
+  total,
+  index,
 }: ExamSubmitListItemProps) {
   const router = useRouter();
 
@@ -17,7 +26,7 @@ export default function UserExamSubmitListItem({
       className="border-b dark:border-gray-700 text-xs text-center cursor-pointer hover:bg-gray-50 focus:bg-gray-50"
       onClick={(e) => {
         router.push(
-          `/exams/${eid}/problems/${problemId}/submits/${'65445155c4fc3d9d4396ae0e'}`,
+          `/exams/${eid}/problems/${problemId}/submits/${personalUserExamSubmitInfo._id}`,
         );
       }}
     >
@@ -25,19 +34,34 @@ export default function UserExamSubmitListItem({
         scope="row"
         className="px-4 py-3 font-medium text-gray-900 whitespace-nowrap dark:text-white"
       >
-        1
+        {total - index}
       </th>
-      <td className="">A+B</td>
-      <td className="text-[#0076C0] font-semibold">정답</td>
+      <td className="">{personalUserExamSubmitInfo.problem.title}</td>
+      <td
+        className={`${
+          personalUserExamSubmitInfo.result?.type === 'done'
+            ? 'text-[#0076C0]'
+            : 'text-red-500'
+        } font-semibold`}
+      >
+        {getCodeSubmitResultTypeDescription(
+          personalUserExamSubmitInfo.result?.type,
+        )}
+      </td>
       <td>
-        <span>1527 </span>
+        <span>
+          {(personalUserExamSubmitInfo.result?.memory / 1048576).toFixed(2)}{' '}
+        </span>
         <span className="ml-[-1px] text-red-500">MB</span>
       </td>
       <td className="">
-        <span>64 </span> <span className="ml-[-1px] text-red-500">ms</span>
+        <span>{personalUserExamSubmitInfo.result.time} </span>{' '}
+        <span className="ml-[-1px] text-red-500">ms</span>
       </td>
-      <td className="">C++17</td>
-      <td className="">2023.09.26 07:00:00</td>
+      <td className="">{personalUserExamSubmitInfo.language}</td>
+      <td className="">
+        {formatDateToYYMMDDHHMM(personalUserExamSubmitInfo.createdAt)}
+      </td>
     </tr>
   );
 }

--- a/app/exams/[eid]/problems/[problemId]/submits/page.tsx
+++ b/app/exams/[eid]/problems/[problemId]/submits/page.tsx
@@ -6,6 +6,21 @@ import { useEffect, useState } from 'react';
 import Loading from '@/app/loading';
 import Image from 'next/image';
 import codeImg from '@/public/images/code.png';
+import axiosInstance from '@/app/utils/axiosInstance';
+import { ProblemInfo } from '@/app/types/problem';
+import { userInfoStore } from '@/app/store/UserInfo';
+import { useQuery } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+import { fetchCurrentUserInfo } from '@/app/utils/fetchCurrentUserInfo';
+import { UserInfo } from '@/app/types/user';
+
+// 문제 정보 조회 API
+const fetchExamProblemDetailInfo = ({ queryKey }: any) => {
+  const problemId = queryKey[1];
+  return axiosInstance.get(
+    `${process.env.NEXT_PUBLIC_API_VERSION}/problem/${problemId}`,
+  );
+};
 
 interface DefaultProps {
   params: {
@@ -15,14 +30,50 @@ interface DefaultProps {
 }
 
 export default function UserExamSubmits(props: DefaultProps) {
-  const [isLoading, setIsLoading] = useState(true);
-
   const eid = props.params.eid;
   const problemId = props.params.problemId;
 
+  const { isPending, isError, data, error } = useQuery({
+    queryKey: ['examProblemDetailInfo', problemId],
+    queryFn: fetchExamProblemDetailInfo,
+    retry: 0,
+  });
+
+  const resData = data?.data.data;
+  const examProblemInfo: ProblemInfo = resData;
+
+  const updateUserInfo = userInfoStore((state: any) => state.updateUserInfo);
+
+  const [isLoading, setIsLoading] = useState(true);
+
+  const currentTime = new Date();
+  const contestStartTime = new Date(examProblemInfo?.parentId.testPeriod.start);
+  const contestEndTime = new Date(examProblemInfo?.parentId.testPeriod.end);
+
+  const router = useRouter();
+
   useEffect(() => {
-    setIsLoading(false);
-  }, []);
+    // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인, 그리고 게시글 작성자인지 확인
+    fetchCurrentUserInfo(updateUserInfo).then((userInfo: UserInfo) => {
+      if (examProblemInfo) {
+        const isContestant = examProblemInfo.parentId.students.some(
+          (student_id) => student_id === userInfo._id,
+        );
+
+        if (
+          isContestant &&
+          contestStartTime <= currentTime &&
+          currentTime < contestEndTime
+        ) {
+          setIsLoading(false);
+          return;
+        }
+
+        alert('접근 권한이 없습니다.');
+        router.back();
+      }
+    });
+  }, [updateUserInfo, examProblemInfo, eid, router]);
 
   if (isLoading) return <Loading />;
 
@@ -47,7 +98,7 @@ export default function UserExamSubmits(props: DefaultProps) {
                 href={`/exams/${eid}/problems/${problemId}`}
                 className="mt-1 ml-1 text-xl font-medium cursor-pointer hover:underline hover:text-[#0038a8] focus:underline focus:text-[#0038a8] text-[#1048b8]"
               >
-                (A+B)
+                ({examProblemInfo.title})
               </Link>
             </div>
           </p>
@@ -69,135 +120,7 @@ export default function UserExamSubmits(props: DefaultProps) {
         </div>
 
         <section className="dark:bg-gray-900">
-          <div className="mx-auto w-full">
-            <div className="border dark:bg-gray-800 relative overflow-hidden rounded-sm">
-              <div className="overflow-x-auto">
-                <table className="w-full text-sm text-left text-gray-500 dark:text-gray-400">
-                  <thead className="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-gray-700 dark:text-gray-400 text-center">
-                    <tr>
-                      <th scope="col" className="w-16 px-4 py-2">
-                        번호
-                      </th>
-                      <th scope="col" className="px-4 py-2">
-                        문제명
-                      </th>
-                      <th scope="col" className="px-4 py-2">
-                        결과
-                      </th>
-                      <th scope="col" className="px-4 py-2">
-                        메모리
-                      </th>
-                      <th scope="col" className="px-4 py-2">
-                        시간
-                      </th>
-                      <th scope="col" className="px-4 py-2">
-                        언어
-                      </th>
-                      <th scope="col" className="px-4 py-2">
-                        제출 시간
-                      </th>
-                    </tr>
-                  </thead>
-                  <UserExamSubmitList eid={eid} problemId={problemId} />
-                </table>
-              </div>
-            </div>
-            <nav
-              className="flex flex-col md:flex-row text-xs justify-between items-start md:items-center space-y-3 md:space-y-0 pl-1 mt-3"
-              aria-label="Table navigation"
-            >
-              <span className="text-gray-500 dark:text-gray-400">
-                <span className="text-gray-500 dark:text-white"> 1 - 10</span>{' '}
-                of
-                <span className="text-gray-500 dark:text-white"> 1000</span>
-              </span>
-              <ul className="inline-flex items-stretch -space-x-px">
-                <li>
-                  <a
-                    href="#"
-                    className="flex items-center justify-center h-full py-1.5 px-[0.3rem] ml-0 text-gray-500 bg-white rounded-l-lg border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
-                  >
-                    <span className="sr-only">Previous</span>
-                    <svg
-                      className="w-5 h-5"
-                      aria-hidden="true"
-                      fill="currentColor"
-                      viewBox="0 0 20 20"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        fillRule="evenodd"
-                        d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
-                        clipRule="evenodd"
-                      />
-                    </svg>
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="#"
-                    className="flex items-center justify-center text-sm py-2 px-3 leading-tight text-gray-400 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
-                  >
-                    1
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="#"
-                    className="flex items-center justify-center text-sm py-2 px-3 leading-tight text-gray-400 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
-                  >
-                    2
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="#"
-                    aria-current="page"
-                    className="flex items-center justify-center text-sm z-10 py-2 px-3 leading-tight text-primary-600 bg-primary-50 border border-primary-300 hover:bg-primary-100 hover:text-primary-700 dark:border-gray-700 dark:bg-gray-700 dark:text-white"
-                  >
-                    3
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="#"
-                    className="flex items-center justify-center text-sm py-2 px-3 leading-tight text-gray-400 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
-                  >
-                    ...
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="#"
-                    className="flex items-center justify-center text-sm py-2 px-3 leading-tight text-gray-400 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
-                  >
-                    100
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="#"
-                    className="flex items-center justify-center h-full py-1.5 px-[0.3rem] leading-tight text-gray-500 bg-white rounded-r-lg border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
-                  >
-                    <span className="sr-only">Next</span>
-                    <svg
-                      className="w-5 h-5"
-                      aria-hidden="true"
-                      fill="currentColor"
-                      viewBox="0 0 20 20"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        fillRule="evenodd"
-                        d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-                        clipRule="evenodd"
-                      />
-                    </svg>
-                  </a>
-                </li>
-              </ul>
-            </nav>
-          </div>
+          <UserExamSubmitList eid={eid} problemId={problemId} />
         </section>
       </div>
     </div>

--- a/app/types/problem.ts
+++ b/app/types/problem.ts
@@ -7,7 +7,7 @@ export interface ProblemInfo {
     students: string[];
     _id: string;
     title: string;
-    course?: string;
+    course: string;
     content: string;
     testPeriod: {
       start: string;

--- a/app/types/submit.ts
+++ b/app/types/submit.ts
@@ -7,6 +7,7 @@ export interface SubmitInfo {
     students: string[];
     _id: string;
     title: string;
+    course?: string;
     content: string;
     testPeriod: {
       start: string;

--- a/app/types/submit.ts
+++ b/app/types/submit.ts
@@ -7,7 +7,7 @@ export interface SubmitInfo {
     students: string[];
     _id: string;
     title: string;
-    course?: string;
+    course: string;
     content: string;
     testPeriod: {
       start: string;


### PR DESCRIPTION
## 👀 이슈

resolve #242 

## 📌 개요

시험에 등록된 문제에 대하여 참가자가 코드를 제출하고 제출한 코드 목록 및
세부 정보를 확인하는 페이지 컴포넌트 내 실제 DB 정보를 표시할 수 있도록
하고자 관련 기능을 추가하였습니다.

## 👩‍💻 작업 사항

- 시험 문제 코드 제출 기능 추가
- 시험 문제 코드 제출 목록 페이지 컴포넌트 내 정보 표시 기능 추가
- 시험 문제 코드 제출 정보 상세 페이지 컴포넌트 내 정보 표시 기능 추가

## ✅ 참고 사항

없습니다