### PR TITLE
[feat] 연습문제 조회 페이지 모바일 해상도에 대한 반응형 웹 디자인 효과 추가 #296

### DIFF
--- a/app/practices/[pid]/page.tsx
+++ b/app/practices/[pid]/page.tsx
@@ -110,21 +110,23 @@ export default function PracticeProblem(props: DefaultProps) {
 
   return (
     <div className="mt-6 mb-24 px-5 2lg:px-0 overflow-x-auto">
-      <div className="flex flex-col w-[60rem] mx-auto">
+      <div className="flex flex-col w-[21rem] xs:w-[90%] xl:w-[72.5%] mx-auto">
         <div className="flex flex-col gap-8">
           <p className="text-2xl font-bold tracking-tight">
             {practiceInfo.title}
           </p>
-          <div className="flex justify-between pb-3 border-b border-gray-300">
-            <div className="flex gap-3">
+          <div className="flex flex-col 3md:flex-row 3md:justify-between gap-1 3md:gap-3 pb-3 border-b border-gray-300">
+            <div className="flex flex-col 3md:flex-row gap-1 3md:gap-3">
               <span className="font-semibold">
+                <span className="3md:hidden text-gray-500">• </span>
                 시간 제한:{' '}
                 <span className="font-mono font-light">
                   {practiceInfo.options.maxRealTime / 1000}초
                 </span>
               </span>
-              <span className='relative bottom-[0.055rem] font-thin before:content-["|"]' />
+              <span className='hidden relative bottom-[0.055rem] font-thin before:content-["|"] 3md:block' />
               <span className="font-semibold">
+                <span className="3md:hidden text-gray-500">• </span>
                 메모리 제한:{' '}
                 <span className="font-mono font-light">
                   <span className="mr-1">{practiceInfo.options.maxMemory}</span>
@@ -134,6 +136,7 @@ export default function PracticeProblem(props: DefaultProps) {
             </div>
             <div className="flex gap-3">
               <span className="font-semibold">
+                <span className="3md:hidden text-gray-500">• </span>
                 작성자:{' '}
                 <span className="font-light">{practiceInfo.writer.name}</span>
               </span>
@@ -141,7 +144,7 @@ export default function PracticeProblem(props: DefaultProps) {
           </div>
         </div>
 
-        <div className="flex gap-2 justify-end mt-4">
+        <div className="flex flex-col 3md:flex-row gap-2 justify-end mt-4">
           <button
             onClick={handleGoToPracticeProblems}
             className="flex justify-center items-center gap-[0.375rem] text-sm text-[#f9fafb] bg-green-500 px-2 py-[0.45rem] rounded-[6px] font-medium focus:bg-[#3e9368] hover:bg-[#3e9368]"

--- a/app/practices/[pid]/submits/components/UserPracticeSubmitListItem.tsx
+++ b/app/practices/[pid]/submits/components/UserPracticeSubmitListItem.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { PracticeSubmitInfo } from '@/app/types/practice';
 import { formatDateToYYMMDDHHMM } from '@/app/utils/formatDate';
 import {


### PR DESCRIPTION
## 👀 이슈

resolve #296 

## 📌 개요

`연습문제 조회` 페이지 접속 시 내부 UI 요소들이 PC 해상도 맞게
표시되던 부분을 모바일 기기 해상도에서도 적절히 배열되도록
반응형 웹 디자인 코드를 추가하였습니다.

## 👩‍💻 작업 사항

- `연습문제 조회` 페이지 모바일 해상도에 대한 반응형 웹 디자인 효과 추가

## ✅ 참고 사항

- 기능 추가 전 모바일(`iPhone SE`) **연습문제 조회** 페이지 화면

<img width="504" alt="before" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/33e527ee-e854-4aab-bd35-098de73992fb">

- 기능 추가 후, 모바일(`iPhone SE`) **연습문제 조회** 페이지 화면

<img width="504" alt="after" src="https://github.com/cbnusw/cbnuoss_2023_frontend/assets/56868605/91a85d55-31d6-4db4-982c-f8b2034dac24">