### PR TITLE
feat: 관리자 사용자의 시험 게시글 코드 제출 목록 페이지 접근 권한 설정

### DIFF
--- a/app/exams/[eid]/page.tsx
+++ b/app/exams/[eid]/page.tsx
@@ -188,6 +188,19 @@ export default function ExamDetail(props: DefaultProps) {
     }
   };
 
+  // "코드 제출 목록" 버튼의 렌더링 조건을 설정
+  const shouldShowSubmitsButton = () => {
+    // 대회 게시글 작성자인 경우, 언제든지 버튼 보임
+    if (userInfo._id === examInfo.writer._id) {
+      return true;
+    }
+
+    // 관리자 사용자의 경우, 대회 종료 시간 이후에만 버튼 보임
+    if (OPERATOR_ROLES.includes(userInfo.role) && currentTime > examEndTime) {
+      return true;
+    }
+  };
+
   // "문제 목록" 버튼의 렌더링 조건을 설정
   const shouldShowProblemsButton = () => {
     // 대회 게시글 작성자인 경우, 언제든지 버튼 보임
@@ -421,7 +434,7 @@ export default function ExamDetail(props: DefaultProps) {
         </div>
         <div>
           <div className="flex flex-col 3md:flex-row gap-2 justify-end">
-            {OPERATOR_ROLES.includes(userInfo.role) && (
+            {shouldShowSubmitsButton() && (
               <button
                 onClick={handleGoToExamSubmits}
                 className="flex justify-center items-center gap-[0.375rem] text-sm text-[#f9fafb] bg-[#6860ff] px-2 py-[0.45rem] rounded-[6px] font-medium focus:bg-[#5951f0] hover:bg-[#5951f0]"

--- a/app/exams/[eid]/submits/page.tsx
+++ b/app/exams/[eid]/submits/page.tsx
@@ -65,13 +65,22 @@ export default function UsersExamSubmits(props: DefaultProps) {
 
   const router = useRouter();
 
+  const currentTime = new Date();
+  const examEndTime = new Date(examInfo?.testPeriod.end);
+
   // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
   useEffect(() => {
     fetchCurrentUserInfo(updateUserInfo).then((userInfo: UserInfo) => {
       if (examInfo) {
+        const isWriter = examInfo.writer._id === userInfo._id;
         const isOperator = OPERATOR_ROLES.includes(userInfo.role);
 
-        if (isOperator) {
+        if (isWriter) {
+          setIsLoading(false);
+          return;
+        }
+
+        if (isOperator && currentTime > examEndTime) {
           setIsLoading(false);
           return;
         }


### PR DESCRIPTION
resolve #342 

## Description

관리자 권한의 사용자로 로그인 후, 시험 게시글 내에서 시험 응시자들이 제출한 코드를
조회할 수 있는 코드 제출 목록 페이지에 대한 접근 권한을 작성자를 제외한 관리자 사용자의
경우 반드시 시험 종료 시간 이후에 코드 제출 목록에 접근할 수 있도록 접근 권한을 추가했습니다.