### PR TITLE
[fix]: 채널톡 서드파티 표시 로직 수정 (#260)

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link';
 import React from 'react';
 
 export default function Footer() {

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -2,7 +2,6 @@
 
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
-import ChannelService from '../third-party/ChannelTalk';
 import { userInfoStore } from '../store/UserInfo';
 import axiosInstance from '../utils/axiosInstance';
 import { useMutation } from '@tanstack/react-query';
@@ -32,18 +31,9 @@ export default function Navbar() {
   const [rightPos, setRightPos] = useState('-right-full');
 
   useEffect(() => {
-    const CT = new ChannelService();
-    CT.loadScript();
-    CT.boot({ pluginKey: process.env.NEXT_PUBLIC_CHANNEL_TALK_PLUGIN_KEY! });
-
     // (로그인 한) 사용자 정보 조회
     const activeAuthorization = localStorage.getItem('activeAuthorization');
     if (activeAuthorization) fetchCurrentUserInfo(updateUserInfo);
-
-    //for unmount
-    return () => {
-      CT.shutdown();
-    };
   }, [updateUserInfo]);
 
   return (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,23 @@
+'use client'
+
 import Link from 'next/link';
 import ContestList from './components/Contests/ContestList';
 import ExamList from './components/exams/ExamList';
+import { useEffect } from 'react';
+import ChannelService from './third-party/ChannelTalk';
 
 export default function Home() {
+  useEffect(() => {
+    const CT = new ChannelService();
+    CT.loadScript();
+    CT.boot({ pluginKey: process.env.NEXT_PUBLIC_CHANNEL_TALK_PLUGIN_KEY! });
+
+    //for unmount
+    return () => {
+      CT.shutdown();
+    };
+  }, []);
+
   return (
     <div className="mt-[-5rem]">
       <div className="h-80 flex flex-col gap-6 justify-center items-center bg-[url('/images/main.jpg')] bg-cover bg-center bright-in">


### PR DESCRIPTION
## 👀 이슈

resolve #260 

## 📌 개요

기존 홈페이지의 우측 하단에 계속 표시되던 `채널톡` 버튼을 메인페이지에서만
표시될 수 있도록 관련 로직을 수정하고자 하였습니다.

## 👩‍💻 작업 사항

- `채널톡` 표시 로직 수정

## ✅ 참고 사항

없습니다