### PR TITLE
feat: 마이페이지 내 작성글 관리 탭 내부 공지사항 탭 추가를 위한 관련 컴포넌트 일괄 추가

### DIFF
--- a/app/mypage/managing-my-post/components/noticePost/MyNoticePostList.tsx
+++ b/app/mypage/managing-my-post/components/noticePost/MyNoticePostList.tsx
@@ -4,20 +4,44 @@ import React, { useEffect, useState } from 'react';
 import Loading from '@/app/loading';
 import EmptyMyNoticePostListItem from './EmptyMyNoticePostListItem';
 import MyNoticePostListItem from './MyNoticePostListItem';
+import axiosInstance from '@/app/utils/axiosInstance';
+import { NoticeInfo } from '@/app/types/notice';
+import { RenderPaginationButtons } from '@/app/components/RenderPaginationButtons';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useQuery } from '@tanstack/react-query';
+
+// 본인이 작성한 공지사항 게시글 목록 반환 API (10개 게시글 단위로)
+const fetchMyNotices = async ({ queryKey }: any) => {
+  const page = queryKey[1];
+  const response = await axiosInstance.get(
+    `${process.env.NEXT_PUBLIC_API_VERSION}/notice/me?page=${page}&limit=10&sort=-createdAt`,
+  );
+  return response.data;
+};
 
 export default function MyNoticePostList() {
-  const [isLoading, setIsLoading] = useState(true);
-  const [isMyPracticePostEmpty, setIsMyPracticeListEmpty] = useState(true);
+  const params = useSearchParams();
 
-  const numberOfItems = 3;
+  const page = Number(params?.get('page')) || 1;
 
-  useEffect(() => {
-    setIsLoading(false);
-    setIsMyPracticeListEmpty(false);
-  }, []);
+  const { isPending, data } = useQuery({
+    queryKey: ['myNotices', page],
+    queryFn: fetchMyNotices,
+  });
 
-  if (isLoading) return <Loading />;
-  if (isMyPracticePostEmpty) return <EmptyMyNoticePostListItem />;
+  const router = useRouter();
+
+  const resData = data?.data;
+  const startItemNum = (resData?.page - 1) * 10 + 1;
+  const endItemNum = startItemNum - 1 + resData?.documents.length;
+  const totalPages = Math.ceil(resData?.total / 10);
+
+  const handlePagination = (newPage: number) => {
+    if (newPage < 1 || newPage > totalPages) return;
+    router.push(`/mypage/managing-my-post?page=${newPage}`);
+  };
+
+  if (isPending) return <Loading />;
 
   return (
     <div className="mx-auto mt-6 w-full">
@@ -38,16 +62,79 @@ export default function MyNoticePostList() {
               </tr>
             </thead>
             <tbody>
-              {Array.from({ length: numberOfItems }, (_, idx) => (
-                <MyNoticePostListItem
-                  key={idx}
-                  nid={'64a52966a1203700203b8ddd'}
-                />
-              ))}
+              {resData?.documents.length === 0 && <EmptyMyNoticePostListItem />}
+              {resData?.documents.map(
+                (noticeInfo: NoticeInfo, index: number) => (
+                  <MyNoticePostListItem
+                    noticeInfo={noticeInfo}
+                    total={resData.total}
+                    page={page}
+                    index={index}
+                    key={index}
+                  />
+                ),
+              )}
             </tbody>
           </table>
         </div>
       </div>
+      <nav
+        className="flex flex-col md:flex-row text-xs justify-between items-start md:items-center space-y-3 md:space-y-0 pl-1 mt-3"
+        aria-label="Table navigation"
+      >
+        <span className="text-gray-500 dark:text-gray-400">
+          <span className="text-gray-500 dark:text-white">
+            {startItemNum} - {endItemNum}
+          </span>{' '}
+          of{' '}
+          <span className="text-gray-500 dark:text-white">{resData.total}</span>
+        </span>
+        <ul className="inline-flex items-stretch -space-x-px">
+          <li>
+            <button
+              onClick={() => handlePagination(Number(page) - 1)}
+              className="flex items-center justify-center h-full py-1.5 px-[0.3rem] ml-0 text-gray-500 bg-white rounded-l-lg border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
+            >
+              <span className="sr-only">Previous</span>
+              <svg
+                className="w-5 h-5"
+                aria-hidden="true"
+                fill="currentColor"
+                viewBox="0 0 20 20"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </button>
+          </li>
+          {RenderPaginationButtons(page, totalPages, handlePagination)}
+          <li>
+            <button
+              onClick={() => handlePagination(Number(page) + 1)}
+              className="flex items-center justify-center h-full py-1.5 px-[0.3rem] leading-tight text-gray-500 bg-white rounded-r-lg border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
+            >
+              <span className="sr-only">Next</span>
+              <svg
+                className="w-5 h-5"
+                aria-hidden="true"
+                fill="currentColor"
+                viewBox="0 0 20 20"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </button>
+          </li>
+        </ul>
+      </nav>
     </div>
   );
 }

--- a/app/mypage/managing-my-post/components/noticePost/MyNoticePostListItem.tsx
+++ b/app/mypage/managing-my-post/components/noticePost/MyNoticePostListItem.tsx
@@ -1,30 +1,35 @@
+import { NoticeInfo } from '@/app/types/notice';
+import { formatDateToYYMMDD } from '@/app/utils/formatDate';
 import { useRouter } from 'next/navigation';
 import React from 'react';
 
 interface MyNoticePostListItemProps {
-  nid: string;
+  noticeInfo: NoticeInfo;
+  total: number;
+  page: number;
+  index: number;
 }
 
-export default function MyNoticePostListItem({
-  nid,
-}: MyNoticePostListItemProps) {
+export default function MyNoticePostListItem(props: MyNoticePostListItemProps) {
+  const { noticeInfo, total, page, index } = props;
+
   const router = useRouter();
 
   return (
     <tr
       className="border-b dark:border-gray-700 text-xs text-center cursor-pointer hover:bg-gray-50 focus:bg-gray-50"
       onClick={(e) => {
-        router.push(`/notices/${nid}`);
+        router.push(`/notices/${noticeInfo._id}`);
       }}
     >
       <th
         scope="row"
         className="px-4 py-3 font-medium text-gray-900 whitespace-nowrap dark:text-white"
       >
-        1
+        {total - (page - 1) * 10 - index}
       </th>
-      <td className="">시스템 이용 간 유의사항</td>
-      <td className="">2023.06.26</td>
+      <td className="">{noticeInfo.title}</td>
+      <td className="">{formatDateToYYMMDD(noticeInfo.createdAt)}</td>
     </tr>
   );
 }

--- a/app/mypage/managing-my-post/page.tsx
+++ b/app/mypage/managing-my-post/page.tsx
@@ -82,7 +82,7 @@ export default function ManagingMyPost() {
             )}
           </div>
         </div>
-        {/* <div>
+        <div>
           <div>
             <button
               onClick={() => handleChangeCategory('notice')}
@@ -96,7 +96,7 @@ export default function ManagingMyPost() {
               <div className="relative top-[3px] h-[2px] rounded-full bg-[#1a1f27]" />
             )}
           </div>
-        </div> */}
+        </div>
       </div>
       <div>
         {category === 'contest' ? (


### PR DESCRIPTION
resolve #320 

## Description

관리자 권한을 지닌 사용자가 마이페이지 내 작성글 관리 탭 내부에서
본인이 작성한 공지사항 게시글 목록을 조회할 수 있도록 하는 공지사항 탭을
추가하고자 하였습니다.

- 추가 이전의 `작성글 관리` 탭 화면
> 공지사항 탭이 존재하지 않음

<img width="1152" alt="Screenshot 2024-09-07 at 12 03 48 PM" src="https://github.com/user-attachments/assets/b270ae42-ff81-493a-91fc-de8b95b26667">

- 추가 후, `작성글 관리` 탭 화면
> 공지사항 탭이 추가됨

<img width="1000" alt="Screenshot 2024-09-07 at 12 07 21 PM" src="https://github.com/user-attachments/assets/c8f7bd5c-e966-4064-b516-07d4fb29145a">