### PR TITLE
fix: 공지사항 게시글 삭제 시 삭제 확인 안내 alert 중복 발생 이슈 제거

### DIFF
--- a/app/notices/[nid]/page.tsx
+++ b/app/notices/[nid]/page.tsx
@@ -87,7 +87,6 @@ export default function NoticeDetail(props: DefaultProps) {
       '현재 공지사항 게시글을 삭제하시겠습니까?\n삭제 후 내용을 되돌릴 수 없습니다.',
     );
     if (!userResponse) return;
-    alert('게시글을 삭제하였습니다.');
 
     deleteNoticeMutation.mutate(nid);
   };


### PR DESCRIPTION
resolve #316 

## Description

공지사항 게시글 페이지 내에서 작성자가 해당 공지사항을 삭제 시에
alert(알림)이 두 번 표시되는 이슈가 확인되어 해당 문제를 제거하였습니다.