### PR TITLE
[feat] 시험 문제 조회 페이지 모바일 해상도에 대한 반응형 웹 디자인 효과 추가 (#274)

### DIFF
--- a/app/exams/[eid]/problems/components/ExamProblemList.tsx
+++ b/app/exams/[eid]/problems/components/ExamProblemList.tsx
@@ -52,7 +52,7 @@ export default function ExamProblemList({
             <div
               {...provided.droppableProps}
               ref={provided.innerRef}
-              className="flex flex-col gap-4 pl-3"
+              className="flex flex-col gap-4"
             >
               {problemsInfo.map((problem, idx) => (
                 <div key={problem._id} className="flex items-center gap-3">

--- a/app/exams/[eid]/problems/page.tsx
+++ b/app/exams/[eid]/problems/page.tsx
@@ -196,6 +196,12 @@ export default function ExamProblems(props: DefaultProps) {
 
   const handleChangeProblemOrder = () => {
     changingProblemOrderBtnRef.current?.blur();
+
+    if (examProblemsInfo.problems.length === 0) {
+      alert('등록된 문제가 없습니다.');
+      return;
+    }
+
     setIsChangingExamProblemOrderActivate((prev) => !prev);
     if (isChagingExamProblemOrderActivate) {
       examProblemReorderMutation.mutate({ eid, params: problemsInfo });
@@ -210,7 +216,7 @@ export default function ExamProblems(props: DefaultProps) {
 
   return (
     <div className="mt-6 mb-24 px-5 2lg:px-0 overflow-x-auto">
-      <div className="flex flex-col w-[60rem] mx-auto">
+      <div className="flex flex-col w-[21rem] xs:w-[90%] xl:w-[72.5%] mx-auto">
         <div className="flex flex-col gap-8">
           <p className="flex items-center text-2xl font-bold tracking-tight">
             <Image
@@ -221,20 +227,20 @@ export default function ExamProblems(props: DefaultProps) {
               quality={100}
               className="ml-[-1rem] fade-in-fast drop-shadow-lg"
             />
-            <div className="lift-up">
+            <div className="lift-up flex flex-col 3md:flex-row 3md:items-end">
               <span className="ml-2 text-3xl font-semibold tracking-wide">
                 문제 목록
               </span>
               <Link
                 href={`/exams/${eid}`}
-                className="mt-1 ml-1 text-xl font-medium cursor-pointer hover:underline hover:text-[#0038a8] focus:underline focus:text-[#0038a8] text-[#1048b8]"
+                className="mt-1 ml-2 3md:ml-1 text-xl font-medium cursor-pointer hover:underline hover:text-[#0038a8] focus:underline focus:text-[#0038a8] text-[#1048b8]"
               >
                 (시험: {title})
               </Link>
             </div>
           </p>
 
-          <div className="flex justify-between items-center pb-3 border-b border-gray-300">
+          <div className="flex flex-col 3md:flex-row justify-between pb-3 border-b border-gray-300">
             <div className="flex gap-2">
               {!isChagingExamProblemOrderActivate && (
                 <>


### PR DESCRIPTION
## 👀 이슈

resolve #274 

## 📌 개요

`시험 문제 조회` 페이지 접속 시 내부 UI 요소들이 PC 해상도 맞게
표시되던 부분을 모바일 기기 해상도에서도 적절히 배열되도록
반응형 웹 디자인 코드를 추가하였습니다.

## 👩‍💻 작업 사항

- `시험 문제 조회` 페이지 모바일 해상도에 대한 반응형 웹 디자인 효과 추가

## ✅ 참고 사항

- 기능 추가 전 모바일(`iPhone SE`) **시험 문제 조회** 페이지 화면

<img width="482" alt="before" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/d12d6f90-7846-434b-bd5a-6983462f4b22">

- 기능 추가 후, 모바일(`iPhone SE`) **시험 문제 조회** 페이지 화면

<img width="482" alt="after" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/754bd288-2194-4186-9784-2575d3f97939">