### PR TITLE
[feat]: 연습문제 코드 제출 목록 및 코드 제출 상세 페이지 정보 표시 기능 추가 (#246)

### DIFF
--- a/app/contests/[cid]/problems/[problemId]/submits/[submitId]/page.tsx
+++ b/app/contests/[cid]/problems/[problemId]/submits/[submitId]/page.tsx
@@ -119,12 +119,10 @@ export default function UserContestSubmit(props: DefaultProps) {
     // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인, 그리고 게시글 작성자인지 확인
     fetchCurrentUserInfo(updateUserInfo).then((userInfo: UserInfo) => {
       if (submitInfo) {
-        const isContestant = submitInfo.parentId.contestants.some(
-          (contestant_id) => contestant_id === userInfo._id,
-        );
+        const isSubmitOwner = userInfo._id === submitInfo.user._id;
 
         if (
-          isContestant &&
+          isSubmitOwner &&
           contestStartTime <= currentTime &&
           currentTime < contestEndTime
         ) {

--- a/app/exams/[eid]/problems/[problemId]/submits/[submitId]/page.tsx
+++ b/app/exams/[eid]/problems/[problemId]/submits/[submitId]/page.tsx
@@ -43,6 +43,7 @@ export default function UserExamSubmit(props: DefaultProps) {
   const { isPending, data } = useQuery({
     queryKey: ['submitInfo', submitId],
     queryFn: fetchSubmitInfo,
+    retry: 0,
   });
 
   const updateUserInfo = userInfoStore((state: any) => state.updateUserInfo);
@@ -66,12 +67,10 @@ export default function UserExamSubmit(props: DefaultProps) {
     // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인, 그리고 게시글 작성자인지 확인
     fetchCurrentUserInfo(updateUserInfo).then((userInfo: UserInfo) => {
       if (submitInfo) {
-        const isContestant = submitInfo.parentId.students.some(
-          (student_id) => student_id === userInfo._id,
-        );
+        const isSubmitOwner = userInfo._id === submitInfo.user._id;
 
         if (
-          isContestant &&
+          isSubmitOwner &&
           examStartTime <= currentTime &&
           currentTime < examEndTime
         ) {

--- a/app/practices/[pid]/submits/components/UserPracticeSubmitList.tsx
+++ b/app/practices/[pid]/submits/components/UserPracticeSubmitList.tsx
@@ -1,37 +1,86 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
 import UserPracticeSubmitListItem from './UserPracticeSubmitListItem';
 import NoneUserPracticeSubmitListItem from './NoneUserPracticeSubmitListItem';
 import Loading from '@/app/loading';
+import axiosInstance from '@/app/utils/axiosInstance';
+import { useQuery } from '@tanstack/react-query';
+import { PracticeSubmitInfo } from '@/app/types/practice';
 
-interface ExamSubmitListProps {
+// 사용자의 코드 제출 정보 목록 정보 조회 API
+const fetchPersonalUserPracticeSubmitsInfo = ({ queryKey }: any) => {
+  const pid = queryKey[1];
+  return axiosInstance.get(
+    `${process.env.NEXT_PUBLIC_API_VERSION}/practice/${pid}/my-submits`,
+  );
+};
+
+interface PracticeSubmitListProps {
   pid: string;
-  problemId: string;
 }
 
-export default function UserExamSubmitList({
+export default function UserPracticeSubmitList({
   pid,
-  problemId,
-}: ExamSubmitListProps) {
-  const [isLoading, setIsLoading] = useState(true);
-  const [isSubmitListEmpty, setIsSumbitListEmpty] = useState(true);
+}: PracticeSubmitListProps) {
+  const { isPending, data } = useQuery({
+    queryKey: ['personalUserPracticeSubmitsInfo', pid],
+    queryFn: fetchPersonalUserPracticeSubmitsInfo,
+    retry: 0,
+  });
 
-  const numberOfItems = 10;
+  const resData = data?.data.data;
+  const personalUserPracticeSubmitsInfo: PracticeSubmitInfo[] = resData;
 
-  useEffect(() => {
-    setIsLoading(false);
-    setIsSumbitListEmpty(false);
-  }, []);
-
-  if (isLoading) return <Loading />;
-  if (isSubmitListEmpty) return <NoneUserPracticeSubmitListItem />;
+  if (isPending) return <Loading />;
 
   return (
-    <tbody>
-      {Array.from({ length: numberOfItems }, (_, idx) => (
-        <UserPracticeSubmitListItem key={idx} pid={pid} problemId={problemId} />
-      ))}
-    </tbody>
+    <div className="mx-auto w-full">
+      <div className="border dark:bg-gray-800 relative overflow-hidden rounded-sm">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm text-left text-gray-500 dark:text-gray-400">
+            <thead className="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-gray-700 dark:text-gray-400 text-center">
+              <tr>
+                <th scope="col" className="w-16 px-4 py-2">
+                  번호
+                </th>
+                <th scope="col" className="px-4 py-2">
+                  결과
+                </th>
+                <th scope="col" className="px-4 py-2">
+                  메모리
+                </th>
+                <th scope="col" className="px-4 py-2">
+                  시간
+                </th>
+                <th scope="col" className="px-4 py-2">
+                  언어
+                </th>
+                <th scope="col" className="px-4 py-2">
+                  제출 시간
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {personalUserPracticeSubmitsInfo?.length === 0 && (
+                <NoneUserPracticeSubmitListItem />
+              )}
+              {personalUserPracticeSubmitsInfo.map(
+                (personalUserPracticeSubmitInfo, idx) => (
+                  <UserPracticeSubmitListItem
+                    key={idx}
+                    personalUserPracticeSubmitInfo={
+                      personalUserPracticeSubmitInfo
+                    }
+                    total={resData.length}
+                    pid={pid}
+                    index={idx}
+                  />
+                ),
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/app/practices/[pid]/submits/components/UserPracticeSubmitListItem.tsx
+++ b/app/practices/[pid]/submits/components/UserPracticeSubmitListItem.tsx
@@ -1,14 +1,21 @@
+import { PracticeSubmitInfo } from '@/app/types/practice';
+import { formatDateToYYMMDDHHMM } from '@/app/utils/formatDate';
+import { getCodeSubmitResultTypeDescription } from '@/app/utils/getCodeSubmitResultTypeDescription';
 import { useRouter } from 'next/navigation';
 import React from 'react';
 
 interface PracticeSubmitListItemProps {
+  personalUserPracticeSubmitInfo: PracticeSubmitInfo;
   pid: string;
-  problemId: string;
+  total: number;
+  index: number;
 }
 
 export default function UserPracticeSubmitListItem({
+  personalUserPracticeSubmitInfo,
   pid,
-  problemId,
+  total,
+  index,
 }: PracticeSubmitListItemProps) {
   const router = useRouter();
 
@@ -16,25 +23,42 @@ export default function UserPracticeSubmitListItem({
     <tr
       className="border-b dark:border-gray-700 text-xs text-center cursor-pointer hover:bg-gray-50 focus:bg-gray-50"
       onClick={(e) => {
-        router.push(`/practices/${pid}/submits/${'65445155c4fc3d9d4396ae0e'}`);
+        router.push(
+          `/practices/${pid}/submits/${personalUserPracticeSubmitInfo._id}`,
+        );
       }}
     >
       <th
         scope="row"
         className="px-4 py-3 font-medium text-gray-900 whitespace-nowrap dark:text-white"
       >
-        1
+        {total - index}
       </th>
-      <td className="text-[#0076C0] font-semibold">정답</td>
+      <td
+        className={`${
+          personalUserPracticeSubmitInfo.result?.type === 'done'
+            ? 'text-[#0076C0]'
+            : 'text-red-500'
+        } font-semibold`}
+      >
+        {getCodeSubmitResultTypeDescription(
+          personalUserPracticeSubmitInfo.result?.type,
+        )}
+      </td>
       <td>
-        <span>1527 </span>
+        <span>
+          {(personalUserPracticeSubmitInfo.result?.memory / 1048576).toFixed(2)}{' '}
+        </span>
         <span className="ml-[-1px] text-red-500">MB</span>
       </td>
       <td className="">
-        <span>64 </span> <span className="ml-[-1px] text-red-500">ms</span>
+        <span>{personalUserPracticeSubmitInfo.result?.time} </span>{' '}
+        <span className="ml-[-1px] text-red-500">ms</span>
       </td>
-      <td className="">C++17</td>
-      <td className="">2023.09.26 07:00:00</td>
+      <td className="">{personalUserPracticeSubmitInfo.language}</td>
+      <td className="">
+        {formatDateToYYMMDDHHMM(personalUserPracticeSubmitInfo.createdAt)}
+      </td>
     </tr>
   );
 }

--- a/app/practices/[pid]/submits/page.tsx
+++ b/app/practices/[pid]/submits/page.tsx
@@ -6,23 +6,63 @@ import { useEffect, useState } from 'react';
 import Loading from '@/app/loading';
 import Image from 'next/image';
 import codeImg from '@/public/images/code.png';
+import axiosInstance from '@/app/utils/axiosInstance';
+import { useQuery } from '@tanstack/react-query';
+import { ProblemInfo } from '@/app/types/problem';
+import { useRouter } from 'next/navigation';
+import { fetchCurrentUserInfo } from '@/app/utils/fetchCurrentUserInfo';
+import { UserInfo } from '@/app/types/user';
+import { userInfoStore } from '@/app/store/UserInfo';
+import { OPERATOR_ROLES } from '@/app/constants/role';
+
+// 연습문제 게시글 정보 조회 API
+const fetchPracticeDetailInfo = ({ queryKey }: any) => {
+  const pid = queryKey[1];
+  return axiosInstance.get(
+    `${process.env.NEXT_PUBLIC_API_VERSION}/practice/${pid}`,
+  );
+};
 
 interface DefaultProps {
   params: {
     pid: string;
-    problemId: string;
   };
 }
 
 export default function UserPracticeSubmits(props: DefaultProps) {
+  const pid = props.params.pid;
+
+  const { isPending, isError, data, error } = useQuery({
+    queryKey: ['practiceDetailInfo', pid],
+    queryFn: fetchPracticeDetailInfo,
+    retry: 0,
+  });
+
+  const updateUserInfo = userInfoStore((state: any) => state.updateUserInfo);
+
+  const resData = data?.data.data;
+  const practiceInfo: ProblemInfo = resData;
+
   const [isLoading, setIsLoading] = useState(true);
 
-  const pid = props.params.pid;
-  const problemId = props.params.problemId;
-
+  const router = useRouter();
   useEffect(() => {
-    setIsLoading(false);
-  }, []);
+    // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인, 그리고 게시글 작성자인지 확인
+    fetchCurrentUserInfo(updateUserInfo).then((userInfo: UserInfo) => {
+      if (practiceInfo) {
+        const isNormalUser =
+          !OPERATOR_ROLES.includes(userInfo.role) && userInfo.role !== 'staff';
+
+        if (isNormalUser) {
+          setIsLoading(false);
+          return;
+        }
+
+        alert('접근 권한이 없습니다.');
+        router.back();
+      }
+    });
+  }, [updateUserInfo, practiceInfo, router]);
 
   if (isLoading) return <Loading />;
 
@@ -47,139 +87,14 @@ export default function UserPracticeSubmits(props: DefaultProps) {
                 href={`/practices/${pid}`}
                 className="mt-1 ml-1 text-xl font-medium cursor-pointer hover:underline hover:text-[#0038a8] focus:underline focus:text-[#0038a8] text-[#1048b8]"
               >
-                (A+B)
+                ({practiceInfo.title})
               </Link>
             </div>
           </p>
         </div>
 
         <section className="dark:bg-gray-900">
-          <div className="mx-auto w-full">
-            <div className="border dark:bg-gray-800 relative overflow-hidden rounded-sm">
-              <div className="overflow-x-auto">
-                <table className="w-full text-sm text-left text-gray-500 dark:text-gray-400">
-                  <thead className="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-gray-700 dark:text-gray-400 text-center">
-                    <tr>
-                      <th scope="col" className="w-16 px-4 py-2">
-                        번호
-                      </th>
-                      <th scope="col" className="px-4 py-2">
-                        결과
-                      </th>
-                      <th scope="col" className="px-4 py-2">
-                        메모리
-                      </th>
-                      <th scope="col" className="px-4 py-2">
-                        시간
-                      </th>
-                      <th scope="col" className="px-4 py-2">
-                        언어
-                      </th>
-                      <th scope="col" className="px-4 py-2">
-                        제출 시간
-                      </th>
-                    </tr>
-                  </thead>
-                  <UserPracticeSubmitList pid={pid} problemId={problemId} />
-                </table>
-              </div>
-            </div>
-            <nav
-              className="flex flex-col md:flex-row text-xs justify-between items-start md:items-center space-y-3 md:space-y-0 pl-1 mt-3"
-              aria-label="Table navigation"
-            >
-              <span className="text-gray-500 dark:text-gray-400">
-                <span className="text-gray-500 dark:text-white"> 1 - 10</span>{' '}
-                of
-                <span className="text-gray-500 dark:text-white"> 1000</span>
-              </span>
-              <ul className="inline-flex items-stretch -space-x-px">
-                <li>
-                  <a
-                    href="#"
-                    className="flex items-center justify-center h-full py-1.5 px-[0.3rem] ml-0 text-gray-500 bg-white rounded-l-lg border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
-                  >
-                    <span className="sr-only">Previous</span>
-                    <svg
-                      className="w-5 h-5"
-                      aria-hidden="true"
-                      fill="currentColor"
-                      viewBox="0 0 20 20"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        fillRule="evenodd"
-                        d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
-                        clipRule="evenodd"
-                      />
-                    </svg>
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="#"
-                    className="flex items-center justify-center text-sm py-2 px-3 leading-tight text-gray-400 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
-                  >
-                    1
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="#"
-                    className="flex items-center justify-center text-sm py-2 px-3 leading-tight text-gray-400 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
-                  >
-                    2
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="#"
-                    aria-current="page"
-                    className="flex items-center justify-center text-sm z-10 py-2 px-3 leading-tight text-primary-600 bg-primary-50 border border-primary-300 hover:bg-primary-100 hover:text-primary-700 dark:border-gray-700 dark:bg-gray-700 dark:text-white"
-                  >
-                    3
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="#"
-                    className="flex items-center justify-center text-sm py-2 px-3 leading-tight text-gray-400 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
-                  >
-                    ...
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="#"
-                    className="flex items-center justify-center text-sm py-2 px-3 leading-tight text-gray-400 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
-                  >
-                    100
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="#"
-                    className="flex items-center justify-center h-full py-1.5 px-[0.3rem] leading-tight text-gray-500 bg-white rounded-r-lg border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
-                  >
-                    <span className="sr-only">Next</span>
-                    <svg
-                      className="w-5 h-5"
-                      aria-hidden="true"
-                      fill="currentColor"
-                      viewBox="0 0 20 20"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        fillRule="evenodd"
-                        d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-                        clipRule="evenodd"
-                      />
-                    </svg>
-                  </a>
-                </li>
-              </ul>
-            </nav>
-          </div>
+          <UserPracticeSubmitList pid={pid} />
         </section>
       </div>
     </div>

--- a/app/types/practice.ts
+++ b/app/types/practice.ts
@@ -1,0 +1,17 @@
+export interface PracticeSubmitInfo {
+  parentId: string | null;
+  parentType: string;
+  result: {
+    memory: number;
+    time: number;
+    type: string;
+  };
+  _id: string;
+  problem: string;
+  source: string;
+  language: string;
+  user: string;
+  createdAt: string;
+  __v: number;
+  code: string;
+}


### PR DESCRIPTION
## 👀 이슈

resolve #246 

## 📌 개요

일반 사용자가 연습문제에서 제출한 코드에 대하여 제출 목록 및 제출 코드 상세 정보를
확인할 수 있는 페이지에 실제 정보가 표시되도록 기능을 추가하였습니다.

## 👩‍💻 작업 사항

- 연습문제 코드 제출 목록 페이지 내 정보 표시 기능 추가
- 연습문제 코드 제출 상세 정보 페이지 내 정보 표시 기능 추가

## ✅ 참고 사항

- 기능 추가 후 **연습문제 코드 제출 목록 및 코드 제출 상세 페이지** 화면

https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/0a26f829-694b-4f2a-86bf-be8156210691