### PR TITLE
feat: 개별 공지사항 목록 아이템 작성일 표시 포맷 변경

### DIFF
--- a/app/notices/components/NoticeListItem.tsx
+++ b/app/notices/components/NoticeListItem.tsx
@@ -1,9 +1,5 @@
 import { NoticeInfo } from '@/app/types/notice';
-import {
-  formatDateToYYMMDDHHMM,
-  formatDateToYYMMDD,
-  formatDateToYYMMDDHHMMSS,
-} from '@/app/utils/formatDate';
+import { formatDateToYYMMDD } from '@/app/utils/formatDate';
 import { useRouter } from 'next/navigation';
 import React from 'react';
 
@@ -35,7 +31,7 @@ export default function NoticeListItem(props: NoticeListItemProps) {
       <td className="hover:underline focus:underline">{noticeInfo.title}</td>
       <td className="font-medium">{noticeInfo.writer.name}</td>
       <td className="font-medium">
-        {formatDateToYYMMDDHHMMSS(noticeInfo.createdAt)}
+        {formatDateToYYMMDD(noticeInfo.createdAt)}
       </td>
     </tr>
   );


### PR DESCRIPTION
resolve #318 

## Description

공지사항 목록 페이지 내에서 작성된 게시글 목록이 표시될 때 개발 공지사항 아이템의 `작성일`이
기존에 `시/분/초`까지 표시되도록 설정되어 있어 이를 `년/월/일`까지만 표시되도록 변경하였습니다.

- 변경 전 `작성일` UI

<img width="272" alt="Screenshot 2024-09-07 at 2 21 35 AM" src="https://github.com/user-attachments/assets/d0495db0-5a9c-4e3b-9edd-ed8529e35a73">

- 변경 후 `작성일` UI

<img width="275" alt="Screenshot 2024-09-07 at 2 16 47 AM" src="https://github.com/user-attachments/assets/d77550e0-b249-4f12-b0f2-3ed8abee7157">