### PR TITLE
feat: 검색 관련 API 호출 시 검색 쿼리 인코딩 일괄 적용

### DIFF
--- a/app/contests/[cid]/problems/[problemId]/edit/components/searchedProblem/SearchedProblemList.tsx
+++ b/app/contests/[cid]/problems/[problemId]/edit/components/searchedProblem/SearchedProblemList.tsx
@@ -9,7 +9,7 @@ import EmptySearchedProblemListItem from './EmptySearchedProblemListItem';
 
 // 연관 검색 문제 정보 목록 조회 API
 const fetchRelatedSearchedProblemInfos = async ({ queryKey }: any) => {
-  const searchQuery = queryKey[1];
+  const searchQuery = encodeURIComponent(queryKey[1]);
   const response = await axiosInstance.get(
     `${process.env.NEXT_PUBLIC_API_VERSION}/search?title=${searchQuery}`,
   );

--- a/app/contests/[cid]/problems/register/components/searchedProblem/SearchedProblemList.tsx
+++ b/app/contests/[cid]/problems/register/components/searchedProblem/SearchedProblemList.tsx
@@ -9,7 +9,7 @@ import EmptySearchedProblemListItem from './EmptySearchedProblemListItem';
 
 // 연관 검색 문제 정보 목록 조회 API
 const fetchRelatedSearchedProblemInfos = async ({ queryKey }: any) => {
-  const searchQuery = queryKey[1];
+  const searchQuery = encodeURIComponent(queryKey[1]);
   const response = await axiosInstance.get(
     `${process.env.NEXT_PUBLIC_API_VERSION}/search?title=${searchQuery}`,
   );

--- a/app/contests/components/ContestList.tsx
+++ b/app/contests/components/ContestList.tsx
@@ -18,7 +18,7 @@ interface ContestListProps {
 // 대회 목록 반환 API (10개 게시글 단위로)
 const fetchContests = async ({ queryKey }: any) => {
   const page = queryKey[1];
-  const searchQuery = queryKey[2];
+  const searchQuery = encodeURIComponent(queryKey[2]);
   const response = await axiosInstance.get(
     `${process.env.NEXT_PUBLIC_API_VERSION}/contest/?page=${page}&limit=10&sort=-createdAt&q=title=${searchQuery}`,
   );

--- a/app/exams/[eid]/problems/[problemId]/edit/components/searchedProblem/SearchedProblemList.tsx
+++ b/app/exams/[eid]/problems/[problemId]/edit/components/searchedProblem/SearchedProblemList.tsx
@@ -9,7 +9,7 @@ import EmptySearchedProblemListItem from './EmptySearchedProblemListItem';
 
 // 연관 검색 문제 정보 목록 조회 API
 const fetchRelatedSearchedProblemInfos = async ({ queryKey }: any) => {
-  const searchQuery = queryKey[1];
+  const searchQuery = encodeURIComponent(queryKey[1]);
   const response = await axiosInstance.get(
     `${process.env.NEXT_PUBLIC_API_VERSION}/search?title=${searchQuery}`,
   );

--- a/app/exams/[eid]/problems/register/components/searchedProblem/SearchedProblemList.tsx
+++ b/app/exams/[eid]/problems/register/components/searchedProblem/SearchedProblemList.tsx
@@ -9,7 +9,7 @@ import EmptySearchedProblemListItem from './EmptySearchedProblemListItem';
 
 // 연관 검색 문제 정보 목록 조회 API
 const fetchRelatedSearchedProblemInfos = async ({ queryKey }: any) => {
-  const searchQuery = queryKey[1];
+  const searchQuery = encodeURIComponent(queryKey[1]);
   const response = await axiosInstance.get(
     `${process.env.NEXT_PUBLIC_API_VERSION}/search?title=${searchQuery}`,
   );

--- a/app/exams/components/ExamList.tsx
+++ b/app/exams/components/ExamList.tsx
@@ -18,7 +18,7 @@ interface ExamListProps {
 // 시험 목록 반환 API (10개 게시글 단위로)
 const fetchExams = async ({ queryKey }: any) => {
   const page = queryKey[1];
-  const searchQuery = queryKey[2];
+  const searchQuery = encodeURIComponent(queryKey[2]);
   const response = await axiosInstance.get(
     `${process.env.NEXT_PUBLIC_API_VERSION}/assignment/?page=${page}&limit=10&sort=-createdAt&q=title,course,writer=${searchQuery}`,
   );

--- a/app/practices/[pid]/edit/components/searchedProblem/SearchedProblemList.tsx
+++ b/app/practices/[pid]/edit/components/searchedProblem/SearchedProblemList.tsx
@@ -9,7 +9,7 @@ import EmptySearchedProblemListItem from './EmptySearchedProblemListItem';
 
 // 연관 검색 문제 정보 목록 조회 API
 const fetchRelatedSearchedProblemInfos = async ({ queryKey }: any) => {
-  const searchQuery = queryKey[1];
+  const searchQuery = encodeURIComponent(queryKey[1]);
   const response = await axiosInstance.get(
     `${process.env.NEXT_PUBLIC_API_VERSION}/search?title=${searchQuery}`,
   );

--- a/app/practices/components/PracticeList.tsx
+++ b/app/practices/components/PracticeList.tsx
@@ -19,7 +19,7 @@ interface PracticeListProps {
 // 연습문제 목록 반환 API (10개 게시글 단위로)
 const fetchPractices = async ({ queryKey }: any) => {
   const page = queryKey[1];
-  const searchQuery = queryKey[2];
+  const searchQuery = encodeURIComponent(queryKey[2]);
   const response = await axiosInstance.get(
     `${process.env.NEXT_PUBLIC_API_VERSION}/practice/?page=${page}&limit=10&sort=-createdAt&q=title,writer=${searchQuery}`,
   );

--- a/app/practices/register/components/searchedProblem/SearchedProblemList.tsx
+++ b/app/practices/register/components/searchedProblem/SearchedProblemList.tsx
@@ -9,7 +9,7 @@ import EmptySearchedProblemListItem from './EmptySearchedProblemListItem';
 
 // 연관 검색 문제 정보 목록 조회 API
 const fetchRelatedSearchedProblemInfos = async ({ queryKey }: any) => {
-  const searchQuery = queryKey[1];
+  const searchQuery = encodeURIComponent(queryKey[1]);
   const response = await axiosInstance.get(
     `${process.env.NEXT_PUBLIC_API_VERSION}/search?title=${searchQuery}`,
   );


### PR DESCRIPTION
resolve #355 

## Description

웹 애플리케이션 내 검색 관련 API를 호출하는 곳에서 검색 쿼리 문자열을
그대로 넘겨주는 것이 아닌 인코딩을 적용하여 특수문자를 인식할 수 있도록
작업했습니다.