### PR TITLE
[feat] 시험 시간 종료 후, 시험 문제 등록 페이지 접근 제한 로직 추가 (#282)

### DIFF
--- a/app/exams/[eid]/problems/register/page.tsx
+++ b/app/exams/[eid]/problems/register/page.tsx
@@ -175,7 +175,13 @@ export default function RegisterExamProblem(props: DefaultProps) {
       if (examInfo) {
         const isWriter = examInfo.writer._id === userInfo._id;
 
-        if (isWriter && currentTime < examEndTime) {
+        if (currentTime >= examEndTime) {
+          alert('종료된 시험은 문제 등록이 불가능합니다.');
+          router.back();
+          return;
+        }
+
+        if (isWriter) {
           setIsLoading(false);
           return;
         }
@@ -185,6 +191,8 @@ export default function RegisterExamProblem(props: DefaultProps) {
       }
     });
   }, [updateUserInfo, examInfo, router]);
+
+  if (isLoading) return <Loading />;
 
   return (
     <div className="mt-2 px-5 2lg:px-0 overflow-x-auto">


### PR DESCRIPTION
## 👀 이슈

resolve #282 

## 📌 개요

설정된 시험 시간이 종료된 후, 작성자가 시험 문제 등록 페이지로 접근 시
페이지 본문이 로드되지 않도록 하는 로직을 추가하였습니다.

## 👩‍💻 작업 사항

- 시험 시간 종료 후, 시험 문제 등록 페이지 접근 제한 로직 추가

## ✅ 참고 사항

- 시험 시간 종료 후, 시험 게시글 작성자의 문제 등록 페이지 접근 시 화면

<img width="644" alt="Screenshot 2024-06-29 at 10 47 41 AM" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/20976f48-f74c-4752-bf36-4b1b329dab2b">