### PR TITLE
[feat]: 코드 제출 목록 정보 갱신 기능 추가 및 개별 제출 정보 컴포넌트 내 정보 표현 기능 수정 (#250)

### DIFF
--- a/app/contests/[cid]/problems/[problemId]/submits/components/UserContestSubmitList.tsx
+++ b/app/contests/[cid]/problems/[problemId]/submits/components/UserContestSubmitList.tsx
@@ -28,6 +28,7 @@ export default function UserContestSubmitList({
     queryKey: ['personalUserContestSubmitsInfo', problemId],
     queryFn: fetchPersonalUserContestSubmitsInfo,
     retry: 0,
+    refetchInterval: 1500,
   });
 
   const resData = data?.data.data;

--- a/app/contests/[cid]/problems/[problemId]/submits/components/UserContestSubmitListItem.tsx
+++ b/app/contests/[cid]/problems/[problemId]/submits/components/UserContestSubmitListItem.tsx
@@ -1,8 +1,13 @@
+'use client';
+
 import { ContestSubmitInfo } from '@/app/types/contest';
 import { formatDateToYYMMDDHHMM } from '@/app/utils/formatDate';
-import { getCodeSubmitResultTypeDescription } from '@/app/utils/getCodeSubmitResultTypeDescription';
+import {
+  getCodeSubmitResultTypeColor,
+  getCodeSubmitResultTypeDescription,
+} from '@/app/utils/getCodeSubmitResultTypeDescription';
 import { useRouter } from 'next/navigation';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 interface ContestSubmitListItemProps {
   personalUserContestSubmitInfo: ContestSubmitInfo;
@@ -19,15 +24,26 @@ export default function UserContestSubmitListItem({
   total,
   index,
 }: ContestSubmitListItemProps) {
+  const [loadingDots, setLoadingDots] = useState('');
+
   const router = useRouter();
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setLoadingDots((prev) => (prev.length < 3 ? prev + '.' : ''));
+    }, 500);
+
+    return () => clearInterval(interval);
+  }, []);
 
   return (
     <tr
       className="border-b dark:border-gray-700 text-xs text-center cursor-pointer hover:bg-gray-50 focus:bg-gray-50"
       onClick={(e) => {
-        router.push(
-          `/contests/${cid}/problems/${problemId}/submits/${personalUserContestSubmitInfo._id}`,
-        );
+        personalUserContestSubmitInfo.result &&
+          router.push(
+            `/contests/${cid}/problems/${problemId}/submits/${personalUserContestSubmitInfo._id}`,
+          );
       }}
     >
       <th
@@ -37,27 +53,42 @@ export default function UserContestSubmitListItem({
         {total - index}
       </th>
       <td className="">{personalUserContestSubmitInfo.problem.title}</td>
-      <td
-        className={`${
-          personalUserContestSubmitInfo.result?.type === 'done'
-            ? 'text-[#0076C0]'
-            : 'text-red-500'
-        } font-semibold`}
-      >
-        {getCodeSubmitResultTypeDescription(
-          personalUserContestSubmitInfo.result?.type,
-        )}
-      </td>
-      <td>
-        <span>
-          {(personalUserContestSubmitInfo.result.memory / 1048576).toFixed(2)}{' '}
-        </span>
-        <span className="ml-[-1px] text-red-500">MB</span>
-      </td>
-      <td className="">
-        <span>{personalUserContestSubmitInfo.result.time} </span>{' '}
-        <span className="ml-[-1px] text-red-500">ms</span>
-      </td>
+      {personalUserContestSubmitInfo.result ? (
+        <>
+          <td
+            className={`text-[${getCodeSubmitResultTypeColor(
+              personalUserContestSubmitInfo.result.type,
+            )}] font-semibold`}
+          >
+            {getCodeSubmitResultTypeDescription(
+              personalUserContestSubmitInfo.result.type,
+            )}
+          </td>
+          <td>
+            <span>
+              {(personalUserContestSubmitInfo.result.memory / 1048576).toFixed(
+                2,
+              )}{' '}
+            </span>
+            <span className="ml-[-1px] text-red-500">MB</span>
+          </td>
+          <td className="">
+            <span>{personalUserContestSubmitInfo.result.time} </span>{' '}
+            <span className="ml-[-1px] text-red-500">ms</span>
+          </td>
+        </>
+      ) : (
+        <>
+          <td className="flex gap-[0.6rem] justify-center items-center w-[3.5rem] h-10 text-[#e67e22] font-semibold mx-auto">
+            채점 중
+            <span className="w-1 ml-[-0.6rem] text-[#e67e22]">
+              {loadingDots}
+            </span>
+          </td>
+          <td>-</td>
+          <td>-</td>
+        </>
+      )}
       <td className="">{personalUserContestSubmitInfo.language}</td>
       <td className="">
         {formatDateToYYMMDDHHMM(personalUserContestSubmitInfo.createdAt)}

--- a/app/exams/[eid]/problems/[problemId]/submits/components/UserExamSubmitList.tsx
+++ b/app/exams/[eid]/problems/[problemId]/submits/components/UserExamSubmitList.tsx
@@ -29,6 +29,7 @@ export default function UserExamSubmitList({
     queryKey: ['personalUserExamSubmitsInfo', problemId],
     queryFn: fetchPersonalUserExamSubmitsInfo,
     retry: 0,
+    refetchInterval: 1500,
   });
 
   const resData = data?.data.data;

--- a/app/exams/[eid]/problems/[problemId]/submits/components/UserExamSubmitListItem.tsx
+++ b/app/exams/[eid]/problems/[problemId]/submits/components/UserExamSubmitListItem.tsx
@@ -1,8 +1,13 @@
+'use client';
+
 import { ExamSubmitInfo } from '@/app/types/exam';
 import { formatDateToYYMMDDHHMM } from '@/app/utils/formatDate';
-import { getCodeSubmitResultTypeDescription } from '@/app/utils/getCodeSubmitResultTypeDescription';
+import {
+  getCodeSubmitResultTypeColor,
+  getCodeSubmitResultTypeDescription,
+} from '@/app/utils/getCodeSubmitResultTypeDescription';
 import { useRouter } from 'next/navigation';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 interface ExamSubmitListItemProps {
   personalUserExamSubmitInfo: ExamSubmitInfo;
@@ -19,15 +24,26 @@ export default function UserExamSubmitListItem({
   total,
   index,
 }: ExamSubmitListItemProps) {
+  const [loadingDots, setLoadingDots] = useState('');
+
   const router = useRouter();
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setLoadingDots((prev) => (prev.length < 3 ? prev + '.' : ''));
+    }, 500);
+
+    return () => clearInterval(interval);
+  }, []);
 
   return (
     <tr
       className="border-b dark:border-gray-700 text-xs text-center cursor-pointer hover:bg-gray-50 focus:bg-gray-50"
       onClick={(e) => {
-        router.push(
-          `/exams/${eid}/problems/${problemId}/submits/${personalUserExamSubmitInfo._id}`,
-        );
+        personalUserExamSubmitInfo.result &&
+          router.push(
+            `/exams/${eid}/problems/${problemId}/submits/${personalUserExamSubmitInfo._id}`,
+          );
       }}
     >
       <th
@@ -37,27 +53,40 @@ export default function UserExamSubmitListItem({
         {total - index}
       </th>
       <td className="">{personalUserExamSubmitInfo.problem.title}</td>
-      <td
-        className={`${
-          personalUserExamSubmitInfo.result?.type === 'done'
-            ? 'text-[#0076C0]'
-            : 'text-red-500'
-        } font-semibold`}
-      >
-        {getCodeSubmitResultTypeDescription(
-          personalUserExamSubmitInfo.result?.type,
-        )}
-      </td>
-      <td>
-        <span>
-          {(personalUserExamSubmitInfo.result?.memory / 1048576).toFixed(2)}{' '}
-        </span>
-        <span className="ml-[-1px] text-red-500">MB</span>
-      </td>
-      <td className="">
-        <span>{personalUserExamSubmitInfo.result.time} </span>{' '}
-        <span className="ml-[-1px] text-red-500">ms</span>
-      </td>
+      {personalUserExamSubmitInfo.result ? (
+        <>
+          <td
+            className={`text-[${getCodeSubmitResultTypeColor(
+              personalUserExamSubmitInfo.result.type,
+            )}] font-semibold`}
+          >
+            {getCodeSubmitResultTypeDescription(
+              personalUserExamSubmitInfo.result.type,
+            )}
+          </td>
+          <td>
+            <span>
+              {(personalUserExamSubmitInfo.result.memory / 1048576).toFixed(2)}{' '}
+            </span>
+            <span className="ml-[-1px] text-red-500">MB</span>
+          </td>
+          <td className="">
+            <span>{personalUserExamSubmitInfo.result.time} </span>{' '}
+            <span className="ml-[-1px] text-red-500">ms</span>
+          </td>
+        </>
+      ) : (
+        <>
+          <td className="flex gap-[0.6rem] justify-center items-center w-[3.5rem] h-10 text-[#e67e22] font-semibold mx-auto">
+            채점 중
+            <span className="w-1 ml-[-0.6rem] text-[#e67e22]">
+              {loadingDots}
+            </span>
+          </td>
+          <td>-</td>
+          <td>-</td>
+        </>
+      )}
       <td className="">{personalUserExamSubmitInfo.language}</td>
       <td className="">
         {formatDateToYYMMDDHHMM(personalUserExamSubmitInfo.createdAt)}

--- a/app/practices/[pid]/submits/components/UserPracticeSubmitList.tsx
+++ b/app/practices/[pid]/submits/components/UserPracticeSubmitList.tsx
@@ -26,6 +26,7 @@ export default function UserPracticeSubmitList({
     queryKey: ['personalUserPracticeSubmitsInfo', pid],
     queryFn: fetchPersonalUserPracticeSubmitsInfo,
     retry: 0,
+    refetchInterval: 1500,
   });
 
   const resData = data?.data.data;

--- a/app/practices/[pid]/submits/components/UserPracticeSubmitListItem.tsx
+++ b/app/practices/[pid]/submits/components/UserPracticeSubmitListItem.tsx
@@ -1,8 +1,13 @@
+'use client';
+
 import { PracticeSubmitInfo } from '@/app/types/practice';
 import { formatDateToYYMMDDHHMM } from '@/app/utils/formatDate';
-import { getCodeSubmitResultTypeDescription } from '@/app/utils/getCodeSubmitResultTypeDescription';
+import {
+  getCodeSubmitResultTypeColor,
+  getCodeSubmitResultTypeDescription,
+} from '@/app/utils/getCodeSubmitResultTypeDescription';
 import { useRouter } from 'next/navigation';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 interface PracticeSubmitListItemProps {
   personalUserPracticeSubmitInfo: PracticeSubmitInfo;
@@ -17,15 +22,26 @@ export default function UserPracticeSubmitListItem({
   total,
   index,
 }: PracticeSubmitListItemProps) {
+  const [loadingDots, setLoadingDots] = useState('');
+
   const router = useRouter();
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setLoadingDots((prev) => (prev.length < 3 ? prev + '.' : ''));
+    }, 500);
+
+    return () => clearInterval(interval);
+  }, []);
 
   return (
     <tr
       className="border-b dark:border-gray-700 text-xs text-center cursor-pointer hover:bg-gray-50 focus:bg-gray-50"
       onClick={(e) => {
-        router.push(
-          `/practices/${pid}/submits/${personalUserPracticeSubmitInfo._id}`,
-        );
+        personalUserPracticeSubmitInfo.result &&
+          router.push(
+            `/practices/${pid}/submits/${personalUserPracticeSubmitInfo._id}`,
+          );
       }}
     >
       <th
@@ -34,27 +50,42 @@ export default function UserPracticeSubmitListItem({
       >
         {total - index}
       </th>
-      <td
-        className={`${
-          personalUserPracticeSubmitInfo.result?.type === 'done'
-            ? 'text-[#0076C0]'
-            : 'text-red-500'
-        } font-semibold`}
-      >
-        {getCodeSubmitResultTypeDescription(
-          personalUserPracticeSubmitInfo.result?.type,
-        )}
-      </td>
-      <td>
-        <span>
-          {(personalUserPracticeSubmitInfo.result?.memory / 1048576).toFixed(2)}{' '}
-        </span>
-        <span className="ml-[-1px] text-red-500">MB</span>
-      </td>
-      <td className="">
-        <span>{personalUserPracticeSubmitInfo.result?.time} </span>{' '}
-        <span className="ml-[-1px] text-red-500">ms</span>
-      </td>
+      {personalUserPracticeSubmitInfo.result ? (
+        <>
+          <td
+            className={`text-[${getCodeSubmitResultTypeColor(
+              personalUserPracticeSubmitInfo.result.type,
+            )}] font-semibold`}
+          >
+            {getCodeSubmitResultTypeDescription(
+              personalUserPracticeSubmitInfo.result.type,
+            )}
+          </td>
+          <td>
+            <span>
+              {(personalUserPracticeSubmitInfo.result.memory / 1048576).toFixed(
+                2,
+              )}{' '}
+            </span>
+            <span className="ml-[-1px] text-red-500">MB</span>
+          </td>
+          <td className="">
+            <span>{personalUserPracticeSubmitInfo.result.time} </span>{' '}
+            <span className="ml-[-1px] text-red-500">ms</span>
+          </td>
+        </>
+      ) : (
+        <>
+          <td className="flex gap-[0.6rem] justify-center items-center w-[3.5rem] h-10 text-[#e67e22] font-semibold mx-auto">
+            채점 중
+            <span className="w-1 ml-[-0.6rem] text-[#e67e22]">
+              {loadingDots}
+            </span>
+          </td>
+          <td>-</td>
+          <td>-</td>
+        </>
+      )}
       <td className="">{personalUserPracticeSubmitInfo.language}</td>
       <td className="">
         {formatDateToYYMMDDHHMM(personalUserPracticeSubmitInfo.createdAt)}

--- a/app/utils/getCodeSubmitResultTypeDescription.ts
+++ b/app/utils/getCodeSubmitResultTypeDescription.ts
@@ -1,9 +1,9 @@
 export function getCodeSubmitResultTypeDescription(resultType: string): string {
   switch (resultType) {
     case 'compile':
-      return '컴파일 오류';
+      return '컴파일 에러';
     case 'runtime':
-      return '런타임 오류';
+      return '런타임 에러';
     case 'timeout':
       return '시간 초과';
     case 'memory':
@@ -14,5 +14,24 @@ export function getCodeSubmitResultTypeDescription(resultType: string): string {
       return '정답';
     default:
       return '알 수 없음';
+  }
+}
+
+export function getCodeSubmitResultTypeColor(resultType: string): string {
+  switch (resultType) {
+    case 'compile':
+      return '#0f4c81';
+    case 'runtime':
+      return '#5c4c87';
+    case 'timeout':
+    case 'memory':
+      return '#fa7268';
+    case 'wrong':
+      return '#dd4124';
+    case 'done':
+      return '#009874';
+    default:
+      alert('Error: unknown [resultType]');
+      return 'X';
   }
 }


### PR DESCRIPTION
## 👀 이슈

resolve #250 

## 📌 개요

대회/시험/연습문제 코드 제출 목록 페이지 내에서 표시되는 정보가
`1.5초` 간격으로 `refetching` 될 수 있도록 하여 최신 데이터를 받아올
수 있도록 하였고, 개별 채점 정보 리스트 아이템 컴포넌트 내에서 표시되는
데이터 정보들을 좀 더 가독성 있게 변경하였습니다.

## 👩‍💻 작업 사항

- 코드 제출 목록 정보 갱신 기능 추가
- 개별 제출 정보 컴포넌트 내 정보 표현 기능 수정

## ✅ 참고 사항

- 기능 수정 후 **코드 제출 목록** 페이지 예시 화면
> 채점 결과에 따라 결과 문자열의 글자색이 변경됨
<img width="1269" alt="Screenshot 2024-03-08 at 11 08 37 AM" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/7536750f-9194-4035-b9a1-a2af99c563dd">
