### PR TITLE
[fix]: 대회 게시글 상세 페이지 모바일 해상도에 대한 페이지 본문 너비 크기 변경 (#264)

### DIFF
--- a/app/contests/[cid]/page.tsx
+++ b/app/contests/[cid]/page.tsx
@@ -431,8 +431,8 @@ export default function ContestDetail(props: DefaultProps) {
   if (isPending) return <Loading />;
 
   return (
-    <div className="mt-6 mb-24 px-5 2lg:px-0 overflow-x-auto">
-      <div className="flex flex-col w-[19rem] xs:w-[90%] xl:w-[72.5%] mx-auto">
+    <div className="mt-6 mb-24 px-1 2lg:px-0 overflow-x-auto">
+      <div className="flex flex-col w-[21rem] xs:w-[90%] xl:w-[72.5%] mx-auto">
         <div className="flex flex-col gap-8">
           <p className="text-2xl font-bold tracking-tight">
             {contestInfo.title}


### PR DESCRIPTION
## 👀 이슈

resolve #264 

## 📌 개요

모바일 기기에서 대회 게시글 상세 페이지 로드 시 게시글 본문의 너비가
작다고 판단되어 좀 더 넓게 보일 수 있도록 너비 크기를 변경하였습니다.

## 👩‍💻 작업 사항

- `대회 게시글 상세` 페이지 모바일 해상도에 대한 페이지 본문 너비 크기 변경

## ✅ 참고 사항

- 너비 크기 수정 전 `대회 게시글 상세` 페이지 모바일 해상도 화면

<img width="336" alt="Screenshot 2024-06-27 at 6 02 45 PM" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/7ce8ca58-f4bc-45ec-ab4e-543aa16f4bb8">

- 너비 크기 수정 후, `대회 게시글 상세` 페이지 모바일 해상도 화면

<img width="335" alt="Screenshot 2024-06-27 at 6 02 34 PM" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/c7e1e0ad-5845-41fb-be8f-c2570f77cea4">