### PR TITLE
[feat]: 시험 게시글 상세 페이지 컴포넌트 내 모바일 반응형 웹 디자인 효과 추가 (#266)

### DIFF
--- a/app/exams/[eid]/page.tsx
+++ b/app/exams/[eid]/page.tsx
@@ -383,12 +383,13 @@ export default function ExamDetail(props: DefaultProps) {
   if (!isConfirmPassword || isPending) return <Loading />;
 
   return (
-    <div className="mt-6 mb-24 px-5 2lg:px-0 overflow-x-auto">
-      <div className="flex flex-col w-[60rem] mx-auto">
+    <div className="mt-6 mb-24 px-1 2lg:px-0 overflow-x-auto">
+      <div className="flex flex-col w-[21rem] xs:w-[90%] xl:w-[72.5%] mx-auto">
         <div className="flex flex-col gap-8">
           <p className="text-2xl font-bold tracking-tight">{examInfo.title}</p>
-          <div className="flex justify-between pb-3 border-b border-gray-300">
+          <div className="flex flex-col 3md:flex-row pb-3 gap-1 3md:gap-3 border-b border-gray-300">
             <span className="font-semibold">
+              <span className="3md:hidden text-gray-500">• </span>
               시험 시간:{' '}
               <span className="font-light">
                 {formatDateToYYMMDDHHMM(examInfo.testPeriod.start)} ~{' '}
@@ -400,16 +401,16 @@ export default function ExamDetail(props: DefaultProps) {
                 )}
               </span>
             </span>
-            <div className="flex gap-3">
-              <span className="font-semibold">
-                수업명: <span className="font-light">{examInfo.course}</span>
-              </span>
-              <span className='relative bottom-[0.055rem] font-thin before:content-["|"]' />
-              <span className="font-semibold">
-                작성자:{' '}
-                <span className="font-light">{examInfo.writer.name}</span>
-              </span>
-            </div>
+            <span className='hidden relative bottom-[0.055rem] font-thin before:content-["|"] 3md:block' />
+            <span className="font-semibold">
+              <span className="3md:hidden text-gray-500">• </span>
+              수업명: <span className="font-light">{examInfo.course}</span>
+            </span>
+            <span className='hidden relative bottom-[0.055rem] font-thin before:content-["|"] 3md:block' />
+            <span className="font-semibold">
+              <span className="3md:hidden text-gray-500">• </span>
+              작성자: <span className="font-light">{examInfo.writer.name}</span>
+            </span>
           </div>
         </div>
         <div className="border-b mt-8 mb-4 pb-5">


### PR DESCRIPTION
## 👀 이슈

resolve #266 

## 📌 개요

`시험 게시글` 페이지 접속 시 게시글이 PC 해상도 맞게
나타나도록 되어 있던 부분을 모바일 기기 해상도에서도
적절히 표시되도록 **반응형 웹 디자인 코드**를 추가하였습니다.

## 👩‍💻 작업 사항

- `시험 게시글 상세` 모바일 반응형 웹 디자인 효과 추가

## ✅ 참고 사항

- 기능 추가 전 모바일(`iPhone 11 Pro`) **시험 게시글 상세** 페이지 화면

<img width="482" alt="Screenshot 2024-06-27 at 6 47 43 PM" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/ac9887b7-5fef-4b72-b2c8-18ff5ef926f7">

- 기능 추가 후, 모바일(`iPhone 11 Pro`) **시험 게시글 상세** 페이지 화면

<img width="482" alt="Screenshot 2024-06-27 at 6 47 31 PM" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/36c27a1a-b100-47f3-ab96-10076905a26d">