### PR TITLE
[feat] 대회 시간 종료 후, 대회 문제 등록 페이지 접근 제한 로직 추가 (#280)

### DIFF
--- a/app/contests/[cid]/problems/register/page.tsx
+++ b/app/contests/[cid]/problems/register/page.tsx
@@ -190,7 +190,13 @@ export default function RegisterContestProblem(props: DefaultProps) {
       if (contestInfo) {
         const isWriter = contestInfo.writer._id === userInfo._id;
 
-        if (isWriter && currentTime < contestEndTime) {
+        if (currentTime >= contestEndTime) {
+          alert('종료된 대회는 문제 등록이 불가능합니다.');
+          router.back();
+          return;
+        }
+
+        if (isWriter) {
           setIsLoading(false);
           return;
         }


### PR DESCRIPTION
## 👀 이슈

resolve #280 

## 📌 개요

설정된 대회 시간이 종료된 후, 작성자가 대회 문제 등록 페이지로 접근 시
페이지 본문이 로드되지 않도록 하는 로직을 추가하였습니다.

## 👩‍💻 작업 사항

- 대회 시간 종료 후, 대회 문제 등록 페이지 접근 제한 로직 추가

## ✅ 참고 사항

- 대회 시간 종료 후, 대회 게시글 작성자의 문제 등록 페이지 접근 시 화면

<img width="780" alt="Screenshot 2024-06-28 at 9 52 32 PM" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/7253f4a3-bff1-470c-b17c-8f6e18c7d60d">