### PR TITLE
[fix]: 시스템 Appearance에 따른 react-markdown-preview 컴포넌트 내 요소 색상 불일치 문제 수정 (#254)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -137,9 +137,27 @@
 }
 
 .markdown-preview {
+  background-color: white !important;
   letter-spacing: 0.04rem;
 }
 
+.markdown-preview figure {
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+  width: 100% !important;
+}
+
+.markdown-preview tr:nth-child(odd) {
+  background-color: white !important;
+}
+
+.markdown-preview tr:nth-child(even) {
+  background-color: #f7f9fc !important;
+}
+
+.markdown-preview td {
+  border-color: #d4d6da !important;
+}
 .markdown-preview p {
   margin-bottom: 0 !important;
 }
@@ -185,12 +203,6 @@
   padding: 1rem 1.75rem !important;
   border-left: 0.25rem solid #2fc27b !important;
   background-color: #fafcfe;
-}
-
-.markdown-preview img {
-  display: block !important;
-  margin-left: auto !important;
-  margin-right: auto !important;
 }
 
 .markdown-preview .copied {
@@ -239,6 +251,24 @@
 
 .go3489369143:hover {
   scale: 1.35;
+}
+
+/* CodeMirror */
+.cm-editor {
+  outline: none !important;
+}
+
+.cm-editor .cm-gutters {
+  justify-content: end !important;
+  min-width: 1.5rem;
+}
+
+.cm-editor .cm-foldGutter {
+  display: none !important;
+}
+
+.cm-editor .cm-gutterElement {
+  color: #999999 !important;
 }
 
 /* --------------- */


### PR DESCRIPTION
## 👀 이슈

resolve #254 

## 📌 개요

시스템에서 다크 모드 사용 시 홈페이지 내 `react-markdown-preview` 컴포넌트가
사용되는 페이지에서 UI가 정상적으로 표시되지 않는 문제가 있어 해당 기능을 수정하였습니다.

## 👩‍💻 작업 사항

- `react-markdown-preview` 컴포넌트 요소에 대한 전역 CSS 스타일 수정

## ✅ 참고 사항

- 기능 수정 전 `Apperance(Dark)` 사용 시 **게시글 상세** 페이지 화면

<img width="1608" alt="Screenshot 2024-03-12 at 7 53 27 AM" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/5a725794-5b66-4d7b-8733-e7dac56ef402">

- 기능 수정 후 `Apperance(Dark)` 사용 시 **게시글 상세** 페이지 화면
> `Apperance(Light)`와 동일하게 표시됨

<img width="1608" alt="Screenshot 2024-03-12 at 8 03 18 AM" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/82bdc4db-65f5-4ebc-9331-3d033cd9b2e6">