### PR TITLE
bug: 대회/시험 문제 목록 순서 변경 로직 에러 수정

### DIFF
--- a/app/contests/[cid]/problems/page.tsx
+++ b/app/contests/[cid]/problems/page.tsx
@@ -280,7 +280,7 @@ export default function ContestProblems(props: DefaultProps) {
   const handleChangeProblemOrder = () => {
     changingProblemOrderBtnRef.current?.blur();
 
-    if (contestProblemsInfo.problems.length <= 2) {
+    if (contestProblemsInfo.problems.length < 2) {
       alert('문제가 2개 이상 등록된 경우에 문제의 순서를 변경할 수 있습니다.');
       return;
     }

--- a/app/exams/[eid]/problems/page.tsx
+++ b/app/exams/[eid]/problems/page.tsx
@@ -197,7 +197,9 @@ export default function ExamProblems(props: DefaultProps) {
   const handleChangeProblemOrder = () => {
     changingProblemOrderBtnRef.current?.blur();
 
-    if (examProblemsInfo.problems.length <= 2) {
+    alert(examProblemsInfo.problems.length);
+
+    if (examProblemsInfo.problems.length < 2) {
       alert('문제가 2개 이상 등록된 경우에 문제의 순서를 변경할 수 있습니다.');
       return;
     }


### PR DESCRIPTION
resolve #346 

## Description

대회/시험 문제 목록의 순서를 변경하고자 할 때 문제 2개 이상 등록된 경우에
한해서만 문제 순서 변경 버튼 클릭 시 해당 기능이 작동되도록 설계되었는데,
2개가 등록되어 있음에도 정상적으로 해당 기능이 작동되지 않는 문제가 있어서
이를 해결했습니다.

