### PR TITLE
[feat]: 사용자 코드 제출 결과에 따른 결과 텍스트 글자색 변경 기능 추가 (#252)

### DIFF
--- a/app/contests/[cid]/problems/[problemId]/submits/[submitId]/page.tsx
+++ b/app/contests/[cid]/problems/[problemId]/submits/[submitId]/page.tsx
@@ -7,7 +7,10 @@ import { UserInfo } from '@/app/types/user';
 import axiosInstance from '@/app/utils/axiosInstance';
 import { fetchCurrentUserInfo } from '@/app/utils/fetchCurrentUserInfo';
 import { formatDateToYYMMDDHHMMSS } from '@/app/utils/formatDate';
-import { getCodeSubmitResultTypeDescription } from '@/app/utils/getCodeSubmitResultTypeDescription';
+import {
+  getCodeSubmitResultTypeColor,
+  getCodeSubmitResultTypeDescription,
+} from '@/app/utils/getCodeSubmitResultTypeDescription';
 import { getLanguageCode } from '@/app/utils/getLanguageCode';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
@@ -226,11 +229,9 @@ ${submitInfo.code}`}
                   </th>
                   <td className="">{submitInfo.problem.title}</td>
                   <td
-                    className={`${
-                      submitInfo.result.type === 'done'
-                        ? 'text-[#0076C0]'
-                        : 'text-red-500'
-                    } font-semibold`}
+                    className={`${getCodeSubmitResultTypeColor(
+                      submitInfo.result.type,
+                    )} font-semibold`}
                   >
                     {getCodeSubmitResultTypeDescription(submitInfo.result.type)}
                   </td>

--- a/app/contests/[cid]/problems/[problemId]/submits/components/UserContestSubmitListItem.tsx
+++ b/app/contests/[cid]/problems/[problemId]/submits/components/UserContestSubmitListItem.tsx
@@ -56,9 +56,9 @@ export default function UserContestSubmitListItem({
       {personalUserContestSubmitInfo.result ? (
         <>
           <td
-            className={`text-[${getCodeSubmitResultTypeColor(
+            className={`${getCodeSubmitResultTypeColor(
               personalUserContestSubmitInfo.result.type,
-            )}] font-semibold`}
+            )} font-semibold`}
           >
             {getCodeSubmitResultTypeDescription(
               personalUserContestSubmitInfo.result.type,

--- a/app/exams/[eid]/problems/[problemId]/submits/[submitId]/page.tsx
+++ b/app/exams/[eid]/problems/[problemId]/submits/[submitId]/page.tsx
@@ -7,7 +7,10 @@ import { UserInfo } from '@/app/types/user';
 import axiosInstance from '@/app/utils/axiosInstance';
 import { fetchCurrentUserInfo } from '@/app/utils/fetchCurrentUserInfo';
 import { formatDateToYYMMDDHHMMSS } from '@/app/utils/formatDate';
-import { getCodeSubmitResultTypeDescription } from '@/app/utils/getCodeSubmitResultTypeDescription';
+import {
+  getCodeSubmitResultTypeColor,
+  getCodeSubmitResultTypeDescription,
+} from '@/app/utils/getCodeSubmitResultTypeDescription';
 import { getLanguageCode } from '@/app/utils/getLanguageCode';
 import { useQuery } from '@tanstack/react-query';
 import dynamic from 'next/dynamic';
@@ -157,11 +160,9 @@ ${submitInfo.code}`}
                   <td className="">{submitInfo.parentId.course}</td>
                   <td className="">{submitInfo.problem.title}</td>
                   <td
-                    className={`${
-                      submitInfo.result.type === 'done'
-                        ? 'text-[#0076C0]'
-                        : 'text-red-500'
-                    } font-semibold`}
+                    className={`${getCodeSubmitResultTypeColor(
+                      submitInfo.result.type,
+                    )} font-semibold`}
                   >
                     {getCodeSubmitResultTypeDescription(submitInfo.result.type)}
                   </td>

--- a/app/exams/[eid]/problems/[problemId]/submits/components/UserExamSubmitListItem.tsx
+++ b/app/exams/[eid]/problems/[problemId]/submits/components/UserExamSubmitListItem.tsx
@@ -56,9 +56,9 @@ export default function UserExamSubmitListItem({
       {personalUserExamSubmitInfo.result ? (
         <>
           <td
-            className={`text-[${getCodeSubmitResultTypeColor(
+            className={`${getCodeSubmitResultTypeColor(
               personalUserExamSubmitInfo.result.type,
-            )}] font-semibold`}
+            )} font-semibold`}
           >
             {getCodeSubmitResultTypeDescription(
               personalUserExamSubmitInfo.result.type,

--- a/app/practices/[pid]/submits/[submitId]/page.tsx
+++ b/app/practices/[pid]/submits/[submitId]/page.tsx
@@ -8,7 +8,10 @@ import { UserInfo } from '@/app/types/user';
 import axiosInstance from '@/app/utils/axiosInstance';
 import { fetchCurrentUserInfo } from '@/app/utils/fetchCurrentUserInfo';
 import { formatDateToYYMMDDHHMMSS } from '@/app/utils/formatDate';
-import { getCodeSubmitResultTypeDescription } from '@/app/utils/getCodeSubmitResultTypeDescription';
+import {
+  getCodeSubmitResultTypeColor,
+  getCodeSubmitResultTypeDescription,
+} from '@/app/utils/getCodeSubmitResultTypeDescription';
 import { getLanguageCode } from '@/app/utils/getLanguageCode';
 import { useQuery } from '@tanstack/react-query';
 import dynamic from 'next/dynamic';
@@ -140,11 +143,9 @@ ${submitInfo.code}`}
                     {submitInfo.problem.title}
                   </th>
                   <td
-                    className={`${
-                      submitInfo.result.type === 'done'
-                        ? 'text-[#0076C0]'
-                        : 'text-red-500'
-                    } font-semibold`}
+                    className={`${getCodeSubmitResultTypeColor(
+                      submitInfo.result.type,
+                    )} font-semibold`}
                   >
                     {getCodeSubmitResultTypeDescription(submitInfo.result.type)}
                   </td>

--- a/app/practices/[pid]/submits/components/UserPracticeSubmitListItem.tsx
+++ b/app/practices/[pid]/submits/components/UserPracticeSubmitListItem.tsx
@@ -53,9 +53,9 @@ export default function UserPracticeSubmitListItem({
       {personalUserPracticeSubmitInfo.result ? (
         <>
           <td
-            className={`text-[${getCodeSubmitResultTypeColor(
+            className={`${getCodeSubmitResultTypeColor(
               personalUserPracticeSubmitInfo.result.type,
-            )}] font-semibold`}
+            )} font-semibold`}
           >
             {getCodeSubmitResultTypeDescription(
               personalUserPracticeSubmitInfo.result.type,

--- a/app/utils/getCodeSubmitResultTypeDescription.ts
+++ b/app/utils/getCodeSubmitResultTypeDescription.ts
@@ -20,16 +20,16 @@ export function getCodeSubmitResultTypeDescription(resultType: string): string {
 export function getCodeSubmitResultTypeColor(resultType: string): string {
   switch (resultType) {
     case 'compile':
-      return '#0f4c81';
+      return 'text-[#0f4c81]';
     case 'runtime':
-      return '#5c4c87';
+      return 'text-[#5c4c87]';
     case 'timeout':
     case 'memory':
-      return '#fa7268';
+      return 'text-[#fa7268]';
     case 'wrong':
-      return '#dd4124';
+      return 'text-[#dd4124]';
     case 'done':
-      return '#009874';
+      return 'text-[#009874]';
     default:
       alert('Error: unknown [resultType]');
       return 'X';


### PR DESCRIPTION
## 👀 이슈

resolve #252 

## 📌 개요

사용자가 `대화/시험/연습문제` 문제 페이지에서 제출 기능을 통해
코드를 제출하였을 경우 채점 결과에 따른 텍스트의 색이 변경되도록
하였습니다.

## 👩‍💻 작업 사항

- 채점 결과에 따른 텍스트 글자색 변경 기능 추가

## ✅ 참고 사항

없습니다