### PR TITLE
[feat] 대회 게시글 상세 페이지 내 게시글 관리 버튼 영역 모바일 해상도에 대한 반응형 웹 디자인 효과 추가 (#270)

### DIFF
--- a/app/contests/[cid]/page.tsx
+++ b/app/contests/[cid]/page.tsx
@@ -481,7 +481,7 @@ export default function ContestDetail(props: DefaultProps) {
           />
         </div>
         <div>
-          <div className="flex gap-2 justify-end">
+          <div className="flex flex-col 3md:flex-row gap-2 justify-end">
             <button
               onClick={handleGoToContestRankList}
               className="flex justify-center items-center gap-[0.375rem] text-sm text-[#f9fafb] bg-[#0388ca] px-2 py-[0.45rem] rounded-[6px] font-medium focus:bg-[#007eb9] hover:bg-[#007eb9]"


### PR DESCRIPTION
## 👀 이슈

resolve #270 

## 📌 개요

`대회 게시글 상세` 페이지 접속 시 게시글 관리 버튼들이 PC 해상도 맞게
표시되던 부분을 모바일 기기 해상도에서도 적절히 배열되도록 반응형 웹 디자인
코드를 추가하였습니다.

## 👩‍💻 작업 사항

- `대회 게시글 상세` 페이지 내 게시글 관리 버튼 영역 모바일 해상도에 대한 반응형 웹 디자인 효과 추가

## ✅ 참고 사항

- 기능 추가 전 모바일(`iPhone SE`) **대회 게시글 상세** 페이지 내 게시글 관리 버튼 영역의 화면
 
<img width="382" alt="before" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/8f3888ae-6738-414d-a001-803d76dd4cee">

- 기능 추가 후, 모바일(`iPhone SE`) **대회 게시글 상세** 페이지 내 게시글 관리 버튼 영역의 화면

<img width="382" alt="after" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/6399ef38-0803-455f-8796-fbe2f88ce809">