### PR TITLE
[feat]: 스태프 권한 멤버의 코드 제출 관련 버튼 및 페이지 접근 제한 기능 일괄 추가 (#248)

### DIFF
--- a/app/contests/[cid]/problems/[problemId]/page.tsx
+++ b/app/contests/[cid]/problems/[problemId]/page.tsx
@@ -292,7 +292,7 @@ export default function ContestProblem(props: DefaultProps) {
             </svg>
             문제 목록
           </button>
-          {isEnrollContest && (
+          {isEnrollContest && userInfo.role !== 'staff' && (
             <>
               <button
                 onClick={handleGoToUserContestSubmits}

--- a/app/contests/[cid]/problems/[problemId]/submit/page.tsx
+++ b/app/contests/[cid]/problems/[problemId]/submit/page.tsx
@@ -16,6 +16,7 @@ import { deleteCookie, getCookie, setCookie } from 'cookies-next';
 import { AxiosError } from 'axios';
 import { UserInfo } from '@/app/types/user';
 import Loading from '@/app/loading';
+import { OPERATOR_ROLES } from '@/app/constants/role';
 
 // 대회 문제 열람 비밀번호 확인 API
 const confirmContestPassword = ({
@@ -192,9 +193,12 @@ export default function SubmitContestProblemCode(props: DefaultProps) {
         const isContestant = contestProblemInfo.parentId.contestants.some(
           (contestant_id) => contestant_id === userInfo._id,
         );
+        const isNormalUser =
+          !OPERATOR_ROLES.includes(userInfo.role) && userInfo.role !== 'staff';
 
         if (
           isContestant &&
+          isNormalUser &&
           contestStartTime <= currentTime &&
           currentTime < contestEndTime
         ) {

--- a/app/contests/[cid]/problems/[problemId]/submits/page.tsx
+++ b/app/contests/[cid]/problems/[problemId]/submits/page.tsx
@@ -15,6 +15,7 @@ import { fetchCurrentUserInfo } from '@/app/utils/fetchCurrentUserInfo';
 import { userInfoStore } from '@/app/store/UserInfo';
 import { UserInfo } from '@/app/types/user';
 import { ProblemInfo } from '@/app/types/problem';
+import { OPERATOR_ROLES } from '@/app/constants/role';
 
 // 대회 문제 열람 비밀번호 확인 API
 const confirmContestPassword = ({
@@ -114,9 +115,12 @@ export default function UserContestSubmits(props: DefaultProps) {
         const isContestant = contestProblemInfo.parentId.contestants.some(
           (contestant_id) => contestant_id === userInfo._id,
         );
+        const isNormalUser =
+          !OPERATOR_ROLES.includes(userInfo.role) && userInfo.role !== 'staff';
 
         if (
           isContestant &&
+          isNormalUser &&
           contestStartTime <= currentTime &&
           currentTime < contestEndTime
         ) {

--- a/app/exams/[eid]/problems/[problemId]/page.tsx
+++ b/app/exams/[eid]/problems/[problemId]/page.tsx
@@ -207,7 +207,7 @@ export default function ExamProblem(props: DefaultProps) {
             </svg>
             문제 목록
           </button>
-          {isEnrollExam && (
+          {isEnrollExam && userInfo.role !== 'staff' && (
             <>
               <button
                 onClick={handleGoToUserExamSubmits}

--- a/app/exams/[eid]/problems/[problemId]/submit/page.tsx
+++ b/app/exams/[eid]/problems/[problemId]/submit/page.tsx
@@ -14,6 +14,7 @@ import { userInfoStore } from '@/app/store/UserInfo';
 import Loading from '@/app/loading';
 import { fetchCurrentUserInfo } from '@/app/utils/fetchCurrentUserInfo';
 import { UserInfo } from '@/app/types/user';
+import { OPERATOR_ROLES } from '@/app/constants/role';
 
 // 문제 정보 조회 API
 const fetchExamProblemDetailInfo = ({ queryKey }: any) => {
@@ -137,9 +138,12 @@ export default function SubmitExamProblemCode(props: DefaultProps) {
         const isContestant = examProblemInfo.parentId.students.some(
           (student_id) => student_id === userInfo._id,
         );
+        const isNormalUser =
+          !OPERATOR_ROLES.includes(userInfo.role) && userInfo.role !== 'staff';
 
         if (
           isContestant &&
+          isNormalUser &&
           examStartTime <= currentTime &&
           currentTime < examEndTime
         ) {

--- a/app/exams/[eid]/problems/[problemId]/submits/page.tsx
+++ b/app/exams/[eid]/problems/[problemId]/submits/page.tsx
@@ -13,6 +13,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { fetchCurrentUserInfo } from '@/app/utils/fetchCurrentUserInfo';
 import { UserInfo } from '@/app/types/user';
+import { OPERATOR_ROLES } from '@/app/constants/role';
 
 // 문제 정보 조회 API
 const fetchExamProblemDetailInfo = ({ queryKey }: any) => {
@@ -59,9 +60,12 @@ export default function UserExamSubmits(props: DefaultProps) {
         const isContestant = examProblemInfo.parentId.students.some(
           (student_id) => student_id === userInfo._id,
         );
+        const isNormalUser =
+          !OPERATOR_ROLES.includes(userInfo.role) && userInfo.role !== 'staff';
 
         if (
           isContestant &&
+          isNormalUser &&
           contestStartTime <= currentTime &&
           currentTime < contestEndTime
         ) {


### PR DESCRIPTION
## 👀 이슈

resolve #248 

## 📌 개요

스태프 권한을 보유한 사용자는 `대회/시험/연습문제`  상세 페이지에서 코드 제출과
관련된 버튼 및 페이지에 접근이 불가하도록 제한하는 기능을 추가하였습니다.

## 👩‍💻 작업 사항

- 스태프 권한 멤버의 코드 제출 관련 버튼 및 페이지 접근 제한 기능 추가

## ✅ 참고 사항

없습니다