### PR TITLE
[feat] 대회 문제 게시글 상세 페이지 모바일 해상도에 대한 반응형 웹 디자인 효과 추가 (#284)

### DIFF
--- a/app/contests/[cid]/problems/[problemId]/page.tsx
+++ b/app/contests/[cid]/problems/[problemId]/page.tsx
@@ -228,14 +228,15 @@ export default function ContestProblem(props: DefaultProps) {
 
   return (
     <div className="mt-6 mb-24 px-5 2lg:px-0 overflow-x-auto">
-      <div className="flex flex-col w-[60rem] mx-auto">
+      <div className="flex flex-col w-[21rem] xs:w-[90%] xl:w-[72.5%] mx-auto">
         <div className="flex flex-col gap-8">
           <p className="text-2xl font-bold tracking-tight">
             {contestProblemInfo.title}
           </p>
-          <div className="flex justify-between pb-3 border-b border-gray-300">
-            <div className="flex gap-3">
+          <div className="flex flex-col 3md:flex-row gap-1 3md:gap-3 pb-3 border-b border-gray-300">
+            <div className="flex flex-col 3md:flex-row gap-1 3md:gap-3">
               <span className="font-semibold">
+                <span className="3md:hidden text-gray-500">• </span>
                 점수:
                 <span className="font-mono font-light">
                   {' '}
@@ -245,16 +246,18 @@ export default function ContestProblem(props: DefaultProps) {
                   점
                 </span>
               </span>
-              <span className='relative bottom-[0.055rem] font-thin before:content-["|"]' />
+              <span className='hidden relative bottom-[0.055rem] font-thin before:content-["|"] 3md:block' />
               <span className="font-semibold">
+                <span className="3md:hidden text-gray-500">• </span>
                 시간 제한:
                 <span className="font-mono font-light">
                   {' '}
                   <span>{contestProblemInfo.options.maxRealTime / 1000}</span>초
                 </span>
               </span>
-              <span className='relative bottom-[0.055rem] font-thin before:content-["|"]' />
+              <span className='hidden relative bottom-[0.055rem] font-thin before:content-["|"] 3md:block' />
               <span className="font-semibold">
+                <span className="3md:hidden text-gray-500">• </span>
                 메모리 제한:
                 <span className="font-mono font-light">
                   {' '}
@@ -267,6 +270,7 @@ export default function ContestProblem(props: DefaultProps) {
             </div>
             <div className="flex gap-3">
               <span className="font-semibold">
+                <span className="3md:hidden text-gray-500">• </span>
                 대회:{' '}
                 <span className="font-light">
                   {contestProblemInfo.parentId.title}
@@ -276,7 +280,7 @@ export default function ContestProblem(props: DefaultProps) {
           </div>
         </div>
 
-        <div className="flex gap-2 justify-end mt-4">
+        <div className="flex flex-col 3md:flex-row gap-2 justify-end mt-4">
           <button
             onClick={handleGoToContestProblems}
             className="flex justify-center items-center gap-[0.375rem] text-sm text-[#f9fafb] bg-green-500 px-2 py-[0.45rem] rounded-[6px] font-medium focus:bg-[#3e9368] hover:bg-[#3e9368]"
@@ -355,7 +359,7 @@ export default function ContestProblem(props: DefaultProps) {
             )}
         </div>
 
-        <div className="gap-5 border-b mt-8 mb-4 pb-5">
+        <div className="gap-5 border-b mt-4 mb-4 pb-5">
           <PDFViewer pdfFileURL={contestProblemInfo.content} />
         </div>
       </div>


### PR DESCRIPTION
## 👀 이슈

resolve #284 

## 📌 개요

`대회 문제 게시글 상세` 페이지 접속 시 페이지 내 요소들이 PC 해상도 맞게
표시되던 부분을 모바일 기기 해상도에서도 적절히 배열되도록
반응형 웹 디자인 코드를 추가하였습니다.

## 👩‍💻 작업 사항

- `대회 문제 게시글 상세` 페이지 내 문제 관리 버튼 영역 모바일 해상도에 대한 반응형 웹 디자인 효과 추가

## ✅ 참고 사항

- 기능 추가 전 모바일(`iPhone 11 pro`) **대회 문제 게시글 상세** 페이지 화면

![before](https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/330c795d-dbdb-4d31-bd5d-1242986143bf)

- 기능 추가 후, 모바일(`iPhone 11 pro`) **대회 문제 게시글 상세** 페이지 화면

![after](https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/ef265101-0e13-4aa5-b692-41991e86b658)