### PR TITLE
feat: 대회/시험 코드 제출 목록 및 상세 페이지 내 빠른 문제 목록 페이지 이동을 위한 버튼 일괄 추가

### DIFF
--- a/app/contests/[cid]/problems/[problemId]/submits/[submitId]/page.tsx
+++ b/app/contests/[cid]/problems/[problemId]/submits/[submitId]/page.tsx
@@ -160,12 +160,16 @@ export default function UserContestSubmit(props: DefaultProps) {
     });
   }, [updateUserInfo, submitInfo, cid, router]);
 
+  const handleGoToContestProblems = () => {
+    router.push(`/contests/${cid}/problems`);
+  };
+
   if (isLoading || !isPasswordChecked) return <Loading />;
 
   return (
     <div className="mt-6 mb-24 px-5 2lg:px-0 overflow-x-auto">
       <div className="flex flex-col w-[60rem] mx-auto">
-        <div className="flex justify-end items-center pb-3">
+        <div className="flex justify-end items-center gap-x-2 pb-3">
           <button
             onClick={handleGoToContestSubmits}
             className="flex justify-center items-center gap-[0.375rem] text-[#f9fafb] bg-[#717171] px-2 py-[0.45rem] rounded-[6px] focus:bg-[#686868] hover:bg-[#686868]"
@@ -180,6 +184,22 @@ export default function UserContestSubmit(props: DefaultProps) {
               <path d="m313-440 196 196q12 12 11.5 28T508-188q-12 11-28 11.5T452-188L188-452q-6-6-8.5-13t-2.5-15q0-8 2.5-15t8.5-13l264-264q11-11 27.5-11t28.5 11q12 12 12 28.5T508-715L313-520h447q17 0 28.5 11.5T800-480q0 17-11.5 28.5T760-440H313Z" />
             </svg>
             뒤로가기
+          </button>
+
+          <button
+            onClick={handleGoToContestProblems}
+            className="flex justify-center items-center gap-[0.375rem] text-sm text-[#f9fafb] bg-green-500 px-2 py-[0.45rem] rounded-[6px] font-medium focus:bg-[#3e9368] hover:bg-[#3e9368]"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              height="20"
+              viewBox="0 -960 960 960"
+              width="20"
+              fill="white"
+            >
+              <path d="M320-240h320v-80H320v80Zm0-160h320v-80H320v80ZM240-80q-33 0-56.5-23.5T160-160v-640q0-33 23.5-56.5T240-880h320l240 240v480q0 33-23.5 56.5T720-80H240Zm280-520h200L520-800v200Z" />
+            </svg>
+            문제 목록
           </button>
         </div>
         <div className="border-y border-[#e4e4e4] border-t-2 border-t-gray-400">

--- a/app/contests/[cid]/problems/[problemId]/submits/components/UserContestSubmitList.tsx
+++ b/app/contests/[cid]/problems/[problemId]/submits/components/UserContestSubmitList.tsx
@@ -68,22 +68,25 @@ export default function UserContestSubmitList({
               </tr>
             </thead>
             <tbody>
-              {personalUserContestSubmitsInfo?.length === 0 && (
+              {personalUserContestSubmitsInfo?.length === 0 ? (
                 <EmptyUserContestSubmitListItem />
-              )}
-              {personalUserContestSubmitsInfo.map(
-                (personalUserContestSubmitInfo, idx) => (
-                  <UserContestSubmitListItem
-                    key={idx}
-                    personalUserContestSubmitInfo={
-                      personalUserContestSubmitInfo
-                    }
-                    total={resData.total}
-                    cid={cid}
-                    problemId={problemId}
-                    index={idx}
-                  />
-                ),
+              ) : (
+                <>
+                  {personalUserContestSubmitsInfo.map(
+                    (personalUserContestSubmitInfo, idx) => (
+                      <UserContestSubmitListItem
+                        key={idx}
+                        personalUserContestSubmitInfo={
+                          personalUserContestSubmitInfo
+                        }
+                        total={resData.total}
+                        cid={cid}
+                        problemId={problemId}
+                        index={idx}
+                      />
+                    ),
+                  )}
+                </>
               )}
             </tbody>
           </table>

--- a/app/contests/[cid]/problems/[problemId]/submits/page.tsx
+++ b/app/contests/[cid]/problems/[problemId]/submits/page.tsx
@@ -155,6 +155,10 @@ export default function UserContestSubmits(props: DefaultProps) {
     });
   }, [updateUserInfo, contestProblemInfo, cid, router]);
 
+  const handleGoToContestProblems = () => {
+    router.push(`/contests/${cid}/problems`);
+  };
+
   if (isLoading || !isPasswordChecked) return <Loading />;
 
   return (
@@ -183,7 +187,7 @@ export default function UserContestSubmits(props: DefaultProps) {
             </div>
           </p>
 
-          <div className="flex justify-end pb-3 border-gray-300">
+          <div className="flex justify-end items-center gap-x-4 pb-3 border-gray-300">
             <div className="flex gap-3">
               <span className="font-semibold">
                 대회:{' '}
@@ -192,6 +196,22 @@ export default function UserContestSubmits(props: DefaultProps) {
                 </span>
               </span>
             </div>
+
+            <button
+              onClick={handleGoToContestProblems}
+              className="flex justify-center items-center gap-[0.375rem] text-sm text-[#f9fafb] bg-green-500 px-2 py-[0.45rem] rounded-[6px] font-medium focus:bg-[#3e9368] hover:bg-[#3e9368]"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                height="20"
+                viewBox="0 -960 960 960"
+                width="20"
+                fill="white"
+              >
+                <path d="M320-240h320v-80H320v80Zm0-160h320v-80H320v80ZM240-80q-33 0-56.5-23.5T160-160v-640q0-33 23.5-56.5T240-880h320l240 240v480q0 33-23.5 56.5T720-80H240Zm280-520h200L520-800v200Z" />
+              </svg>
+              문제 목록
+            </button>
           </div>
         </div>
 

--- a/app/contests/[cid]/submits/components/UsersContestSubmitList.tsx
+++ b/app/contests/[cid]/submits/components/UsersContestSubmitList.tsx
@@ -107,19 +107,22 @@ export default function UsersContestSubmitList({
               </tr>
             </thead>
             <tbody>
-              {contestSubmitsInfo?.length === 0 && (
+              {contestSubmitsInfo?.length === 0 ? (
                 <EmptyUsersContestSubmitListItem />
+              ) : (
+                <>
+                  {contestSubmitsInfo.map((contestSubmitInfo, idx) => (
+                    <UsersContestSubmitListItem
+                      key={idx}
+                      contestSubmitInfo={contestSubmitInfo}
+                      total={resData.total}
+                      page={page}
+                      cid={cid}
+                      index={idx}
+                    />
+                  ))}
+                </>
               )}
-              {contestSubmitsInfo.map((contestSubmitInfo, idx) => (
-                <UsersContestSubmitListItem
-                  key={idx}
-                  contestSubmitInfo={contestSubmitInfo}
-                  total={resData.total}
-                  page={page}
-                  cid={cid}
-                  index={idx}
-                />
-              ))}
             </tbody>
           </table>
         </div>

--- a/app/exams/[eid]/problems/[problemId]/submits/[submitId]/page.tsx
+++ b/app/exams/[eid]/problems/[problemId]/submits/[submitId]/page.tsx
@@ -87,12 +87,16 @@ export default function UserExamSubmit(props: DefaultProps) {
     });
   }, [updateUserInfo, submitInfo, eid, router]);
 
+  const handleGoToExamProblems = () => {
+    router.push(`/exams/${eid}/problems`);
+  };
+
   if (isLoading) return <Loading />;
 
   return (
     <div className="mt-6 mb-24 px-5 2lg:px-0 overflow-x-auto">
       <div className="flex flex-col w-[60rem] mx-auto">
-        <div className="flex justify-end items-center pb-3">
+        <div className="flex justify-end items-center gap-x-2 pb-3">
           <button
             onClick={handleGoToExamSubmits}
             className="flex justify-center items-center gap-[0.375rem] text-[#f9fafb] bg-[#717171] px-2 py-[0.45rem] rounded-[6px] focus:bg-[#686868] hover:bg-[#686868]"
@@ -107,6 +111,22 @@ export default function UserExamSubmit(props: DefaultProps) {
               <path d="m313-440 196 196q12 12 11.5 28T508-188q-12 11-28 11.5T452-188L188-452q-6-6-8.5-13t-2.5-15q0-8 2.5-15t8.5-13l264-264q11-11 27.5-11t28.5 11q12 12 12 28.5T508-715L313-520h447q17 0 28.5 11.5T800-480q0 17-11.5 28.5T760-440H313Z" />
             </svg>
             뒤로가기
+          </button>
+
+          <button
+            onClick={handleGoToExamProblems}
+            className="flex justify-center items-center gap-[0.375rem] text-sm text-[#f9fafb] bg-green-500 px-2 py-[0.45rem] rounded-[6px] font-medium focus:bg-[#3e9368] hover:bg-[#3e9368]"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              height="20"
+              viewBox="0 -960 960 960"
+              width="20"
+              fill="white"
+            >
+              <path d="M320-240h320v-80H320v80Zm0-160h320v-80H320v80ZM240-80q-33 0-56.5-23.5T160-160v-640q0-33 23.5-56.5T240-880h320l240 240v480q0 33-23.5 56.5T720-80H240Zm280-520h200L520-800v200Z" />
+            </svg>
+            문제 목록
           </button>
         </div>
         <div className="border-y border-[#e4e4e4] border-t-2 border-t-gray-400">

--- a/app/exams/[eid]/problems/[problemId]/submits/components/UserExamSubmitList.tsx
+++ b/app/exams/[eid]/problems/[problemId]/submits/components/UserExamSubmitList.tsx
@@ -68,20 +68,23 @@ export default function UserExamSubmitList({
               </tr>
             </thead>
             <tbody>
-              {personalUserExamSubmitsInfo?.length === 0 && (
+              {personalUserExamSubmitsInfo?.length === 0 ? (
                 <EmptyUserExamSubmitListItem />
-              )}
-              {personalUserExamSubmitsInfo.map(
-                (personalUserExamSubmitInfo, idx) => (
-                  <UserExamSubmitListItem
-                    key={idx}
-                    personalUserExamSubmitInfo={personalUserExamSubmitInfo}
-                    total={resData.total}
-                    eid={eid}
-                    problemId={problemId}
-                    index={idx}
-                  />
-                ),
+              ) : (
+                <>
+                  {personalUserExamSubmitsInfo.map(
+                    (personalUserExamSubmitInfo, idx) => (
+                      <UserExamSubmitListItem
+                        key={idx}
+                        personalUserExamSubmitInfo={personalUserExamSubmitInfo}
+                        total={resData.total}
+                        eid={eid}
+                        problemId={problemId}
+                        index={idx}
+                      />
+                    ),
+                  )}
+                </>
               )}
             </tbody>
           </table>

--- a/app/exams/[eid]/problems/[problemId]/submits/page.tsx
+++ b/app/exams/[eid]/problems/[problemId]/submits/page.tsx
@@ -79,6 +79,10 @@ export default function UserExamSubmits(props: DefaultProps) {
     });
   }, [updateUserInfo, examProblemInfo, eid, router]);
 
+  const handleGoToExamProblems = () => {
+    router.push(`/exams/${eid}/problems`);
+  };
+
   if (isLoading) return <Loading />;
 
   return (
@@ -107,7 +111,7 @@ export default function UserExamSubmits(props: DefaultProps) {
             </div>
           </p>
 
-          <div className="flex justify-end pb-3 border-gray-300">
+          <div className="flex justify-end items-center gap-x-4 pb-3 border-gray-300">
             <div className="flex gap-3">
               <span className="font-semibold">
                 시험명:{' '}
@@ -123,6 +127,22 @@ export default function UserExamSubmits(props: DefaultProps) {
                 </span>
               </span>
             </div>
+
+            <button
+              onClick={handleGoToExamProblems}
+              className="flex justify-center items-center gap-[0.375rem] text-sm text-[#f9fafb] bg-green-500 px-2 py-[0.45rem] rounded-[6px] font-medium focus:bg-[#3e9368] hover:bg-[#3e9368]"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                height="20"
+                viewBox="0 -960 960 960"
+                width="20"
+                fill="white"
+              >
+                <path d="M320-240h320v-80H320v80Zm0-160h320v-80H320v80ZM240-80q-33 0-56.5-23.5T160-160v-640q0-33 23.5-56.5T240-880h320l240 240v480q0 33-23.5 56.5T720-80H240Zm280-520h200L520-800v200Z" />
+              </svg>
+              문제 목록
+            </button>
           </div>
         </div>
 

--- a/app/exams/[eid]/submits/components/UsersExamSubmitList.tsx
+++ b/app/exams/[eid]/submits/components/UsersExamSubmitList.tsx
@@ -102,19 +102,22 @@ export default function UsersExamSubmitList({
               </tr>
             </thead>
             <tbody>
-              {contestSubmitsInfo?.length === 0 && (
+              {contestSubmitsInfo?.length === 0 ? (
                 <EmptyUsersExamSubmitListItem />
+              ) : (
+                <>
+                  {contestSubmitsInfo.map((examSubmitInfo, idx) => (
+                    <UsersExamSubmitListItem
+                      key={idx}
+                      examSubmitInfo={examSubmitInfo}
+                      total={resData.total}
+                      page={page}
+                      eid={eid}
+                      index={idx}
+                    />
+                  ))}
+                </>
               )}
-              {contestSubmitsInfo.map((examSubmitInfo, idx) => (
-                <UsersExamSubmitListItem
-                  key={idx}
-                  examSubmitInfo={examSubmitInfo}
-                  total={resData.total}
-                  page={page}
-                  eid={eid}
-                  index={idx}
-                />
-              ))}
             </tbody>
           </table>
         </div>

--- a/app/practices/[pid]/submits/components/UserPracticeSubmitList.tsx
+++ b/app/practices/[pid]/submits/components/UserPracticeSubmitList.tsx
@@ -62,21 +62,24 @@ export default function UserPracticeSubmitList({
               </tr>
             </thead>
             <tbody>
-              {personalUserPracticeSubmitsInfo?.length === 0 && (
+              {personalUserPracticeSubmitsInfo?.length === 0 ? (
                 <EmptyUserPracticeSubmitListItem />
-              )}
-              {personalUserPracticeSubmitsInfo.map(
-                (personalUserPracticeSubmitInfo, idx) => (
-                  <UserPracticeSubmitListItem
-                    key={idx}
-                    personalUserPracticeSubmitInfo={
-                      personalUserPracticeSubmitInfo
-                    }
-                    total={resData.length}
-                    pid={pid}
-                    index={idx}
-                  />
-                ),
+              ) : (
+                <>
+                  {personalUserPracticeSubmitsInfo.map(
+                    (personalUserPracticeSubmitInfo, idx) => (
+                      <UserPracticeSubmitListItem
+                        key={idx}
+                        personalUserPracticeSubmitInfo={
+                          personalUserPracticeSubmitInfo
+                        }
+                        total={resData.length}
+                        pid={pid}
+                        index={idx}
+                      />
+                    ),
+                  )}
+                </>
               )}
             </tbody>
           </table>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,6 +7,13 @@ module.exports = {
     './node_modules/flowbite-react/**/*.js',
     './public/**/*.html',
   ],
+  safelist: [
+    'text-[#0f4c81]',
+    'text-[#5c4c87]',
+    'text-[#fa7268]',
+    'text-[#dd4124]',
+    'text-[#009874]',
+  ],
   theme: {
     extend: {
       backgroundImage: {


### PR DESCRIPTION
resolve #340 

## Description

대회/시험 코드 제출 목록 및 상세 페이지 내에서 사용자가 문제 목록 페이지로
`1 Step`에 이동할 수 있도록 문제 목록 페이지로 이동할 수 있는 버튼을
일괄적으로 추가했습니다.