### PR TITLE
[feat] 시험 문제 게시글 상세 페이지 모바일 해상도에 대한 반응형 웹 디자인 효과 추가 (#286)

### DIFF
--- a/app/contests/[cid]/problems/[problemId]/page.tsx
+++ b/app/contests/[cid]/problems/[problemId]/page.tsx
@@ -233,7 +233,7 @@ export default function ContestProblem(props: DefaultProps) {
           <p className="text-2xl font-bold tracking-tight">
             {contestProblemInfo.title}
           </p>
-          <div className="flex flex-col 3md:flex-row gap-1 3md:gap-3 pb-3 border-b border-gray-300">
+          <div className="flex flex-col 3md:flex-row 3md:justify-between gap-1 3md:gap-3 pb-3 border-b border-gray-300">
             <div className="flex flex-col 3md:flex-row gap-1 3md:gap-3">
               <span className="font-semibold">
                 <span className="3md:hidden text-gray-500">• </span>

--- a/app/contests/[cid]/ranklist/page.tsx
+++ b/app/contests/[cid]/ranklist/page.tsx
@@ -189,7 +189,7 @@ export default function ContestRankList(props: DefaultProps) {
             </div>
           </p>
           <div className="flex flex-col 3md:flex-row justify-between pb-3 border-b border-gray-300">
-            <div className="flex gap-2">
+            <div className="flex flex-col 3md:flex-row gap-2 justify-end mt-4">
               {shouldShowProblemsButton() && (
                 <button
                   onClick={handleGoToContestProblems}

--- a/app/exams/[eid]/problems/[problemId]/page.tsx
+++ b/app/exams/[eid]/problems/[problemId]/page.tsx
@@ -154,22 +154,24 @@ export default function ExamProblem(props: DefaultProps) {
 
   return (
     <div className="mt-6 mb-24 px-5 2lg:px-0 overflow-x-auto">
-      <div className="flex flex-col w-[60rem] mx-auto">
+      <div className="flex flex-col w-[21rem] xs:w-[90%] xl:w-[72.5%] mx-auto">
         <div className="flex flex-col gap-8">
           <p className="text-2xl font-bold tracking-tight">
             {examProblemInfo.title}
           </p>
-          <div className="flex justify-between pb-3 border-b border-gray-300">
-            <div className="flex gap-3">
+          <div className="flex flex-col 3md:flex-row gap-1 3md:gap-3 pb-3 border-b border-gray-300">
+            <div className="flex flex-col 3md:flex-row gap-1 3md:gap-3">
               <span className="font-semibold">
+                <span className="3md:hidden text-gray-500">• </span>
                 시간 제한:
                 <span className="font-mono font-light">
                   {' '}
                   <span>{examProblemInfo.options.maxRealTime / 1000}</span>초
                 </span>
               </span>
-              <span className='relative bottom-[0.055rem] font-thin before:content-["|"]' />
+              <span className='hidden relative bottom-[0.055rem] font-thin before:content-["|"] 3md:block' />
               <span className="font-semibold">
+                <span className="3md:hidden text-gray-500">• </span>
                 메모리 제한:
                 <span className="font-mono font-light">
                   {' '}
@@ -180,15 +182,17 @@ export default function ExamProblem(props: DefaultProps) {
                 </span>
               </span>
             </div>
-            <div className="flex gap-3">
+            <div className="flex flex-col 3md:flex-row gap-1 3md:gap-3">
               <span className="font-semibold">
+                <span className="3md:hidden text-gray-500">• </span>
                 시험명:{' '}
                 <span className="font-light">
                   {examProblemInfo.parentId.title}
                 </span>
               </span>
-              <span className='relative bottom-[0.055rem] font-thin before:content-["|"]' />
+              <span className='hidden relative bottom-[0.055rem] font-thin before:content-["|"] 3md:block' />
               <span className="font-semibold">
+                <span className="3md:hidden text-gray-500">• </span>
                 수업명:{' '}
                 <span className="font-light">
                   {examProblemInfo.parentId.course}
@@ -198,7 +202,7 @@ export default function ExamProblem(props: DefaultProps) {
           </div>
         </div>
 
-        <div className="flex gap-2 justify-end mt-4">
+        <div className="flex flex-col 3md:flex-row gap-2 justify-end mt-4">
           <button
             onClick={handleGoToExamProblems}
             className="flex justify-center items-center gap-[0.375rem] text-sm text-[#f9fafb] bg-green-500 px-2 py-[0.45rem] rounded-[6px] font-medium focus:bg-[#3e9368] hover:bg-[#3e9368]"

--- a/app/exams/[eid]/problems/[problemId]/page.tsx
+++ b/app/exams/[eid]/problems/[problemId]/page.tsx
@@ -159,7 +159,7 @@ export default function ExamProblem(props: DefaultProps) {
           <p className="text-2xl font-bold tracking-tight">
             {examProblemInfo.title}
           </p>
-          <div className="flex flex-col 3md:flex-row gap-1 3md:gap-3 pb-3 border-b border-gray-300">
+          <div className="flex flex-col 3md:flex-row 3md:justify-between gap-1 3md:gap-3 pb-3 border-b border-gray-300">
             <div className="flex flex-col 3md:flex-row gap-1 3md:gap-3">
               <span className="font-semibold">
                 <span className="3md:hidden text-gray-500">• </span>

--- a/app/globals.css
+++ b/app/globals.css
@@ -45,6 +45,11 @@
     0.25px 1px 4px 0 rgba(0, 0, 0, 0.19);
 }
 
+.react-pdf__Document {
+  display: flex !important;
+  justify-content: center !important;
+}
+
 /* CKEDITOR5 CSS */
 .ck-editor__editable:not(.ck-editor__nested-editable) {
   min-height: 30rem;


### PR DESCRIPTION
## 👀 이슈

resolve #286 

## 📌 개요

`시험 문제 게시글 상세` 페이지 접속 시 페이지 내 요소들이 PC 해상도 맞게
표시되던 부분을 모바일 기기 해상도에서도 적절히 배열되도록
반응형 웹 디자인 코드를 추가하고자 하였습니다

## 👩‍💻 작업 사항

- `시험 문제 게시글 상세` 페이지 내 문제 관리 버튼 영역 모바일 해상도에 대한 반응형 웹 디자인 효과 추가

## ✅ 참고 사항

- 기능 추가 전 모바일(`iPhone SE`) **시험 문제 게시글 상세** 페이지 화면

<img width="377" alt="Screenshot 2024-06-29 at 4 18 24 PM" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/7b709ce9-73ca-46be-b584-5dc988e44a70">

- 기능 추가 후, 모바일(`iPhone SE`) **시험 문제 게시글 상세** 페이지 화면

<img width="377" alt="Screenshot 2024-06-29 at 4 56 04 PM" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/50596e2f-7345-48a2-97a2-bbe05a0a84d7">