### PR TITLE
[feat]: 대회 게시글 모바일 반응형 페이지 효과 추가 (#258)

### DIFF
--- a/app/contests/[cid]/page.tsx
+++ b/app/contests/[cid]/page.tsx
@@ -432,48 +432,45 @@ export default function ContestDetail(props: DefaultProps) {
 
   return (
     <div className="mt-6 mb-24 px-5 2lg:px-0 overflow-x-auto">
-      <div className="flex flex-col w-[60rem] mx-auto">
+      <div className="flex flex-col w-[19rem] xs:w-[90%] xl:w-[72.5%] mx-auto">
         <div className="flex flex-col gap-8">
           <p className="text-2xl font-bold tracking-tight">
             {contestInfo.title}
           </p>
-          <div className="flex justify-between pb-3 border-b border-gray-300">
-            <div className="flex gap-3">
-              <span className="font-semibold">
-                참가신청 기간:{' '}
-                <span className="font-light">
-                  {contestInfo.applyingPeriod ? (
-                    <>
-                      {formatDateToYYMMDDHHMM(contestInfo.applyingPeriod.start)}{' '}
-                      ~ {formatDateToYYMMDDHHMM(contestInfo.applyingPeriod.end)}
-                    </>
-                  ) : (
-                    <>
-                      ~ {formatDateToYYMMDDHHMM(contestInfo.testPeriod.start)}
-                    </>
-                  )}
-                </span>
+          <div className="flex flex-col 3md:flex-row pb-3 gap-1 3md:gap-3 border-b border-gray-300">
+            <span className="font-semibold">
+              <span className="3md:hidden text-gray-500">• </span>
+              참가신청 기간:{' '}
+              <span className="font-light">
+                {contestInfo.applyingPeriod ? (
+                  <>
+                    {formatDateToYYMMDDHHMM(contestInfo.applyingPeriod.start)} ~{' '}
+                    {formatDateToYYMMDDHHMM(contestInfo.applyingPeriod.end)}
+                  </>
+                ) : (
+                  <>~ {formatDateToYYMMDDHHMM(contestInfo.testPeriod.start)}</>
+                )}
               </span>
-              <span className='relative bottom-[0.055rem] font-thin before:content-["|"]' />
-              <span className="font-semibold">
-                대회 시간:{' '}
-                <span className="font-light">
-                  {formatDateToYYMMDDHHMM(contestInfo.testPeriod.start)} ~{' '}
-                  {formatDateToYYMMDDHHMM(contestInfo.testPeriod.end)}{' '}
-                  {timeUntilEnd?.isPast ? (
-                    <span className="text-red-500 font-bold">(종료)</span>
-                  ) : (
-                    renderRemainingTime()
-                  )}
-                </span>
+            </span>
+            <span className='hidden relative bottom-[0.055rem] font-thin before:content-["|"] 3md:block' />
+            <span className="font-semibold">
+              <span className="3md:hidden text-gray-500">• </span>
+              대회 시간:{' '}
+              <span className="font-light">
+                {formatDateToYYMMDDHHMM(contestInfo.testPeriod.start)} ~{' '}
+                {formatDateToYYMMDDHHMM(contestInfo.testPeriod.end)}{' '}
+                {timeUntilEnd?.isPast ? (
+                  <span className="text-red-500 font-bold">(종료)</span>
+                ) : (
+                  renderRemainingTime()
+                )}
               </span>
-            </div>
-            <div className="flex gap-3">
-              <span className="font-semibold">
-                작성자:{' '}
-                <span className="font-light">{contestInfo.writer.name}</span>
-              </span>
-            </div>
+            </span>
+            <span className="ml-0 font-semibold 3md:ml-auto">
+              <span className="3md:hidden text-gray-500">• </span>
+              작성자:{' '}
+              <span className="font-light">{contestInfo.writer.name}</span>
+            </span>
           </div>
         </div>
 
@@ -585,7 +582,7 @@ export default function ContestDetail(props: DefaultProps) {
                     <span className="text-red-500">신청 취소가 가능</span>
                     합니다.
                   </div>
-                  <div className="text-[#777] text-xs">
+                  <div className="px-5 text-[#777] text-xs">
                     비정상적인 이력이 확인될 경우, 서비스 이용이 제한됩니다.
                   </div>
                 </div>
@@ -596,7 +593,7 @@ export default function ContestDetail(props: DefaultProps) {
                     <span className="text-red-500">신청이 불가능</span>
                     합니다.
                   </div>
-                  <div className="text-[#777] text-xs">
+                  <div className="px-5 text-[#777] text-xs">
                     참가 신청 이전에 반드시 대회 내용을 자세히 읽어주시기
                     바랍니다.
                   </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -145,7 +145,7 @@ export default function Home() {
               />
             </svg>
           </Link>
-          <Link href="/notices" className="flex relative">
+          <Link href="/notice" className="flex relative">
             <div className="flex flex-col gap-4 w-[22.5rem] 3xs:w-[30rem] px-6 py-[1.825rem] 2lg:mb-0 rounded-[0.825rem] bg-gradient-to-r from-[#357ad4] to-[#5ac3c7]">
               <p className="text-base text-white font-semibold tracking-wider">
                 공지사항


### PR DESCRIPTION
## 👀 이슈

resolve #258 

## 📌 개요

`대회 게시글` 페이지 접속 시 게시글이 PC 해상도 맞게
나타나도록 되어 있던 부분을 모바일 기기 해상도에서도
알맞게 표시되도록 **반응형 코드**를 추가하고자 하였습니다.

## 👩‍💻 작업 사항

- `대회 게시글` 모바일 반응형 페이지 효과 추가
- 메인페이지 내 공지사항 배너 리다이렉팅 주소 변경

## ✅ 참고 사항

- 기능 추가 전 모바일 `iPhone SE` 기준 **대회 게시글** 페이지 화면

<img width="397" alt="Screenshot 2024-03-16 at 11 47 28 AM" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/4ece1124-a9e8-4a13-b3f5-c6c1da060765">

- 기능 추가 후 모바일 `iPhone SE` 기준 **대회 게시글** 페이지 화면

<img width="396" alt="Screenshot 2024-03-16 at 11 54 09 AM" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/e27b689f-3726-44c4-9b77-c07f02292991">