### PR TITLE
[fix]: 관리자 계정의 시험 문제 상세 페이지 접근 허용 로직 추가 (#262)

### DIFF
--- a/app/exams/[eid]/problems/[problemId]/page.tsx
+++ b/app/exams/[eid]/problems/[problemId]/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { OPERATOR_ROLES } from '@/app/constants/role';
 import Loading from '@/app/loading';
 import { userInfoStore } from '@/app/store/UserInfo';
 import { ProblemInfo } from '@/app/types/problem';
@@ -119,9 +120,15 @@ export default function ExamProblem(props: DefaultProps) {
     fetchCurrentUserInfo(updateUserInfo).then((userInfo: UserInfo) => {
       if (examProblemInfo) {
         const isWriter = examProblemInfo.writer._id === userInfo._id;
+        const isOperator = OPERATOR_ROLES.includes(userInfo.role);
         const isContestant = examProblemInfo.parentId.students.some(
           (student_id) => student_id === userInfo._id,
         );
+
+        if (isWriter) {
+          setIsLoading(false);
+          return;
+        }
 
         if (
           isContestant &&
@@ -132,7 +139,7 @@ export default function ExamProblem(props: DefaultProps) {
           return;
         }
 
-        if (isWriter) {
+        if (isOperator && currentTime > examEndTime) {
           setIsLoading(false);
           return;
         }


### PR DESCRIPTION
## 👀 이슈

resolve #262 

## 📌 개요

기존에 관리자 계정으로 로그인한 사용자가 시험 시간이 종료된 시험에 한하여
문제 상세 페이지의 접근이 허용되어야 했는데, 해당 로직의 누락으로 접근이 불가하던
이슈가 발생하여 접근이 가능하도록 관련 로직을 추가하였습니다.

## 👩‍💻 작업 사항

- 관리자 계정의 시험 문제 페이지 접근 허용 로직 추가

## ✅ 참고 사항

없습니다