### PR TITLE
[feat] 대회 문제 조회 페이지 모바일 해상도에 대한 반응형 웹 디자인 효과 추가 (#276)

### DIFF
--- a/app/contests/[cid]/problems/components/ContestProblemList.tsx
+++ b/app/contests/[cid]/problems/components/ContestProblemList.tsx
@@ -52,7 +52,7 @@ export default function ContestProblemList({
             <div
               {...provided.droppableProps}
               ref={provided.innerRef}
-              className="flex flex-col gap-4 pl-3"
+              className="flex flex-col gap-4"
             >
               {problemsInfo.map((problem, idx) => (
                 <div key={problem._id} className="flex items-center gap-3">

--- a/app/contests/[cid]/problems/page.tsx
+++ b/app/contests/[cid]/problems/page.tsx
@@ -279,6 +279,12 @@ export default function ContestProblems(props: DefaultProps) {
 
   const handleChangeProblemOrder = () => {
     changingProblemOrderBtnRef.current?.blur();
+
+    if (contestProblemsInfo.problems.length <= 2) {
+      alert('문제가 2개 이상 등록된 경우에 문제의 순서를 변경할 수 있습니다.');
+      return;
+    }
+
     setIsChangingContestProblemOrderActivate((prev) => !prev);
     if (isChagingContestProblemOrderActivate) {
       contestProblemReorderMutation.mutate({ cid, params: problemsInfo });
@@ -289,7 +295,7 @@ export default function ContestProblems(props: DefaultProps) {
 
   return (
     <div className="mt-2 mb-24 px-5 2lg:px-0 overflow-x-auto">
-      <div className="flex flex-col w-[60rem] mx-auto">
+      <div className="flex flex-col w-[21rem] xs:w-[90%] xl:w-[72.5%] mx-auto">
         <div className="flex flex-col gap-8">
           <p className="flex items-center text-2xl font-bold tracking-tight">
             <Image
@@ -300,21 +306,21 @@ export default function ContestProblems(props: DefaultProps) {
               quality={100}
               className="ml-[-1rem] fade-in-fast drop-shadow-lg"
             />
-            <div className="lift-up">
+            <div className="lift-up flex flex-col 3md:flex-row 3md:items-end">
               <span className="ml-2 text-3xl font-semibold tracking-wide">
                 문제 목록
               </span>
               <Link
                 href={`/contests/${cid}`}
-                className="mt-1 ml-1 text-xl font-medium cursor-pointer hover:underline hover:text-[#0038a8] focus:underline focus:text-[#0038a8] text-[#1048b8]"
+                className="mt-1 ml-2 3md:ml-1 text-xl font-medium cursor-pointer hover:underline hover:text-[#0038a8] focus:underline focus:text-[#0038a8] text-[#1048b8]"
               >
                 (대회: {contestProblemsInfo.title})
               </Link>
             </div>
           </p>
 
-          <div className="flex justify-between items-center pb-3 border-b border-gray-300">
-            <div className="flex gap-2">
+          <div className="flex flex-col 3md:flex-row justify-between pb-3 border-b border-gray-300">
+            <div className="flex flex-col 3md:flex-row gap-2">
               {!isChagingContestProblemOrderActivate && (
                 <>
                   <button

--- a/app/contests/[cid]/ranklist/page.tsx
+++ b/app/contests/[cid]/ranklist/page.tsx
@@ -182,7 +182,7 @@ export default function ContestRankList(props: DefaultProps) {
               </span>
               <Link
                 href={`/contests/${cid}`}
-                className="mt-1 ml-1 text-xl font-medium cursor-pointer hover:underline hover:text-[#0038a8] focus:underline focus:text-[#0038a8] text-[#1048b8]"
+                className="mt-1 ml-2 3md:ml-1 text-xl font-medium cursor-pointer hover:underline hover:text-[#0038a8] focus:underline focus:text-[#0038a8] text-[#1048b8]"
               >
                 ({contestInfo.title})
               </Link>


### PR DESCRIPTION
## 👀 이슈

resolve #276 

## 📌 개요

`대회 문제 조회` 페이지 접속 시 내부 UI 요소들이 PC 해상도 맞게
표시되던 부분을 모바일 기기 해상도에서도 적절히 배열되도록
반응형 웹 디자인 코드를 추가하였습니다.

## 👩‍💻 작업 사항

- `대회 문제 조회` 페이지 모바일 해상도에 대한 반응형 웹 디자인 효과 추가

## ✅ 참고 사항

- 기능 추가 전 모바일(`iPhone SE`) **대회 문제 조회** 페이지 화면

<img width="482" alt="Screenshot 2024-06-28 at 5 09 14 PM" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/06844a2f-d11b-4cfe-a1f1-bee66dc50fcd">

- 기능 추가 후, 모바일(`iPhone SE`) **대회 문제 조회** 페이지 화면

<img width="482" alt="Screenshot 2024-06-28 at 5 09 22 PM" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/7f113f7f-77f8-4ef7-898d-6526343cfc81">