### PR TITLE
[feat] 시험 문제 조회 페이지 내 문제 관리 버튼 영역 모바일 해상도에 대한 반응형 웹 디자인 효과 추가 (#276)

### DIFF
--- a/app/exams/[eid]/problems/page.tsx
+++ b/app/exams/[eid]/problems/page.tsx
@@ -197,8 +197,8 @@ export default function ExamProblems(props: DefaultProps) {
   const handleChangeProblemOrder = () => {
     changingProblemOrderBtnRef.current?.blur();
 
-    if (examProblemsInfo.problems.length === 0) {
-      alert('등록된 문제가 없습니다.');
+    if (examProblemsInfo.problems.length <= 2) {
+      alert('문제가 2개 이상 등록된 경우에 문제의 순서를 변경할 수 있습니다.');
       return;
     }
 
@@ -241,11 +241,12 @@ export default function ExamProblems(props: DefaultProps) {
           </p>
 
           <div className="flex flex-col 3md:flex-row justify-between pb-3 border-b border-gray-300">
-            <div className="flex gap-2">
+            <div className="flex flex-col 3md:flex-row gap-2">
               {!isChagingExamProblemOrderActivate && (
                 <>
                   {OPERATOR_ROLES.includes(userInfo.role) &&
-                    userInfo._id === examProblemsInfo.writer._id && (
+                    userInfo._id === examProblemsInfo.writer._id &&
+                    currentTime < examEndTime && (
                       <button
                         onClick={handleRegisterExamProblem}
                         className="flex justify-center items-center gap-[0.375rem] text-sm text-[#f9fafb] bg-green-500 px-2 py-[0.45rem] rounded-[6px] font-medium focus:bg-[#3e9368] hover:bg-[#3e9368]"
@@ -266,7 +267,8 @@ export default function ExamProblems(props: DefaultProps) {
               )}
 
               {OPERATOR_ROLES.includes(userInfo.role) &&
-                userInfo._id === examProblemsInfo.writer._id && (
+                userInfo._id === examProblemsInfo.writer._id &&
+                currentTime < examEndTime && (
                   <button
                     onClick={handleChangeProblemOrder}
                     ref={changingProblemOrderBtnRef}


### PR DESCRIPTION
## 👀 이슈

resolve #278 

## 📌 개요

`시험 문제 조회` 페이지 접속 시 시험 문제 관리 버튼 UI 요소들이 PC 해상도 맞게
표시되던 부분을 모바일 기기 해상도에서도 적절히 배열되도록
반응형 웹 디자인 코드를 추가하였습니다.

## 👩‍💻 작업 사항

- `시험 문제 조회` 페이지 내 문제 관리 버튼 영역 모바일 해상도에 대한 반응형 웹 디자인 효과 추가

## ✅ 참고 사항

- 기능 추가 전 모바일(`iPhone SE`) **대회 문제 조회** 페이지 화면

<img width="382" alt="Screenshot 2024-06-28 at 5 56 51 PM" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/582e0beb-4cd2-4b11-a5aa-3dc58d01f69c">

- 기능 추가 후, 모바일(`iPhone SE`) **대회 문제 조회** 페이지 화면

<img width="382" alt="Screenshot 2024-06-28 at 5 57 44 PM" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/6627bffd-012a-4194-aeec-5ea085c1585d">