### PR TITLE
[feat]: 대회 순위 게시글 페이지 모바일 해상도에 대한 반응형 웹 디자인 효과 추가 (#268)

### DIFF
--- a/app/contests/[cid]/ranklist/components/UserScoreInfoListItem.tsx
+++ b/app/contests/[cid]/ranklist/components/UserScoreInfoListItem.tsx
@@ -20,10 +20,6 @@ export default function UserScoreInfoListItem({
 }: UserScoreInfoListItemProps) {
   const router = useRouter();
 
-  const handleGoToTheProblem = (problemId: string) => {
-    router.push(`/contests/${cid}/problems/${problemId}`);
-  };
-
   return (
     <div className="flex justify-between min-h-[9rem] border border-gray-300 shadow-md">
       <div className="flex flex-col p-3">
@@ -48,7 +44,7 @@ export default function UserScoreInfoListItem({
                 score.right ? 'bg-[#3870e0]' : 'bg-[#e0e0e0]'
               } border ${
                 score.right ? 'border-[#3565c4]' : 'border-[#d3d3d3]'
-              } hover:brightness-90 duration-150`}
+              }`}
             >
               <div className="absolute top-[0.175rem] left-[0.175rem]">
                 <svg
@@ -61,36 +57,37 @@ export default function UserScoreInfoListItem({
                   <path d="M480.238-137q-71.145 0-133.868-27.023t-109.12-73.348q-46.398-46.325-73.324-108.826Q137-408.699 137-479.762q0-71.145 27.023-133.868t73.348-109.12q46.325-46.398 108.826-73.324Q408.699-823 479.762-823q71.145 0 133.868 27.023t109.12 73.348q46.398 46.325 73.324 108.826Q823-551.301 823-480.238q0 71.145-27.023 133.868t-73.348 109.12q-46.325 46.398-108.826 73.324Q551.301-137 480.238-137Z" />
                 </svg>
               </div>
-              <button
+              <div
                 className={`${
                   score.right ? 'text-white' : 'text-[#3f3f3f]'
-                } text-[0.825rem] underline font-medium hover:text-[#eee] focus:text-[#eee]`}
-                onClick={() => handleGoToTheProblem(score.problem)}
+                } text-[0.825rem] font-medium`}
               >
                 문제 {index + 1}번
-              </button>
-              <span
-                className={`${
-                  score.right ? 'text-white' : 'text-[#3f3f3f]'
-                } text-[0.825rem]`}
-              >
-                시도: {score.tries}회
-              </span>
-              <span
-                className={`${
-                  score.right ? 'text-white' : 'text-[#3f3f3f]'
-                } text-[0.825rem]`}
-              >
-                시간: {score.time}분
-              </span>
+              </div>
+              <div className="mt-1 flex flex-col text-center">
+                <span
+                  className={`${
+                    score.right ? 'text-white' : 'text-[#3f3f3f]'
+                  } text-[0.5rem]`}
+                >
+                  시도: {score.tries}회
+                </span>
+                <span
+                  className={`${
+                    score.right ? 'mt-[-0.2rem] text-white' : 'text-[#3f3f3f]'
+                  } text-[0.5rem]`}
+                >
+                  시간: {score.time}분
+                </span>
+              </div>
             </div>
           ))}
         </div>
       </div>
 
-      <div className="flex justify-around w-32 border-l border-gray-300">
+      <div className="flex justify-around border-l border-gray-300">
         <div className="flex flex-col w-full text-center bg-[#f7f7f7]">
-          <div className="flex justify-center items-center text-[0.825rem] font-semibold bg-[#f7f7f7] h-8 border-b border-gray-300">
+          <div className="w-12 3md:w-[4.5rem] flex justify-center items-center text-[0.825rem] font-semibold bg-[#f7f7f7] h-8 border-b border-gray-300">
             점수
           </div>
           <div className="flex justify-center items-center bg-white h-full">
@@ -98,7 +95,7 @@ export default function UserScoreInfoListItem({
           </div>
         </div>
         <div className="flex flex-col w-full text-center bg-[#f7f7f7]">
-          <div className="flex justify-center items-center text-[0.825rem] font-semibold bg-[#f7f7f7] h-8 border-b border-l border-gray-300">
+          <div className="w-12 3md:w-[4.5rem] flex justify-center items-center text-[0.825rem] font-semibold bg-[#f7f7f7] h-8 border-b border-l border-gray-300">
             패널티
           </div>
           <div className="flex justify-center items-center bg-white h-full border-l text-red-600">

--- a/app/contests/[cid]/ranklist/components/UserScoreInfoListItem.tsx
+++ b/app/contests/[cid]/ranklist/components/UserScoreInfoListItem.tsx
@@ -68,14 +68,14 @@ export default function UserScoreInfoListItem({
                 <span
                   className={`${
                     score.right ? 'text-white' : 'text-[#3f3f3f]'
-                  } text-[0.5rem]`}
+                  } text-[0.7rem]`}
                 >
                   시도: {score.tries}회
                 </span>
                 <span
                   className={`${
                     score.right ? 'mt-[-0.2rem] text-white' : 'text-[#3f3f3f]'
-                  } text-[0.5rem]`}
+                  } text-[0.7rem]`}
                 >
                   시간: {score.time}분
                 </span>

--- a/app/contests/[cid]/ranklist/page.tsx
+++ b/app/contests/[cid]/ranklist/page.tsx
@@ -164,8 +164,8 @@ export default function ContestRankList(props: DefaultProps) {
   if (isAnyQueryPending) return <Loading />;
 
   return (
-    <div className="mt-2 mb-24 px-5 2lg:px-0 overflow-x-auto">
-      <div className="flex flex-col w-[60rem] mx-auto">
+    <div className="mt-2 mb-24 px-1 2lg:px-0 overflow-x-auto">
+      <div className="flex flex-col w-[21rem] xs:w-[90%] xl:w-[72.5%] mx-auto">
         <div className="flex flex-col gap-8">
           <p className="flex items-center text-2xl font-bold tracking-tight">
             <Image
@@ -176,7 +176,7 @@ export default function ContestRankList(props: DefaultProps) {
               quality={100}
               className="ml-[-1rem] fade-in-fast drop-shadow-lg"
             />
-            <div className="lift-up">
+            <div className="lift-up flex flex-col 3md:flex-row 3md:items-end">
               <span className="ml-2 text-3xl font-semibold tracking-wide">
                 대회 순위
               </span>
@@ -188,7 +188,7 @@ export default function ContestRankList(props: DefaultProps) {
               </Link>
             </div>
           </p>
-          <div className="flex justify-between items-center pb-3 border-b border-gray-300">
+          <div className="flex flex-col 3md:flex-row justify-between pb-3 border-b border-gray-300">
             <div className="flex gap-2">
               {shouldShowProblemsButton() && (
                 <button
@@ -209,7 +209,7 @@ export default function ContestRankList(props: DefaultProps) {
               )}
             </div>
             <div className="mt-3">
-              <span className="font-semibold">
+              <span className="font-semibold 3md:ml-auto">
                 대회 시간:{' '}
                 <span className="font-light">
                   {formatDateToYYMMDDHHMM(contestInfo.testPeriod.start)} ~{' '}


### PR DESCRIPTION
## 👀 이슈

resolve #268 

## 📌 개요

`대회 순위 게시글` 페이지 접속 시 게시글이 PC 해상도 맞게
나타나도록 되어 있던 부분을 모바일 기기 해상도에서도
적절히 표시되도록 **반응형 웹 디자인 코드**를 추가하였습니다.

## 👩‍💻 작업 사항

- `대회 순위 페이지` 모바일 반응형 웹 디자인 효과 추가

## ✅ 참고 사항

- 기능 추가 전 모바일(`iPhone SE`) **대회 순위** 페이지 화면

<img width="505" alt="before" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/808f906c-2cb9-42cd-8b25-f062468df43e">

- 기능 추가 후, 모바일(`iPhone SE`) **대회 순위** 페이지 화면

<img width="506" alt="after" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/c7b02e9c-0f44-40fe-b0d7-2a9460968a7a">