### PR TITLE
[fix] 메인페이지 내 신청 가능한 대회 데이터 조회를 위한 API 변경 #298

### DIFF
--- a/app/components/Contests/ContestList.tsx
+++ b/app/components/Contests/ContestList.tsx
@@ -10,7 +10,7 @@ import { ContestInfo } from '@/app/types/contest';
 
 const fetchProgressingContests = () => {
   return axiosInstance.get(
-    `${process.env.NEXT_PUBLIC_API_VERSION}/contest/progressing`,
+    `${process.env.NEXT_PUBLIC_API_VERSION}/contest/available`,
   );
 };
 
@@ -21,27 +21,9 @@ export default function ContestList() {
   });
 
   const resData = data?.data.data;
+  const contestCnt = resData?.length || 0;
 
-  // Filter contests that are applicable
-  const applicableContests = resData?.documents.filter(
-    (contestInfo: ContestInfo) => {
-      const now = new Date();
-      let isContestApplicable = false;
-
-      if (contestInfo.applyingPeriod) {
-        const applyingPeriodEnd = new Date(contestInfo.applyingPeriod.end);
-        isContestApplicable = applyingPeriodEnd > now;
-      } else {
-        const testPeriodStart = new Date(contestInfo.testPeriod.start);
-        isContestApplicable = testPeriodStart > now;
-      }
-
-      return isContestApplicable;
-    },
-  );
-
-  if (resData?.documents.length === 0 || applicableContests?.length === 0)
-    return <NoneContestListItem />;
+  if (contestCnt === 0) return <NoneContestListItem />;
 
   return (
     <>
@@ -53,16 +35,13 @@ export default function ContestList() {
         </>
       ) : (
         <>
-          {applicableContests.map((contestInfo: ContestInfo) => (
+          {resData.map((contestInfo: ContestInfo) => (
             <ContestListItem contestInfo={contestInfo} key={contestInfo._id} />
           ))}
 
-          {Array.from(
-            { length: 4 - applicableContests?.length },
-            (_, index) => (
-              <DummyContestListemItem key={index} />
-            ),
-          )}
+          {Array.from({ length: 4 - resData?.length }, (_, index) => (
+            <DummyContestListemItem key={index} />
+          ))}
         </>
       )}
     </>


### PR DESCRIPTION
## 👀 이슈

resolve #298 

## 📌 개요

기존 메인페이지 내 **신청 가능한 대회** 요소에서 대회 시간이 종료되기 전까지의 모든 대회 정보가
조회된 후, 그 데이터를 기준으로 대회 시작 시간 이전의 대회들만 페이지에 표시되도록 하는 로직을
프론트 측에서 추가하였는데, 해당 작업을 서버에서 처리하도록 변경하여 홈페이지 성능을 개선하고자
하였습니다.

## 👩‍💻 작업 사항

- 메인페이지 내 신청 가능한 대회 데이터 조회를 위한 API 변경

## ✅ 참고 사항

없습니다