### PR TITLE
feat: Navbar 컴포넌트 내 로그인 한 유저명과 suffix(님) 사이 공백 추가

### DIFF
--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -92,7 +92,7 @@ export default function Navbar() {
                   href="/mypage/profile"
                   className="px-3 py-2 rounded-md hover:bg-[#f3f4f5]"
                 >
-                  <span className="font-semibold">{userInfo.name}</span>님
+                  <span className="font-semibold">{userInfo.name}</span> 님
                 </Link>
                 <button
                   className="px-3 py-2 rounded-md hover:bg-[#f3f4f5]"


### PR DESCRIPTION
resolve #310 

## Description

Navbar 컴포넌트 내 로그인 한 유저명과 suffix(님) 사이에 공백을 추가하였습니다.

- 공백 추가 후 닉네임 요소

<img width="173" alt="Screenshot 2024-09-06 at 6 39 16 PM" src="https://github.com/user-attachments/assets/7d1edf4c-c5d1-41c6-8f9f-47aa7f459215">