### PR TITLE
[feat]: 시험 게시글 상세 페이지 내 게시글 관리 버튼 영역 모바일 해상도에 대한 반응형 웹 디자인 효과 추가 (#272)

### DIFF
--- a/app/exams/[eid]/page.tsx
+++ b/app/exams/[eid]/page.tsx
@@ -420,7 +420,7 @@ export default function ExamDetail(props: DefaultProps) {
           />
         </div>
         <div>
-          <div className="flex gap-2 justify-end">
+          <div className="flex flex-col 3md:flex-row gap-2 justify-end">
             {OPERATOR_ROLES.includes(userInfo.role) && (
               <button
                 onClick={handleGoToExamSubmits}


### PR DESCRIPTION
## 👀 이슈

resolve #272 

## 📌 개요

`시험 게시글 상세` 페이지 접속 시 게시글 관리 버튼들이 PC 해상도 맞게
표시되던 부분을 모바일 기기 해상도에서도 적절히 배열되도록 반응형 웹 디자인
코드를 추가하였습니다.

## 👩‍💻 작업 사항

- `시험 게시글 상세` 페이지 내 게시글 관리 버튼 영역 모바일 해상도에 대한 반응형 웹 디자인 효과 추가

## ✅ 참고 사항

- 기능 추가 전 모바일(`iPhone SE`) **시험 게시글 상세** 페이지 내 게시글 관리 버튼 영역의 화면
 
<img width="382" alt="before" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/a5eda850-65f0-4055-ac36-a7ee977a5c26">

- 기능 추가 후, 모바일(`iPhone SE`) **시험 게시글 상세** 페이지 내 게시글 관리 버튼 영역의 화면
 
<img width="382" alt="after" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/b100f3ed-cadb-4f5c-aaed-218930db0d5a">