### PR TITLE
Bug/288

### DIFF
--- a/app/contests/[cid]/page.tsx
+++ b/app/contests/[cid]/page.tsx
@@ -128,6 +128,22 @@ export default function ContestDetail(props: DefaultProps) {
           alert('정의되지 않은 http status code입니다');
       }
     },
+    onError: (error: AxiosError) => {
+      const resData: any = error.response?.data;
+      switch (resData.status) {
+        case 400:
+          switch (resData.code) {
+            case 'BEFORE_APPLYING_PERIOD':
+              alert('대회 신청 기간이 아닙니다.');
+              break;
+            default:
+              alert('정의되지 않은 http code입니다.');
+          }
+          break;
+        default:
+          alert('정의되지 않은 http status code입니다');
+      }
+    },
   });
 
   const unErollContestMutation = useMutation({

--- a/app/contests/[cid]/problems/[problemId]/submits/components/UserContestSubmitListItem.tsx
+++ b/app/contests/[cid]/problems/[problemId]/submits/components/UserContestSubmitListItem.tsx
@@ -53,42 +53,31 @@ export default function UserContestSubmitListItem({
         {total - index}
       </th>
       <td className="">{personalUserContestSubmitInfo.problem.title}</td>
-      {personalUserContestSubmitInfo.result ? (
-        <>
-          <td
-            className={`${getCodeSubmitResultTypeColor(
+      <td
+        className={`${
+          personalUserContestSubmitInfo.result
+            ? getCodeSubmitResultTypeColor(
+                personalUserContestSubmitInfo.result.type,
+              )
+            : ''
+        } font-semibold`}
+      >
+        {personalUserContestSubmitInfo.result
+          ? getCodeSubmitResultTypeDescription(
               personalUserContestSubmitInfo.result.type,
-            )} font-semibold`}
-          >
-            {getCodeSubmitResultTypeDescription(
-              personalUserContestSubmitInfo.result.type,
-            )}
-          </td>
-          <td>
-            <span>
-              {(personalUserContestSubmitInfo.result.memory / 1048576).toFixed(
-                2,
-              )}{' '}
-            </span>
-            <span className="ml-[-1px] text-red-500">MB</span>
-          </td>
-          <td className="">
-            <span>{personalUserContestSubmitInfo.result.time} </span>{' '}
-            <span className="ml-[-1px] text-red-500">ms</span>
-          </td>
-        </>
-      ) : (
-        <>
-          <td className="flex gap-[0.6rem] justify-center items-center w-[3.5rem] h-10 text-[#e67e22] font-semibold mx-auto">
-            채점 중
-            <span className="w-1 ml-[-0.6rem] text-[#e67e22]">
-              {loadingDots}
-            </span>
-          </td>
-          <td>-</td>
-          <td>-</td>
-        </>
-      )}
+            )
+          : 'N/A'}
+      </td>
+      <td>
+        <span>
+          {(personalUserContestSubmitInfo.result?.memory / 1048576).toFixed(2)}{' '}
+        </span>
+        <span className="ml-[-1px] text-red-500">MB</span>
+      </td>
+      <td className="">
+        <span>{personalUserContestSubmitInfo.result?.time} </span>{' '}
+        <span className="ml-[-1px] text-red-500">ms</span>
+      </td>
       <td className="">{personalUserContestSubmitInfo.language}</td>
       <td className="">
         {formatDateToYYMMDDHHMM(personalUserContestSubmitInfo.createdAt)}

--- a/app/contests/[cid]/submits/components/UsersContestSubmitListItem.tsx
+++ b/app/contests/[cid]/submits/components/UsersContestSubmitListItem.tsx
@@ -1,6 +1,9 @@
 import { ContestSubmitInfo } from '@/app/types/contest';
 import { formatDateToYYMMDDHHMM } from '@/app/utils/formatDate';
-import { getCodeSubmitResultTypeDescription } from '@/app/utils/getCodeSubmitResultTypeDescription';
+import {
+  getCodeSubmitResultTypeColor,
+  getCodeSubmitResultTypeDescription,
+} from '@/app/utils/getCodeSubmitResultTypeDescription';
 import { useRouter } from 'next/navigation';
 import React from 'react';
 
@@ -25,7 +28,8 @@ export default function UsersContestSubmitListItem({
     <tr
       className="border-b dark:border-gray-700 text-xs text-center cursor-pointer hover:bg-gray-50 focus:bg-gray-50"
       onClick={(e) => {
-        router.push(`/contests/${cid}/submits/${contestSubmitInfo._id}`);
+        contestSubmitInfo.result &&
+          router.push(`/contests/${cid}/submits/${contestSubmitInfo._id}`);
       }}
     >
       <th
@@ -41,19 +45,21 @@ export default function UsersContestSubmitListItem({
       <td className="">{contestSubmitInfo.problem.title}</td>
       <td
         className={`${
-          contestSubmitInfo.result.type === 'done'
-            ? 'text-[#0076C0]'
-            : 'text-red-500'
+          contestSubmitInfo.result
+            ? getCodeSubmitResultTypeColor(contestSubmitInfo.result.type)
+            : ''
         } font-semibold`}
       >
-        {getCodeSubmitResultTypeDescription(contestSubmitInfo.result.type)}
+        {contestSubmitInfo.result
+          ? getCodeSubmitResultTypeDescription(contestSubmitInfo.result.type)
+          : 'N/A'}
       </td>
       <td>
-        <span>{(contestSubmitInfo.result.memory / 1048576).toFixed(2)} </span>
+        <span>{(contestSubmitInfo.result?.memory / 1048576).toFixed(2)} </span>
         <span className="ml-[-1px] text-red-500">MB</span>
       </td>
       <td className="">
-        <span>{contestSubmitInfo.result.time} </span>{' '}
+        <span>{contestSubmitInfo.result?.time} </span>
         <span className="ml-[-1px] text-red-500">ms</span>
       </td>
       <td className="">{contestSubmitInfo.language}</td>


### PR DESCRIPTION
## 👀 이슈

resolve #288 

## 📌 개요

대회 문제 제출 목록 페이지 내에서 코드 컴파일의 결과에 해당하는 속성인 result가
null인 경우 페이지 로드가 이뤄지지 않는 오류가 존재하여 이를 해결하였습니다.

## 👩‍💻 작업 사항

- 대회 신청 기간이 아닌 일자에서 일반 사용자의 대회 신청 요청 시 신청 제한 안내 메시지 표시 로직 추가
- 대회 문제 제출 목록 관련 페이지 내 코드 컴파일 결과 속성의 null인 경우 페이지 로드 오류 제거

## ✅ 참고 사항

없습니다