### PR TITLE
feat(SOJF-3): 대회/시험 신청하기 버튼 렌더링 조건 설정

### DIFF
--- a/app/contests/[cid]/page.tsx
+++ b/app/contests/[cid]/page.tsx
@@ -586,7 +586,7 @@ export default function ContestDetail(props: DefaultProps) {
           </div>
         </div>
 
-        {!OPERATOR_ROLES.includes(userInfo.role) && (
+        {userInfo.role === 'student' && (
           <div className="mt-4">
             <p className="text-2xl font-semibold mt-10 ">참여 방법</p>
             <div className="flex flex-col items-center gap-4 mt-4 mx-auto bg-[#fafafa] w-full py-[1.75rem] border border-[#e4e4e4] border-t-2 border-t-gray-400">

--- a/app/exams/[eid]/page.tsx
+++ b/app/exams/[eid]/page.tsx
@@ -506,7 +506,7 @@ export default function ExamDetail(props: DefaultProps) {
           </div>
         </div>
 
-        {!OPERATOR_ROLES.includes(userInfo.role) && (
+        {userInfo.role === 'student' && (
           <div className="mt-4">
             <p className="text-2xl font-semibold mt-10 ">참여 방법</p>
             <div className="flex flex-col items-center gap-4 mt-4 mx-auto bg-[#fafafa] w-full py-[1.75rem] border border-[#e4e4e4] border-t-2 border-t-gray-400">


### PR DESCRIPTION
resolve #366 

## Description

대회/시험 상세 페이지 내에서 로그인한 사용자는 대회/시험 신청기간 중 `신청하기` 버튼을 클릭해
해당 대회/시험에 참여 신청을 진행할 수 있는데, 시스템 목적 상 일반 `member` 회원이 아닌
`student` 회원에 대해서만 `신청하기` 버튼이 렌더링될 수 있도록 하고자 했습니다.